### PR TITLE
Rework .travis.yml: Build matrix, integrate tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,42 @@
-dist: trusty
-
 language: cpp
-compiler:
-    - clang
-    - gcc
+python: "3.7"
 
 install:
     - sudo apt-get -y -q update
     - sudo apt-get -y -q build-dep herbstluftwm
     - sudo apt-get -y -q install dzen2
 
-before_script:
+script:
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start
-
-script:
     - make -j2
     - sudo make PREFIX=/usr install
     - herbstluftwm &
     - sleep 1
     - herbstclient version
+
+jobs:
+    include:
+        - name: "Ubuntu 14.04, gcc-4.8"
+          dist: trusty
+          env: CC=gcc-4.8 CXX=g++-4.8
+        - name: "Ubuntu 14.04, clang-5"
+          dist: trusty
+          env: CC=clang-5 CXX=clang++-5
+        - name: "Ubuntu 16.04, gcc-5"
+          dist: xenial
+          env: CC=gcc-5 CXX=g++-5
+        - name: "Ubuntu 16.04, gcc-7"
+          dist: xenial
+          env: CC=gcc-7 CXX=g++-7
+        - name: "Ubuntu 16.04, clang-7, run tests"
+          dist: xenial
+          env: CC=clang-7 CXX=clang++-7
+          addons:
+              apt:
+                  packages:
+                      - xterm
+                      - tox
+          script:
+              - make -j2
+              - tox


### PR DESCRIPTION
This introduces a matrix of builds using combinations of Ubuntu versions and compilers (and their versions).

Additionally, one of the matrix entries is used to run tox instead of the usual build-install-execute script.