### PR TITLE
use $TERMINAL environment variable for spawning a terminal

### DIFF
--- a/share/autostart
+++ b/share/autostart
@@ -21,7 +21,7 @@ Mod=Mod1    # Use alt as the main modifier
 hc keybind $Mod-Shift-q quit
 hc keybind $Mod-Shift-r reload
 hc keybind $Mod-Shift-c close
-hc keybind $Mod-Return spawn xterm
+hc keybind $Mod-Return spawn ${TERMINAL:-xterm} # use youre $TERMINAL with xterm as fallback
 
 # basic movement
 # focusing clients


### PR DESCRIPTION
i3 also searches for `$TERMINAL` and so I set the variable but I don't have xterm installed. And I wondered, why herbstluftwm can't start my terminal ;)