### PR TITLE
Remove die() from utils

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -899,10 +899,12 @@ int main(int argc, char* argv[]) {
     XConnection X = XConnection::connect();
     g_display = X.display();
     if (!g_display) {
-        die("herbstluftwm: cannot open display\n");
+        std::cerr << "herbstluftwm: cannot open display" << std::endl;
+        exit(EXIT_FAILURE);
     }
     if (X.checkotherwm()) {
-        die("herbstluftwm: another window manager is already running\n");
+        std::cerr << "herbstluftwm: another window manager is already running" << std::endl;
+        exit(EXIT_FAILURE);
     }
     // remove zombies on SIGCHLD
     sigaction_signal(SIGCHLD, remove_zombies);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -51,12 +51,6 @@ int MOD(int x, int n) {
     return ((((x) % (signed)(n)) + (signed)(n)) % (signed)(n));
 }
 
-// print a message to stderr and exit
-void die(const char *errstr) {
-    std::cerr << errstr;
-    exit(EXIT_FAILURE);
-}
-
 // inspired by dwm's gettextprop()
 GString* window_property_to_g_string(Display* dpy, Window window, Atom atom) {
     GString* result = nullptr;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -143,9 +143,6 @@ bool window_has_property(Display*, Window window, char* prop_name) {
 char** argv_duplicate(int argc, char** argv) {
     if (argc <= 0) return nullptr;
     char** new_argv = new char*[argc];
-    if (!new_argv) {
-        die("cannot malloc - there is no memory available\n");
-    }
     int i;
     for (i = 0; i < argc; i++) {
         new_argv[i] = g_strdup(argv[i]);
@@ -531,9 +528,6 @@ char* posix_sh_escape(const char* source) {
     if (count == 0) return nullptr;
     // TODO migrate to new
     char* target = (char*)malloc(sizeof(char) * (count + source_len + 1));
-    if (!target) {
-        die("cannot malloc - there is no memory available\n");
-    }
 
     // do the actual escaping
     // special chars:

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -51,13 +51,9 @@ int MOD(int x, int n) {
     return ((((x) % (signed)(n)) + (signed)(n)) % (signed)(n));
 }
 
-/// print a printf-like message to stderr and exit
-// from dwm.c
-void die(const char *errstr, ...) {
-    va_list ap;
-    va_start(ap, errstr);
-    vfprintf(stderr, errstr, ap);
-    va_end(ap);
+// print a message to stderr and exit
+void die(const char *errstr) {
+    std::cerr << errstr;
     exit(EXIT_FAILURE);
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -35,8 +35,8 @@ int MOD(int x, int n);
             (b) = TMPNAME; \
         } while(0);
 
-/// print a printf-like message to stderr and exit
-void die(const char *errstr, ...);
+// print a message to stderr and exit
+void die(const char *errstr);
 
 #define ATOM(A) XInternAtom(g_display, (A), False)
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -35,9 +35,6 @@ int MOD(int x, int n);
             (b) = TMPNAME; \
         } while(0);
 
-// print a message to stderr and exit
-void die(const char *errstr);
-
 #define ATOM(A) XInternAtom(g_display, (A), False)
 
 GString* window_property_to_g_string(Display* dpy, Window window, Atom atom);

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -24,7 +24,8 @@ XConnection XConnection::connect(std::string display_name) {
     char* display_str = (display_name != "") ? (char*)display_name.c_str() : nullptr;
     Display* d = XOpenDisplay(display_str);
     if (d == NULL) {
-        die("herbstluftwm: XOpenDisplay() failed\n");
+        std::cerr << "herbstluftwm: XOpenDisplay() failed" << std::endl;
+        exit(EXIT_FAILURE);
     }
     return XConnection(d);
 }


### PR DESCRIPTION
The current implementation of die() triggers a compiler warning
about the format string not being a literal.

Most of its points of usage are not really needed (malloc never fails[tm]),
or can be replaced with cerr/exit.