### PR TITLE
Use PKG_CONFIG variable during make.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -2,12 +2,14 @@
 X11INC = /usr/X11R6/include
 X11LIB = /usr/X11R6/lib
 
-# Xinerama
-XINERAMALIBS = `pkg-config --silence-errors --libs xinerama`
-XINERAMAFLAGS = `pkg-config --exists xinerama && echo -DXINERAMA`
+PKG_CONFIG ?= pkg-config
 
-INCS = -Isrc/ -I/usr/include -I${X11INC}  `pkg-config --cflags glib-2.0`
-LIBS = -lc -L${X11LIB} -lXext -lX11 $(XINERAMALIBS) `pkg-config --libs glib-2.0`
+# Xinerama
+XINERAMALIBS = `$(PKG_CONFIG) --silence-errors --libs xinerama`
+XINERAMAFLAGS = `$(PKG_CONFIG) --exists xinerama && echo -DXINERAMA`
+
+INCS = -Isrc/ -I/usr/include -I${X11INC}  `$(PKG_CONFIG) --cflags glib-2.0`
+LIBS = -lc -L${X11LIB} -lXext -lX11 $(XINERAMALIBS) `$(PKG_CONFIG) --libs glib-2.0`
 
 ifeq ($(shell uname),Linux)
 LIBS += -lrt


### PR DESCRIPTION
Allows the location of the pkg-config binary to be set as a variable
during make. This is needed to use prefixed pkg-config for cross
compilation.

Submitted with the permission of the original author (see comments in https://galileo.mailstation.de/gerrit/#/c/1249/).