### PR TITLE
Drop glib.h from ipc-client and further clean ups

### DIFF
--- a/ipc-client/client-utils.c
+++ b/ipc-client/client-utils.c
@@ -2,13 +2,15 @@
 #include "client-utils.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 #include <X11/Xutil.h>
+#include <stdarg.h>
 
 // inspired by dwm's gettextprop()
-GString* window_property_to_g_string(Display* dpy, Window window, Atom atom) {
-    GString* result = NULL;
+char* read_window_property(Display* dpy, Window window, Atom atom) {
+    char* result = NULL;
     char** list = NULL;
     int n = 0;
     XTextProperty prop;
@@ -19,12 +21,12 @@ GString* window_property_to_g_string(Display* dpy, Window window, Atom atom) {
     // convert text property to a gstring
     if (prop.encoding == XA_STRING
         || prop.encoding == XInternAtom(dpy, "UTF8_STRING", False)) {
-        result = g_string_new((char*)prop.value);
+        result = strdup((char*)prop.value);
     } else {
         if (XmbTextPropertyToTextList(dpy, &prop, &list, &n) >= Success
             && n > 0 && *list)
         {
-            result = g_string_new(*list);
+            result = strdup((char*)*list);
             XFreeStringList(list);
         }
     }
@@ -41,7 +43,7 @@ char** argv_duplicate(int argc, char** argv) {
     }
     int i;
     for (i = 0; i < argc; i++) {
-        new_argv[i] = g_strdup(argv[i]);
+        new_argv[i] = strdup(argv[i]);
     }
     return new_argv;
 }

--- a/ipc-client/client-utils.c
+++ b/ipc-client/client-utils.c
@@ -39,7 +39,8 @@ char** argv_duplicate(int argc, char** argv) {
     if (argc <= 0) return NULL;
     char** new_argv = malloc(sizeof(char*) * argc);
     if (!new_argv) {
-        die("cannot malloc - there is no memory available\n");
+        fprintf(stderr, "cannot malloc - there is no memory available\n");
+        exit(EXIT_FAILURE);
     }
     int i;
     for (i = 0; i < argc; i++) {
@@ -56,12 +57,4 @@ void argv_free(int argc, char** argv) {
         free(argv[i]);
     }
     free(argv);
-}
-
-void die(const char *errstr, ...) {
-    va_list ap;
-    va_start(ap, errstr);
-    vfprintf(stderr, errstr, ap);
-    va_end(ap);
-    exit(EXIT_FAILURE);
 }

--- a/ipc-client/client-utils.h
+++ b/ipc-client/client-utils.h
@@ -9,7 +9,6 @@
 char* read_window_property(Display* dpy, Window window, Atom atom);
 char** argv_duplicate(int argc, char** argv);
 void argv_free(int argc, char** argv);
-void die(const char *errstr, ...);
 
 
 #endif

--- a/ipc-client/client-utils.h
+++ b/ipc-client/client-utils.h
@@ -2,11 +2,11 @@
 #ifndef __HERBSTLUFT_CLIENT_UTILS_H_
 #define __HERBSTLUFT_CLIENT_UTILS_H_
 
-#include <glib.h>
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 
-GString* window_property_to_g_string(Display* dpy, Window window, Atom atom);
+// return a window property or NULL on error
+char* read_window_property(Display* dpy, Window window, Atom atom);
 char** argv_duplicate(int argc, char** argv);
 void argv_free(int argc, char** argv);
 void die(const char *errstr, ...);

--- a/ipc-client/ipc-client.c
+++ b/ipc-client/ipc-client.c
@@ -91,7 +91,7 @@ bool hc_create_client_window(HCConnection* con) {
 }
 
 bool hc_send_command(HCConnection* con, int argc, char* argv[],
-                     GString** ret_out, int* ret_status) {
+                     char** ret_out, int* ret_status) {
     if (!hc_create_client_window(con)) {
         return false;
     }
@@ -106,7 +106,7 @@ bool hc_send_command(HCConnection* con, int argc, char* argv[],
     // get output
     int command_status = 0;
     XEvent event;
-    GString* output = NULL;
+    char* output = NULL;
     bool output_received = false, status_received = false;
     while (!output_received || !status_received) {
         XNextEvent(con->display, &event);
@@ -121,8 +121,8 @@ bool hc_send_command(HCConnection* con, int argc, char* argv[],
         }
         if (!output_received
             && pe->atom == con->atom_output) {
-            output = window_property_to_g_string(con->display, con->client_window,
-                                                 con->atom_output);
+            output = read_window_property(con->display, con->client_window,
+                                          con->atom_output);
             if (!output) {
                 fprintf(stderr, "could not get WindowProperty \"%s\"\n",
                                 HERBST_IPC_OUTPUT_ATOM);
@@ -154,7 +154,7 @@ bool hc_send_command(HCConnection* con, int argc, char* argv[],
 }
 
 bool hc_send_command_once(int argc, char* argv[],
-                          GString** ret_out, int* ret_status) {
+                          char** ret_out, int* ret_status) {
     HCConnection* con = hc_connect();
     if (con == NULL) {
         return false;

--- a/ipc-client/ipc-client.h
+++ b/ipc-client/ipc-client.h
@@ -4,7 +4,6 @@
  * See LICENSE for details */
 
 #include <X11/Xlib.h>
-#include <glib.h>
 #include <stdbool.h>
 
 #ifndef __HERBSTLUFT_IPC_CLIENT_H_
@@ -19,9 +18,9 @@ void hc_disconnect(HCConnection* con);
 bool hc_create_client_window(HCConnection* con);
 
 bool hc_send_command(HCConnection* con, int argc, char* argv[],
-                     GString** ret_out, int* ret_status);
+                     char** ret_out, int* ret_status);
 bool hc_send_command_once(int argc, char* argv[],
-                          GString** ret_out, int* ret_status);
+                          char** ret_out, int* ret_status);
 
 bool hc_hook_window_connect(HCConnection* con);
 bool hc_next_hook(HCConnection* con, int* argc, char** argv[]);

--- a/ipc-client/main.c
+++ b/ipc-client/main.c
@@ -10,11 +10,13 @@
 #include <signal.h>
 #include <regex.h>
 #include <assert.h>
+#include <string.h>
 
 #include "../src/ipc-protocol.h"
 
 #include "ipc-client.h"
 #include "client-utils.h"
+#include "../src/ipc-protocol.h"
 
 #define HERBSTCLIENT_VERSION_STRING \
     "herbstclient " HERBSTLUFT_VERSION " (built on " __DATE__ ")\n"
@@ -229,7 +231,7 @@ int main(int argc, char* argv[]) {
         // install signals
         command_status = main_hook(argc-arg_index, argv+arg_index);
     } else {
-        GString* output;
+        char* output;
         bool suc = hc_send_command_once(argc-arg_index, argv+arg_index,
                                         &output, &command_status);
         if (!suc) {
@@ -240,16 +242,17 @@ int main(int argc, char* argv[]) {
         if (command_status != 0) { // any error, output to stderr
             file = stderr;
         }
-        fputs(output->str, file);
+        fputs(output, file);
         if (g_ensure_newline) {
-            if (output->len > 0 && output->str[output->len - 1] != '\n') {
+            size_t output_len = strlen(output);
+            if (output_len > 0 && output[output_len - 1] != '\n') {
                 fputs("\n", file);
             }
         }
         if (command_status == HERBST_NEED_MORE_ARGS) { // needs more arguments
             fprintf(stderr, "%s: not enough arguments\n", argv[arg_index]); // first argument == cmd
         }
-        g_string_free(output, true);
+        free(output);
     }
     return command_status;
 }

--- a/ipc-client/main.c
+++ b/ipc-client/main.c
@@ -21,18 +21,18 @@
 #define HERBSTCLIENT_VERSION_STRING \
     "herbstclient " HERBSTLUFT_VERSION " (built on " __DATE__ ")\n"
 
-void print_help(char* command, FILE* file);
-void init_hook_regex(int argc, char* argv[]);
-void destroy_hook_regex();
+static void print_help(char* command, FILE* file);
+static void init_hook_regex(int argc, char* argv[]);
+static void destroy_hook_regex();
 
-int g_ensure_newline = 1; // if set, output ends with a newline
-bool g_null_char_as_delim = false; // if true, the null character is used as delimiter
-bool g_print_last_arg_only = false; // if true, prints only the last argument of a hook
-int g_wait_for_hook = 0; // if set, do not execute command but wait
-bool g_quiet = false;
-regex_t* g_hook_regex = NULL;
-int g_hook_regex_count = 0;
-int g_hook_count = 1; // count of hooks to wait for, 0 means: forever
+static int g_ensure_newline = 1; // if set, output ends with a newline
+static bool g_null_char_as_delim = false; // if true, the null character is used as delimiter
+static bool g_print_last_arg_only = false; // if true, prints only the last argument of a hook
+static int g_wait_for_hook = 0; // if set, do not execute command but wait
+static bool g_quiet = false;
+static regex_t* g_hook_regex = NULL;
+static int g_hook_regex_count = 0;
+static int g_hook_count = 1; // count of hooks to wait for, 0 means: forever
 
 static void quit_herbstclient(int signal) {
     // TODO: better solution to quit x connection more softly?

--- a/ipc-client/main.c
+++ b/ipc-client/main.c
@@ -11,9 +11,9 @@
 #include <regex.h>
 #include <assert.h>
 
-#include "ipc-client.h"
-#include "../src/globals.h"
 #include "../src/ipc-protocol.h"
+
+#include "ipc-client.h"
 #include "client-utils.h"
 
 #define HERBSTCLIENT_VERSION_STRING \
@@ -47,8 +47,8 @@ void init_hook_regex(int argc, char* argv[]) {
     for (i = 0; i < argc; i++) {
         int status = regcomp(g_hook_regex + i, argv[i], REG_NOSUB|REG_EXTENDED);
         if (status != 0) {
-            char buf[ERROR_STRING_BUF_SIZE];
-            regerror(status, g_hook_regex + i, buf, ERROR_STRING_BUF_SIZE);
+            char buf[1000];
+            regerror(status, g_hook_regex + i, buf, sizeof(buf));
             fprintf(stderr, "Cannot parse regex \"%s\": ", argv[i]);
             fprintf(stderr, "%s\n", buf);
             destroy_hook_regex();


### PR DESCRIPTION
This PR cleans up the ipc-client subdirectory aka herbstclient.

@dnnr: Can you take a look at it? I'm unsure about the changes in the Makefile and the config.mk. It's better than before, but I'm not very familiar how to properly setup the dependencies between the Makefile variables.