### PR TITLE
Add error handling for XOpenDisplay()

### DIFF
--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -1,5 +1,6 @@
 #include "xconnection.h"
 #include "globals.h"
+#include "utils.h"
 
 #include <X11/Xlib.h>
 #include <X11/Xproto.h>
@@ -22,6 +23,9 @@ XConnection::~XConnection() {
 XConnection XConnection::connect(std::string display_name) {
     char* display_str = (display_name != "") ? (char*)display_name.c_str() : nullptr;
     Display* d = XOpenDisplay(display_str);
+    if (d == NULL) {
+        die("herbstluftwm: XOpenDisplay() failed\n");
+    }
     return XConnection(d);
 }
 


### PR DESCRIPTION
This can be triggered by not having a DISPLAY environment variable set.