### PR TITLE
Gently shut down hlwm in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@ script:
     - make -j2
     - sudo make PREFIX=/usr install
     - herbstluftwm &
+    - hlwmpid=$!
     - sleep 1
     - herbstclient version
+    - herbstclient quit
+    - wait $hlwmpid
 
 jobs:
     include:


### PR DESCRIPTION
Wait for hlwm to shut down in travis in order to avoid the fatal IO error message complaining about the lost display.