### PR TITLE
Feature/mirror

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -494,6 +494,9 @@ rotate::
     Rotates the layout on the focused tag counterclockwise by 90 degrees. This
     only manipulates the alignment of frames, not the content of them.
 
+mirror::
+    Similar to rotate. Mirrors the layout on the focused tag at the vertical axis.
+
 set 'NAME' 'VALUE'::
     Sets the specified setting 'NAME' to 'VALUE'. All <<SETTINGS,*SETTINGS*>>
     are listed in the <<SETTINGS, section below>>.

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -111,6 +111,7 @@ struct {
     { "shift",          2,  first_parameter_is_flag },
     { "remove",         1,  no_completion },
     { "rotate",         1,  no_completion },
+    { "mirror",         1,  no_completion },
     { "set",            3,  no_completion },
     { "get",            2,  no_completion },
     { "toggle",         2,  no_completion },

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1825,6 +1825,25 @@ void frame_show_recursive(HSFrame* frame) {
     frame_do_recursive(frame, frame_show_clients, 2);
 }
 
+static void frame_mirror(HSFrame* frame) {
+    if (frame && frame->type == TYPE_FRAMES) {
+        HSLayout* l = &frame->content.layout;
+        if (l->align == ALIGN_HORIZONTAL){
+            l->selection = l->selection ? 0 : 1;
+            HSFrame* temp = l->a;
+            l->a = l->b;
+            l->b = temp;
+            l->fraction = FRACTION_UNIT - l->fraction;
+        }
+    }
+}
+
+int layout_mirror_command() {
+    frame_do_recursive(get_current_monitor()->tag->frame, frame_mirror, -1);
+    monitor_apply_layout(get_current_monitor());
+    return 0;
+}
+
 static void frame_rotate(HSFrame* frame) {
     if (frame && frame->type == TYPE_FRAMES) {
         HSLayout* l = &frame->content.layout;

--- a/src/layout.h
+++ b/src/layout.h
@@ -158,6 +158,7 @@ void frame_do_recursive_data(HSFrame* frame, void (*action)(HSFrame*,void*),
 void frame_hide_recursive(HSFrame* frame);
 void frame_show_recursive(HSFrame* frame);
 int layout_rotate_command();
+int layout_mirror_command();
 // do an action for each client in frame tree
 // returns success or failure
 int frame_foreach_client(HSFrame* frame, ClientAction action, void* data);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,6 +158,7 @@ CommandBinding g_commands[] = {
     CMD_BIND(             "rename",         tag_rename_command),
     CMD_BIND(             "move",           tag_move_window_command),
     CMD_BIND_NO_OUTPUT(   "rotate",         layout_rotate_command),
+    CMD_BIND_NO_OUTPUT(   "mirror",         layout_mirror_command),
     CMD_BIND(             "move_index",     tag_move_window_by_index_command),
     CMD_BIND(             "add_monitor",    add_monitor_command),
     CMD_BIND(             "raise_monitor",  monitor_raise_command),


### PR DESCRIPTION
This is a mirror function based on the existing rotate function.
It mirrors the focused tag on the vertical axis.
It's particularly useful on dual monitor setups when you want the important frames to remain at the center even if they are moved from one monitor to the other. 