### PR TITLE
Use $(CXX) as a default value for LDXX

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -16,7 +16,7 @@ endif
 # FLAGS
 CC ?= gcc
 LD = $(CC)
-LDXX ?= g++
+LDXX ?= $(CXX)
 CFLAGS ?= -g
 CFLAGS += -pedantic -Wall -std=c99
 CXXFLAGS ?= -g


### PR DESCRIPTION
Using g++ circumvents explicit compiler selection via the CXX
environment variable. Using $(CXX) as fallback ensures that the selected
compiler is used for linking.