### PR TITLE
Fix cumbersome API for parsing directions

### DIFF
--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -14,30 +14,35 @@
 
 using namespace std;
 
+Direction::Direction(char ch)
+{
+    std::map<char, V> mapping = {
+        {'u', Up}, {'r', Right}, {'d', Down}, {'l', Left},
+    };
+    auto it = mapping.find(ch);
+    if (it != mapping.end()) {
+        value = it->second;
+        valid = true;
+    }
+}
+
+bool operator==(const Direction &lhs, const Direction::V &rhs) {
+    return lhs.valid && lhs.value == rhs;
+}
+
 void floating_init() {
 }
 
 void floating_destroy() {
 }
 
-int char_to_direction(char ch) {
-    switch (ch) {
-        case 'u': return DirUp;
-        case 'r': return DirRight;
-        case 'l': return DirLeft;
-        case 'd': return DirDown;
-        default:  return -1;
-    }
-}
-
 // rectlist_rotate rotates the list of given rectangles, s.t. the direction dir
 // becomes the direction "right". idx is some distinguished element, whose
 // index may change
-static void rectlist_rotate(RectangleIdxVec& rects, int& idx,
-                                enum HSDirection dir) {
+static void rectlist_rotate(RectangleIdxVec& rects, int& idx, Direction dir) {
     // Note: For DirRight, there is nothing to do.
 
-    if (dir == DirUp) {
+    if (dir == Direction::Up) {
         // just flip by the horizontal axis
         for (auto& r : rects) {
             r.second.y = - r.second.y - r.second.height;
@@ -49,7 +54,7 @@ static void rectlist_rotate(RectangleIdxVec& rects, int& idx,
         // and then direction up now has become direction down
     }
 
-    if (dir == DirUp || dir == DirDown) {
+    if (dir == Direction::Up || dir == Direction::Down) {
         // flip by the diagonal
         //
         //   *-------------> x     *-------------> x
@@ -64,7 +69,7 @@ static void rectlist_rotate(RectangleIdxVec& rects, int& idx,
         }
     }
 
-    if (dir == DirLeft) {
+    if (dir == Direction::Left) {
         // flip by the vertical axis
         for (auto& r : rects) {
             r.second.x = - r.second.x - r.second.width;
@@ -77,8 +82,7 @@ static void rectlist_rotate(RectangleIdxVec& rects, int& idx,
 }
 
 // returns the found index in the original buffer
-int find_rectangle_in_direction(RectangleIdxVec& rects, int idx,
-                                enum HSDirection dir) {
+int find_rectangle_in_direction(RectangleIdxVec& rects, int idx, Direction dir) {
     rectlist_rotate(rects, idx, dir);
     return find_rectangle_right_of(rects, idx);
 }
@@ -159,7 +163,7 @@ int find_rectangle_right_of(RectangleIdxVec rects, int idx) {
 }
 
 // returns the found index in the modified buffer
-int find_edge_in_direction(RectangleIdxVec& rects, int idx, enum HSDirection dir)
+int find_edge_in_direction(RectangleIdxVec& rects, int idx, Direction dir)
 {
     rectlist_rotate(rects, idx, dir);
     int found = find_edge_right_of(rects, idx);
@@ -206,7 +210,7 @@ int find_edge_right_of(RectangleIdxVec rects, int idx) {
 }
 
 
-bool floating_focus_direction(enum HSDirection dir) {
+bool floating_focus_direction(Direction dir) {
     if (g_settings->monitors_locked()) { return false; }
     HSTag* tag = get_current_monitor()->tag;
     vector<HSClient*> clients;
@@ -232,7 +236,7 @@ bool floating_focus_direction(enum HSDirection dir) {
     return true;
 }
 
-bool floating_shift_direction(enum HSDirection dir) {
+bool floating_shift_direction(Direction dir) {
     if (g_settings->monitors_locked()) { return false; }
     HSTag* tag = get_current_monitor()->tag;
     vector<HSClient*> clients;
@@ -279,12 +283,12 @@ bool floating_shift_direction(enum HSDirection dir) {
     auto r = rects[idx].second;
     //printf("edge: %dx%d at %d,%d\n", r.width, r.height, r.x, r.y);
     //printf("focus: %dx%d at %d,%d\n", focusrect.width, focusrect.height, focusrect.x, focusrect.y);
-    switch (dir) {
+    switch (dir.value) {
         //          delta = new edge  -  old edge
-        case DirRight: dx = r.x  -   (focusrect.x + focusrect.width); break;
-        case DirLeft:  dx = r.x + r.width   -   focusrect.x; break;
-        case DirDown:  dy = r.y  -  (focusrect.y + focusrect.height); break;
-        case DirUp:    dy = r.y + r.height  -  focusrect.y; break;
+        case Direction::Right: dx = r.x  -   (focusrect.x + focusrect.width); break;
+        case Direction::Left:  dx = r.x + r.width   -   focusrect.x; break;
+        case Direction::Down:  dy = r.y  -  (focusrect.y + focusrect.height); break;
+        case Direction::Up:    dy = r.y + r.height  -  focusrect.y; break;
     }
     //printf("dx=%d, dy=%d\n", dx, dy);
     curfocus->float_size_.x += dx;

--- a/src/floating.h
+++ b/src/floating.h
@@ -4,12 +4,21 @@
 #include <sys/types.h>
 #include "x11-types.h"
 
-enum HSDirection {
-    DirRight,
-    DirLeft,
-    DirUp,
-    DirDown,
+struct Direction {
+    enum V {
+        Up,
+        Right,
+        Down,
+        Left,
+    };
+
+    Direction(V v) : value(v), valid(true) {}
+    Direction(char ch);
+
+    V value;
+    bool valid = false;
 };
+bool operator==(const Direction& lhs, const Direction::V& rhs);
 
 void floating_init();
 void floating_destroy();
@@ -18,15 +27,14 @@ typedef std::vector<std::pair<int,Rectangle>> RectangleIdxVec;
 
 // utilities
 int char_to_direction(char ch);
-int find_rectangle_in_direction(RectangleIdxVec& rects, int idx, enum HSDirection dir);
+int find_rectangle_in_direction(RectangleIdxVec& rects, int idx, Direction dir);
 int find_rectangle_right_of(RectangleIdxVec rects, int idx);
-int find_edge_in_direction(RectangleIdxVec& rects, int idx,
-                                enum HSDirection dir);
+int find_edge_in_direction(RectangleIdxVec& rects, int idx, Direction dir);
 int find_edge_right_of(RectangleIdxVec rects, int idx);
 
 // actual implementations
-bool floating_focus_direction(enum HSDirection dir);
-bool floating_shift_direction(enum HSDirection dir);
+bool floating_focus_direction(Direction dir);
+bool floating_shift_direction(Direction dir);
 
 
 #endif

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1225,9 +1225,9 @@ int frame_focus_command(int argc, char** argv, Output output) {
     int index;
     bool neighbour_found = true;
     if (frame->getTag()->floating) {
-        auto dir = char_to_direction(direction);
-        if (dir < 0) return HERBST_INVALID_ARGUMENT;
-        neighbour_found = floating_focus_direction((enum HSDirection)dir);
+        Direction dir(direction);
+        if (!dir.valid) return HERBST_INVALID_ARGUMENT;
+        neighbour_found = floating_focus_direction(dir);
     } else if (!external_only &&
         (index = frame_inner_neighbour_index(frame, direction)) != -1) {
         frame->setSelection(index);
@@ -1252,10 +1252,9 @@ int frame_focus_command(int argc, char** argv, Output output) {
     }
     if (!neighbour_found && g_settings->focus_crosses_monitor_boundaries()) {
         // find monitor in the specified direction
-        int dir = char_to_direction(direction);
-        if (dir < 0) return HERBST_INVALID_ARGUMENT;
-        int idx = g_monitors->indexInDirection(get_current_monitor(),
-                                               (enum HSDirection)dir);
+        Direction dir(direction);
+        if (!dir.valid) return HERBST_INVALID_ARGUMENT;
+        int idx = g_monitors->indexInDirection(get_current_monitor(), dir);
         if (idx < 0) {
             output << argv[0] << ": No neighbour found\n";
             return HERBST_FORBIDDEN;
@@ -1287,9 +1286,9 @@ int frame_move_window_command(int argc, char** argv, Output output) {
     HSClient* currentClient = get_current_client();
     if (currentClient && currentClient->is_client_floated()) {
         // try to move the floating window
-        auto dir = char_to_direction(direction);
-        if (dir < 0) return HERBST_INVALID_ARGUMENT;
-        bool success = floating_shift_direction((enum HSDirection)dir);
+        Direction dir(direction);
+        if (!dir.valid) return HERBST_INVALID_ARGUMENT;
+        bool success = floating_shift_direction(dir);
         return success ? 0 : HERBST_FORBIDDEN;
     }
     int index;

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -45,7 +45,7 @@ void MonitorManager::ensure_monitors_are_available() {
     monitor_update_focus_objects();
 }
 
-int MonitorManager::indexInDirection(HSMonitor* m, enum HSDirection dir) {
+int MonitorManager::indexInDirection(HSMonitor* m, Direction dir) {
     RectangleIdxVec rects;
     int relidx = -1;
     FOR (i,0,size()) {
@@ -69,9 +69,9 @@ int MonitorManager::string_to_monitor_index(std::string string) {
             idx %= size();
             return idx;
         } else if (string[0] == '-') {
-            int dir = char_to_direction(string[1]);
-            if (dir < 0) return -1;
-            return indexInDirection(focus(), (enum HSDirection)dir);
+            Direction dir(string[1]);
+            if (!dir.valid) return -1;
+            return indexInDirection(focus(), dir);
         } else {
             return -1;
         }

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -31,7 +31,7 @@ public:
     // relayout the monitor showing this tag, if there is any
     void relayoutTag(HSTag* tag);
 
-    int indexInDirection(HSMonitor* m, enum HSDirection dir);
+    int indexInDirection(HSMonitor* m, Direction dir);
 
     void lock();
     void unlock();


### PR DESCRIPTION
Have a small helper struct that encodes if a valid direction was parsed
or not. Apart from that, treatable in the same fashion as a C++ enum class.

Please comment whether you like this solution to the awkward workaround introduced in e3318f536.
