### PR TITLE
Fix typo for client position in floating mode

### DIFF
--- a/src/clientlist.cpp
+++ b/src/clientlist.cpp
@@ -716,7 +716,7 @@ void client_resize_floating(HSClient* client, HSMonitor* m) {
     }
     Rectangle rect = client->float_size;
     rect.x += m->rect.x;
-    rect.x += m->rect.y;
+    rect.y += m->rect.y;
     rect.x += m->pad_left;
     rect.y += m->pad_up;
     // ensure position is on monitor


### PR DESCRIPTION
If you have a hlwm monitor with an y-offset, the position of floating windows was calculated wrong. This also affected mouse resize behavior.