### PR TITLE
Remove obsolete suppression for -Winvalid-offsetof

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -20,7 +20,7 @@ LDXX ?= g++
 CFLAGS ?= -g
 CFLAGS += -pedantic -Wall -std=c99
 CXXFLAGS ?= -g
-CXXFLAGS += -pedantic -Wall -Werror -std=c++11 -Wno-sign-compare -Wno-narrowing -Wno-invalid-offsetof
+CXXFLAGS += -pedantic -Wall -Werror -std=c++11 -Wno-sign-compare -Wno-narrowing
 VERSIONFLAGS = \
     -D HERBSTLUFT_VERSION=\"$(VERSION)\" \
     -D HERBSTLUFT_VERSION_MAJOR=$(VERSION_MAJOR) \


### PR DESCRIPTION
There are no warnings for this in the codebase.