### PR TITLE
Save previous tag when stealing from other monitor

### DIFF
--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -815,6 +815,8 @@ int monitor_set_tag(HSMonitor* monitor, HSTag* tag) {
                 monitor_focus_by_index(monitor_index_of(other));
                 return 0;
             }
+            // save old tag
+            monitor->tag_previous = monitor->tag;
             // swap tags
             other->tag = monitor->tag;
             monitor->tag = tag;


### PR DESCRIPTION
When `use`ing a tag that was already shown on another monitor and
swap_monitors_to_get_tag was set, we did not save the current tag in
monitor->previous_tag which resulted in use_previous not jumping back to
the previous tag but the one before that.