### PR TITLE
Common interface and behavior for communicating basic types with the user

### DIFF
--- a/src/arglist.cpp
+++ b/src/arglist.cpp
@@ -8,8 +8,7 @@ ArgList::ArgList(const std::initializer_list<std::string> &l)
 ArgList::ArgList(const ArgList::Container &c) : c_(std::make_shared<Container>(c)) { reset(); }
 
 ArgList::ArgList(const std::string &s, char delim) {
-    c_ = std::make_shared<Container>();
-    split(*c_, s, delim);
+    c_ = std::make_shared<Container>(split(s, delim));
     reset();
 }
 
@@ -23,7 +22,8 @@ std::string ArgList::operator[](size_t idx) {
     return c_->operator[](idx);
 }
 
-void ArgList::split(Container &ret, const std::string &s, char delim) {
+ArgList::Container ArgList::split(const std::string &s, char delim) {
+    Container ret;
     std::stringstream tmp(s);
     std::string item;
     // read "lines" seperated by delim
@@ -34,11 +34,6 @@ void ArgList::split(Container &ret, const std::string &s, char delim) {
     if (!s.empty() && s.back() == delim) {
         ret.push_back("");
     }
-}
-
-ArgList::Container ArgList::split(const std::string &s, char delim) {
-    Container ret;
-    split(ret, s, delim);
     return ret;
 }
 

--- a/src/arglist.cpp
+++ b/src/arglist.cpp
@@ -1,4 +1,4 @@
-#include "types.h"
+#include "arglist.h"
 
 using namespace std;
 

--- a/src/arglist.h
+++ b/src/arglist.h
@@ -1,0 +1,71 @@
+#ifndef HERBSTLUFT_ARGLIST_H
+#define HERBSTLUFT_ARGLIST_H
+
+#include <vector>
+#include <string>
+#include <sstream>
+#include <memory>
+
+struct ArgList {
+    using Container = std::vector<std::string>;
+
+    // a simple split(), as C++ doesn't have it
+    static Container split(const std::string &s, char delim = '.');
+
+    // a simple join(), as C++ doesn't have it
+    static std::string join(Container::const_iterator first,
+                            Container::const_iterator last,
+                            char delim = '.');
+
+    ArgList(const std::initializer_list<std::string> &l);
+    ArgList(const Container &c);
+    // constructor that splits the given string
+    ArgList(const std::string &s, char delim = '.');
+    // operator to obtain shifted version of list (shallow copy)
+    ArgList operator+(Container::difference_type shift_amount);
+    std::string operator[](size_t idx);
+
+    Container::const_iterator begin() const { return begin_; }
+    Container::const_iterator end() const { return c_->cend(); }
+    const std::string& front() { return *begin_; }
+    const std::string& back() { return c_->back(); }
+    bool empty() const { return begin_ == c_->end(); }
+    Container::size_type size() const { return std::distance(begin_, c_->cend()); }
+
+    std::string join(char delim = '.');
+
+    void reset() { begin_ = c_->cbegin(); }
+    void shift(Container::difference_type amount = 1) {
+        begin_ += std::min(amount, std::distance(begin_, c_->cend()));
+    }
+    Container toVector() const {
+        return Container(begin_, c_->cend());
+    }
+    /** try to read as many values as in target. If this fails
+     * the original shift is restored
+     */
+    bool read(std::initializer_list<std::string*> targets);
+    /** construct a new ArgList with every occurence of 'from' replaced by 'to'
+     */
+    ArgList replace(const std::string& from, const std::string& to);
+    // the first element without any shifts.
+    std::string command() const {
+        if (c_->begin() != c_->end()) {
+            return *c_->begin();
+        } else {
+            return std::string("");
+        }
+    }
+
+protected:
+    static void split(Container &ret, const std::string &s, char delim = '.');
+
+    Container::const_iterator begin_;
+    /* shared pointer to make object copy-able:
+     * 1. payload is shared (no redundant copies)
+     * 2. begin_ stays valid
+     */
+    std::shared_ptr<Container> c_;
+};
+
+#endif

--- a/src/arglist.h
+++ b/src/arglist.h
@@ -53,13 +53,11 @@ struct ArgList {
         if (c_->begin() != c_->end()) {
             return *c_->begin();
         } else {
-            return std::string("");
+            return {};
         }
     }
 
 protected:
-    static void split(Container &ret, const std::string &s, char delim = '.');
-
     Container::const_iterator begin_;
     /* shared pointer to make object copy-able:
      * 1. payload is shared (no redundant copies)

--- a/src/attribute.h
+++ b/src/attribute.h
@@ -1,7 +1,6 @@
 #ifndef ATTRIBUTE_H
 #define ATTRIBUTE_H
 
-#include "x11-types.h"
 #include "entity.h"
 
 #include <string>

--- a/src/attribute_.h
+++ b/src/attribute_.h
@@ -4,8 +4,6 @@
 #include "attribute.h"
 #include "object.h"
 #include "signal.h"
-#include "x11-types.h" // for hl::Color
-#include <set>
 #include <functional>
 #include <stdexcept>
 
@@ -32,12 +30,13 @@ public:
         writeable_ = true;
     }
 
-    // delegate type(), str() to a static methods in specializations,
-    // so they can also be used by DynAttribute_<T>
+    // delegate type() to a static methods in specializations,
+    // so it can also be used by DynAttribute_<T>
     Type type() override { return Attribute_<T>::staticType(); }
-    std::string str() override { return Attribute_<T>::str(payload_); }
     static Type staticType();
-    static std::string str(T payload) { return std::to_string(payload); }
+
+    // wrap Converter::str() for convenience
+    std::string str() override { return Converter<T>::str(payload_); }
 
     Signal_<T>& changed() override { return changed_; }
 
@@ -58,16 +57,10 @@ public:
         return payload_ != payload;
     }
 
-    /** parse a text into the right type,
-     * possibly raising a std::invalid_argument exception. The string can be
-     * a specification in relative to 'previous', e.g. "toggle" for booleans.
-     */
-    static T parse(const std::string& source, T const* previous);
-
     std::string change(const std::string &payload_str) override {
         if (!writeable()) return "attribute is read-only";
         try {
-            T new_payload = parse(payload_str, &payload_); // throws
+            T new_payload = Converter<T>::parse(payload_str, &payload_); // throws
 
             // validate, if needed
             if (validator_) {
@@ -109,80 +102,17 @@ protected:
     T payload_;
 };
 
-/** Integer **/
-
+/** Type mappings **/
 template<>
 inline Type Attribute_<int>::staticType() { return Type::ATTRIBUTE_INT; }
-
-template<>
-inline int Attribute_<int>::parse(const std::string &payload, int const*) {
-    return std::stoi(payload);
-}
-
-/** Unsigned **/
-
 template<>
 inline Type Attribute_<unsigned long>::staticType() { return Type::ATTRIBUTE_ULONG; }
-
-template<>
-inline unsigned long Attribute_<unsigned long>::parse(const std::string &payload, unsigned long const*) {
-    return std::stoul(payload);
-}
-
-/** Boolean **/
-
 template<>
 inline Type Attribute_<bool>::staticType() { return Type::ATTRIBUTE_BOOL; }
-
-template<>
-inline std::string Attribute_<bool>::str(bool payload) {
-    return { payload ? "true" : "false" };
-}
-
-template<>
-inline bool Attribute_<bool>::parse(const std::string &payload, bool const* previous) {
-    std::set<std::string> t = {"true", "on", "1"};
-    std::set<std::string> f = {"false", "off", "0"};
-    if (f.find(payload) != f.end())
-        return false;
-    else if (t.find(payload) != t.end())
-        return true;
-    else if (payload == "toggle" && previous)
-        return !*previous;
-    else throw std::invalid_argument(
-            previous
-            ? "only on/off/true/false/toggle are valid booleans"
-            : "only on/off/true/false are valid booleans");
-}
-
-/** STRING **/
-
 template<>
 inline Type Attribute_<std::string>::staticType() { return Type::ATTRIBUTE_STRING; }
-
-template<>
-inline std::string Attribute_<std::string>::str(std::string payload) { return payload; }
-
-template<>
-inline std::string Attribute_<std::string>::parse(const std::string &payload, std::string const*) {
-    return payload;
-}
-
-/** COLOR **/
-
 template<>
 inline Type Attribute_<Color>::staticType() { return Type::ATTRIBUTE_COLOR; }
-
-template<>
-inline std::string Attribute_<Color>::str(Color payload) { return payload.str(); }
-
-template<>
-inline Color Attribute_<Color>::parse(const std::string &payload, Color const*) {
-    Color new_color;
-    std::string msg = Color::fromStr(payload, new_color);
-    if (msg != "") throw std::invalid_argument(msg);
-    return new_color;
-}
 
 template<typename T>
 class DynAttribute_ : public Attribute {
@@ -213,18 +143,14 @@ public:
                     "No change signalling on dynamic attributes.");
     }
 
-    static T parse(const std::string& source) {
-        return Attribute_<T>::parse(source, {});
-    }
-
     std::string str() override {
-        return Attribute_<T>::str(getter_());
+        return Converter<T>::str(getter_());
     }
 
     std::string change(const std::string &payload_str) override {
         if (!writeable()) return "attribute is read-only";
         try {
-            T new_payload = parse(payload_str); // throws
+            T new_payload = Converter<T>::parse(payload_str, nullptr); // throws
             return setter_(new_payload);
         } catch (std::invalid_argument const& e) {
             return std::string("invalid argument: ") + e.what();

--- a/src/attribute_.h
+++ b/src/attribute_.h
@@ -4,9 +4,9 @@
 #include "attribute.h"
 #include "object.h"
 #include "signal.h"
+#include "x11-types.h" // for Color
 #include <functional>
 #include <stdexcept>
-
 
 template<typename T>
 class Attribute_ : public Attribute {

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -6,6 +6,7 @@
 #include "signal.h"
 #include "types.h"
 
+#include <X11/Xlib.h>
 #include <unordered_map>
 
 class Theme;

--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -20,24 +20,13 @@ void floating_init() {
 void floating_destroy() {
 }
 
-int char_to_direction(char ch) {
-    switch (ch) {
-        case 'u': return DirUp;
-        case 'r': return DirRight;
-        case 'l': return DirLeft;
-        case 'd': return DirDown;
-        default:  return -1;
-    }
-}
-
 // rectlist_rotate rotates the list of given rectangles, s.t. the direction dir
 // becomes the direction "right". idx is some distinguished element, whose
 // index may change
-static void rectlist_rotate(RectangleIdxVec& rects, int& idx,
-                                enum HSDirection dir) {
+static void rectlist_rotate(RectangleIdxVec& rects, int& idx, Direction dir) {
     // Note: For DirRight, there is nothing to do.
 
-    if (dir == DirUp) {
+    if (dir == Direction::Up) {
         // just flip by the horizontal axis
         for (auto& r : rects) {
             r.second.y = - r.second.y - r.second.height;
@@ -49,7 +38,7 @@ static void rectlist_rotate(RectangleIdxVec& rects, int& idx,
         // and then direction up now has become direction down
     }
 
-    if (dir == DirUp || dir == DirDown) {
+    if (dir == Direction::Up || dir == Direction::Down) {
         // flip by the diagonal
         //
         //   *-------------> x     *-------------> x
@@ -64,7 +53,7 @@ static void rectlist_rotate(RectangleIdxVec& rects, int& idx,
         }
     }
 
-    if (dir == DirLeft) {
+    if (dir == Direction::Left) {
         // flip by the vertical axis
         for (auto& r : rects) {
             r.second.x = - r.second.x - r.second.width;
@@ -77,8 +66,7 @@ static void rectlist_rotate(RectangleIdxVec& rects, int& idx,
 }
 
 // returns the found index in the original buffer
-int find_rectangle_in_direction(RectangleIdxVec& rects, int idx,
-                                enum HSDirection dir) {
+int find_rectangle_in_direction(RectangleIdxVec& rects, int idx, Direction dir) {
     rectlist_rotate(rects, idx, dir);
     return find_rectangle_right_of(rects, idx);
 }
@@ -159,7 +147,7 @@ int find_rectangle_right_of(RectangleIdxVec rects, int idx) {
 }
 
 // returns the found index in the modified buffer
-int find_edge_in_direction(RectangleIdxVec& rects, int idx, enum HSDirection dir)
+int find_edge_in_direction(RectangleIdxVec& rects, int idx, Direction dir)
 {
     rectlist_rotate(rects, idx, dir);
     int found = find_edge_right_of(rects, idx);
@@ -206,7 +194,7 @@ int find_edge_right_of(RectangleIdxVec rects, int idx) {
 }
 
 
-bool floating_focus_direction(enum HSDirection dir) {
+bool floating_focus_direction(Direction dir) {
     if (g_settings->monitors_locked()) { return false; }
     HSTag* tag = get_current_monitor()->tag;
     vector<HSClient*> clients;
@@ -232,7 +220,7 @@ bool floating_focus_direction(enum HSDirection dir) {
     return true;
 }
 
-bool floating_shift_direction(enum HSDirection dir) {
+bool floating_shift_direction(Direction dir) {
     if (g_settings->monitors_locked()) { return false; }
     HSTag* tag = get_current_monitor()->tag;
     vector<HSClient*> clients;
@@ -281,10 +269,10 @@ bool floating_shift_direction(enum HSDirection dir) {
     //printf("focus: %dx%d at %d,%d\n", focusrect.width, focusrect.height, focusrect.x, focusrect.y);
     switch (dir) {
         //          delta = new edge  -  old edge
-        case DirRight: dx = r.x  -   (focusrect.x + focusrect.width); break;
-        case DirLeft:  dx = r.x + r.width   -   focusrect.x; break;
-        case DirDown:  dy = r.y  -  (focusrect.y + focusrect.height); break;
-        case DirUp:    dy = r.y + r.height  -  focusrect.y; break;
+        case Direction::Right: dx = r.x  -   (focusrect.x + focusrect.width); break;
+        case Direction::Left:  dx = r.x + r.width   -   focusrect.x; break;
+        case Direction::Down:  dy = r.y  -  (focusrect.y + focusrect.height); break;
+        case Direction::Up:    dy = r.y + r.height  -  focusrect.y; break;
     }
     //printf("dx=%d, dy=%d\n", dx, dy);
     curfocus->float_size_.x += dx;

--- a/src/floating.h
+++ b/src/floating.h
@@ -1,15 +1,8 @@
 #ifndef __HERBST_FLOATING_H_
 #define __HERBST_FLOATING_H_
 
-#include <sys/types.h>
+#include "types.h"
 #include "x11-types.h"
-
-enum HSDirection {
-    DirRight,
-    DirLeft,
-    DirUp,
-    DirDown,
-};
 
 void floating_init();
 void floating_destroy();
@@ -18,15 +11,14 @@ typedef std::vector<std::pair<int,Rectangle>> RectangleIdxVec;
 
 // utilities
 int char_to_direction(char ch);
-int find_rectangle_in_direction(RectangleIdxVec& rects, int idx, enum HSDirection dir);
+int find_rectangle_in_direction(RectangleIdxVec& rects, int idx, Direction dir);
 int find_rectangle_right_of(RectangleIdxVec rects, int idx);
-int find_edge_in_direction(RectangleIdxVec& rects, int idx,
-                                enum HSDirection dir);
+int find_edge_in_direction(RectangleIdxVec& rects, int idx, Direction dir);
 int find_edge_right_of(RectangleIdxVec rects, int idx);
 
 // actual implementations
-bool floating_focus_direction(enum HSDirection dir);
-bool floating_shift_direction(enum HSDirection dir);
+bool floating_focus_direction(Direction dir);
+bool floating_shift_direction(Direction dir);
 
 
 #endif

--- a/src/hook.h
+++ b/src/hook.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include <vector>
-#include "x11-types.h"
+
 class Object;
 
 // a Hook monitors a given object, i.e. gets callbacks

--- a/src/layout.h
+++ b/src/layout.h
@@ -143,7 +143,7 @@ public:
     void setLayout(int l) { layout = l; }
     int getSelection() { return selection; }
     size_t clientCount() { return clients.size(); }
-    std::shared_ptr<HSFrame> neighbour(char direction);
+    std::shared_ptr<HSFrame> neighbour(Direction direction);
     std::vector<HSClient*> removeAllClients();
 
     std::shared_ptr<HSFrameLeaf> thisLeaf();
@@ -264,7 +264,7 @@ void frame_unfocus(); // unfocus currently focused window
 // get neighbour in a specific direction 'l' 'r' 'u' 'd' (left, right,...)
 // returns the neighbour or NULL if there is no one
 HSFrame* frame_neighbour(HSFrame* frame, char direction);
-int frame_inner_neighbour_index(std::shared_ptr<HSFrameLeaf> frame, char direction);
+int frame_inner_neighbour_index(std::shared_ptr<HSFrameLeaf> frame, Direction direction);
 int frame_focus_command(int argc, char** argv, Output output);
 
 // follow selection to leaf and focus this frame

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -45,7 +45,7 @@ void MonitorManager::ensure_monitors_are_available() {
     monitor_update_focus_objects();
 }
 
-int MonitorManager::indexInDirection(HSMonitor* m, enum HSDirection dir) {
+int MonitorManager::indexInDirection(HSMonitor* m, Direction dir) {
     RectangleIdxVec rects;
     int relidx = -1;
     FOR (i,0,size()) {
@@ -69,9 +69,12 @@ int MonitorManager::string_to_monitor_index(std::string string) {
             idx %= size();
             return idx;
         } else if (string[0] == '-') {
-            int dir = char_to_direction(string[1]);
-            if (dir < 0) return -1;
-            return indexInDirection(focus(), (enum HSDirection)dir);
+            try {
+                auto dir = Converter<Direction>::parse(string.substr(1), {});
+                return indexInDirection(focus(), dir);
+            } catch (...) {
+                return -1;
+            }
         } else {
             return -1;
         }

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -31,7 +31,7 @@ public:
     // relayout the monitor showing this tag, if there is any
     void relayoutTag(HSTag* tag);
 
-    int indexInDirection(HSMonitor* m, enum HSDirection dir);
+    int indexInDirection(HSMonitor* m, Direction dir);
 
     void lock();
     void unlock();

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -260,11 +260,10 @@ template <> int do_comparison<unsigned long>(const unsigned long& a, const unsig
 }
 
 template <typename T> int parse_and_compare(string a, string b, Output o) {
-    vector<string> strings = { a, b };
     vector<T> vals;
-    for (auto & x : strings) {
+    for (auto &x : {a, b}) {
         try {
-            vals.push_back(Attribute_<T>::parse(x, nullptr));
+            vals.push_back(Converter<T>::parse(x, nullptr));
         } catch(std::exception& e) {
             o << "can not parse \"" << x << "\" to "
               << typeid(T).name() << ": " << e.what() << endl;

--- a/src/types.h
+++ b/src/types.h
@@ -2,6 +2,8 @@
 #define HERBSTLUFT_TYPES_H
 
 #include "arglist.h"
+#include "x11-types.h" // for hl::Color
+#include <set>
 
 /* A path in the object tree */
 using Path = ArgList;
@@ -9,5 +11,69 @@ using Path = ArgList;
 /* Types for I/O with the user */
 using Input = ArgList;
 using Output = std::ostream&;
+
+/* Primitive types that can be converted from/to user input/output */
+template<typename T>
+struct Converter {
+    /** Parse a text into the right type
+     * Throws std::invalid_argument or std::out_of_range
+     * 'Source' may be given relative to 'relativeTo', e.g. "toggle" for booleans.
+     */
+    static T parse(const std::string& source, T const* relativeTo);
+
+    /** Return a user-friendly string representation */
+    static std::string str(T payload) { return std::to_string(payload); }
+};
+
+// Integers
+template<>
+inline int Converter<int>::parse(const std::string &payload, int const*) {
+    return std::stoi(payload);
+}
+template<>
+inline unsigned long Converter<unsigned long>::parse(const std::string &payload, unsigned long const*) {
+    return std::stoul(payload);
+}
+
+// Booleans
+template<>
+inline std::string Converter<bool>::str(bool payload) {
+    return { payload ? "true" : "false" };
+}
+template<>
+inline bool Converter<bool>::parse(const std::string &payload, bool const* previous) {
+    std::set<std::string> t = {"true", "on", "1"};
+    std::set<std::string> f = {"false", "off", "0"};
+    if (f.find(payload) != f.end())
+        return false;
+    else if (t.find(payload) != t.end())
+        return true;
+    else if (payload == "toggle" && previous)
+        return !*previous;
+    else throw std::invalid_argument(
+            previous
+            ? "only on/off/true/false/toggle are valid booleans"
+            : "only on/off/true/false are valid booleans");
+}
+
+// Strings
+template<>
+inline std::string Converter<std::string>::str(std::string payload) { return payload; }
+template<>
+inline std::string Converter<std::string>::parse(const std::string &payload, std::string const*) {
+    return payload;
+}
+
+// Colors
+template<>
+inline std::string Converter<Color>::str(Color payload) { return payload.str(); }
+
+template<>
+inline Color Converter<Color>::parse(const std::string &payload, Color const*) {
+    Color new_color;
+    std::string msg = Color::fromStr(payload, new_color);
+    if (msg != "") throw std::invalid_argument(msg);
+    return new_color;
+}
 
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,6 @@
 #define HERBSTLUFT_TYPES_H
 
 #include "arglist.h"
-#include "x11-types.h" // for hl::Color
 #include <set>
 
 /* A path in the object tree */
@@ -64,16 +63,6 @@ inline std::string Converter<std::string>::parse(const std::string &payload, std
     return payload;
 }
 
-// Colors
-template<>
-inline std::string Converter<Color>::str(Color payload) { return payload.str(); }
-
-template<>
-inline Color Converter<Color>::parse(const std::string &payload, Color const*) {
-    Color new_color;
-    std::string msg = Color::fromStr(payload, new_color);
-    if (msg != "") throw std::invalid_argument(msg);
-    return new_color;
-}
+// Note: include x11-types.h for colors
 
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -3,6 +3,7 @@
 
 #include "arglist.h"
 #include <set>
+#include <map>
 
 /* A path in the object tree */
 using Path = ArgList;
@@ -62,6 +63,21 @@ template<>
 inline std::string Converter<std::string>::parse(const std::string &payload, std::string const*) {
     return payload;
 }
+
+// Directions (used in frames, floating)
+enum class Direction { Right, Left, Up, Down };
+template<>
+inline Direction Converter<Direction>::parse(const std::string &payload, Direction const*) {
+    std::map<char, Direction> mapping = {
+        {'u', Direction::Up},   {'r', Direction::Right},
+        {'d', Direction::Down}, {'l', Direction::Left},
+    };
+    auto it = mapping.find(payload.at(0));
+    if (it == mapping.end())
+        throw std::invalid_argument("Invalid direction \"" + payload + "\"");
+    return it->second;
+}
+
 
 // Note: include x11-types.h for colors
 

--- a/src/types.h
+++ b/src/types.h
@@ -1,77 +1,12 @@
 #ifndef HERBSTLUFT_TYPES_H
 #define HERBSTLUFT_TYPES_H
 
-#include <vector>
-#include <string>
-#include <sstream>
-#include <memory>
+#include "arglist.h"
 
-struct ArgList {
-    using Container = std::vector<std::string>;
-
-    // a simple split(), as C++ doesn't have it
-    static Container split(const std::string &s, char delim = '.');
-
-    // a simple join(), as C++ doesn't have it
-    static std::string join(Container::const_iterator first,
-                            Container::const_iterator last,
-                            char delim = '.');
-
-    ArgList(const std::initializer_list<std::string> &l);
-    ArgList(const Container &c);
-    // constructor that splits the given string
-    ArgList(const std::string &s, char delim = '.');
-    // operator to obtain shifted version of list (shallow copy)
-    ArgList operator+(Container::difference_type shift_amount);
-    std::string operator[](size_t idx);
-
-    Container::const_iterator begin() const { return begin_; }
-    Container::const_iterator end() const { return c_->cend(); }
-    const std::string& front() { return *begin_; }
-    const std::string& back() { return c_->back(); }
-    bool empty() const { return begin_ == c_->end(); }
-    Container::size_type size() const { return std::distance(begin_, c_->cend()); }
-
-    std::string join(char delim = '.');
-
-    void reset() { begin_ = c_->cbegin(); }
-    void shift(Container::difference_type amount = 1) {
-        begin_ += std::min(amount, std::distance(begin_, c_->cend()));
-    }
-    Container toVector() const {
-        return Container(begin_, c_->cend());
-    }
-    /** try to read as many values as in target. If this fails
-     * the original shift is restored
-     */
-    bool read(std::initializer_list<std::string*> targets);
-    /** construct a new ArgList with every occurence of 'from' replaced by 'to'
-     */
-    ArgList replace(const std::string& from, const std::string& to);
-    // the first element without any shifts.
-    std::string command() const {
-        if (c_->begin() != c_->end()) {
-            return *c_->begin();
-        } else {
-            return std::string("");
-        }
-    }
-
-protected:
-    static void split(Container &ret, const std::string &s, char delim = '.');
-
-    Container::const_iterator begin_;
-    /* shared pointer to make object copy-able:
-     * 1. payload is shared (no redundant copies)
-     * 2. begin_ stays valid
-     */
-    std::shared_ptr<Container> c_;
-};
-
+/* A path in the object tree */
 using Path = ArgList;
 
-
-// STRTODO: move this into the herbstluftwm namespace
+/* Types for I/O with the user */
 using Input = ArgList;
 using Output = std::ostream&;
 

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -6,42 +6,32 @@
 #include <X11/Xutil.h>
 
 #include <iostream>
+#include <sstream>
 #include <iomanip>
 #include <cstdio>
-#include <sstream>
-
-
-// get X11 color from color string. This fails if there is no x connection
-// from dwm.c
-std::string queryX11Color(const char *source, XColor& dest_color) {
-	if (!g_display) {
-		return "g_display is not set";
-	}
-	Colormap cmap = DefaultColormap(g_display, g_screen);
-	XColor screen_color;
-	if(!XAllocNamedColor(g_display, cmap, source, &screen_color, &dest_color)) {
-		return std::string("cannot allocate color \'") + source + "\'";
-	}
-	//dest.name_ = source;
-	return "";
-}
+#include <cassert>
 
 Color Color::black() {
     // currently, the constructor without arguments constructs black
-    Color c;
-    return c;
+    return {};
 }
 
 Color::Color()
-    : red_(0)
-    , green_(0)
-    , blue_(0)
-    , x11pixelValue_(0)
+    : red_(0), green_(0), blue_(0), x11pixelValue_(0)
 {
 }
 
+Color::Color(XColor xcol)
+    : red_(xcol.red), green_(xcol.green), blue_(xcol.blue), x11pixelValue_(xcol.pixel)
+{
+    // TODO: special interpretation of red, green, blue when
+    // xcol.flags lacks one of DoRed, DoGreen, DoBlue?
+}
+
 Color::Color(std::string name) {
-    if ("" != fromStr(name, *this)) {
+    try {
+        *this = fromStr(name);
+    } catch (std::invalid_argument) {
         *this = black();
     }
 }
@@ -57,30 +47,23 @@ std::string Color::str() const {
     return ss.str();
 }
 
-std::string Color::fromStr(const std::string& source, Color& target) {
-    XColor xcol;
-    std::string msg = queryX11Color(source.c_str(), xcol);
-    if (msg != "") {
-        return msg;
-    } else {
-        // TODO: how to interpret these fields if
-        // xcol.flags lacks one of DoRed, DoGreen, DoBlue?
-        target.red_ = xcol.red;
-        target.green_ = xcol.green;
-        target.blue_ = xcol.blue;
-        target.x11pixelValue_ = xcol.pixel;
-        return "";
-    }
+Color Color::fromStr(const std::string& payload) {
+    // get X11 color from color string. This fails if there is no x connection
+    // from dwm.c
+    assert(g_display);
+    Colormap cmap = DefaultColormap(g_display, g_screen);
+    XColor screen_color, ret_color;
+    auto success = XAllocNamedColor(g_display, cmap,
+                                    payload.c_str(), &screen_color, &ret_color);
+    if (!success)
+        throw std::invalid_argument(
+                std::string("cannot allocate color \'") + payload + "\'");
+
+    return Color(ret_color);
 }
 
 XColor Color::toXColor() const {
-	XColor xcol;
-	xcol.pixel = x11pixelValue_;
-    xcol.red = red_;
-    xcol.green = green_;
-    xcol.blue = blue_;
-	xcol.flags = DoRed | DoGreen | DoBlue;
-	return xcol;
+    return XColor{x11pixelValue_, red_, green_, blue_, DoRed | DoGreen | DoBlue, 0};
 }
 
 Rectangle Rectangle::fromStr(const char* source) {

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -67,16 +67,16 @@ XColor Color::toXColor() const {
 }
 
 Rectangle Rectangle::fromStr(const char* source) {
-	int x, y;
-	unsigned int w, h;
-	int flags = XParseGeometry(source, &x, &y, &w, &h);
+    int x, y;
+    unsigned int w, h;
+    int flags = XParseGeometry(source, &x, &y, &w, &h);
 
-	return {
-		(XValue & flags) ? x : 0,
-		(YValue & flags) ? y : 0,
-		(WidthValue & flags) ? w : 0,
-		(HeightValue & flags) ? h : 0
-	};
+    return {
+        (XValue & flags) ? x : 0,
+        (YValue & flags) ? y : 0,
+        (WidthValue & flags) ? (int)w : 0,
+        (HeightValue & flags) ? (int)h : 0
+    };
 }
 
 std::ostream& operator<< (std::ostream& stream, const Rectangle& rect) {

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -31,7 +31,7 @@ Color::Color(XColor xcol)
 Color::Color(std::string name) {
     try {
         *this = fromStr(name);
-    } catch (std::invalid_argument) {
+    } catch (...) {
         *this = black();
     }
 }

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -78,7 +78,7 @@ inline std::string Converter<Rectangle>::str(Rectangle payload) {
 template<>
 inline Rectangle Converter<Rectangle>::parse(const std::string &payload, Rectangle const*) {
     // TODO: relative modifiers, ie a syntax for shifts, might be cool
-    return Rectangle::fromStr(payload.c_str());
+    return Rectangle::fromStr(payload);
 }
 
 using RectangleVec = std::vector<Rectangle>;

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -1,6 +1,7 @@
 #ifndef __HERBST_X11_TYPES_H_
 #define __HERBST_X11_TYPES_H_
 
+#include "types.h"
 #include <vector>
 #include <string>
 #include <iostream>
@@ -14,13 +15,13 @@
 class Color {
 public:
     Color();
+    Color(XColor xcol);
     Color(std::string name);
 
-    // parse a color from source into target. if parsing fails, an error
-    // message is returned and target is left unchanged.
-    static std::string fromStr(const std::string& source, Color& target);
     static Color black();
 
+    // throws std::invalid_argument
+    static Color fromStr(const std::string& payload);
     std::string str() const;
 
     // return an XColor as obtained form XQueryColor
@@ -46,6 +47,15 @@ private:
     // the x11 internal pixel value.
     unsigned long x11pixelValue_;
 };
+
+template<>
+inline std::string Converter<Color>::str(Color payload) { return payload.str(); }
+
+template<>
+inline Color Converter<Color>::parse(const std::string &payload, Color const*) {
+    // TODO: relative modifiers, ie brightness+10/red-20 would be cool
+    return Color::fromStr(payload);
+}
 
 struct Rectangle {
     static Rectangle fromStr(const char *source);

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include <sstream>
 #include <memory>
 #include <X11/Xlib.h>
 
@@ -65,6 +66,20 @@ struct Rectangle {
     int width;
     int height;
 };
+std::ostream& operator<< (std::ostream& stream, const Rectangle& matrix);
+
+template<>
+inline std::string Converter<Rectangle>::str(Rectangle payload) {
+    std::stringstream ss;
+    ss << payload;
+    return ss.str();
+}
+
+template<>
+inline Rectangle Converter<Rectangle>::parse(const std::string &payload, Rectangle const*) {
+    // TODO: relative modifiers, ie a syntax for shifts, might be cool
+    return Rectangle::fromStr(payload.c_str());
+}
 
 using RectangleVec = std::vector<Rectangle>;
 
@@ -72,9 +87,6 @@ struct Point2D {
     int x;
     int y;
 };
-
-std::ostream& operator<< (std::ostream& stream, const Rectangle& matrix);
-
 
 #endif
 


### PR DESCRIPTION
This is a follow-up to the discussion in #152.

Ideas behind this approach:

- Strip logic of type conversions out of Attributes, put it into types.h instead
- Have a common interface for said conversions such as the types we have conversions for can be easily made into attributes (e.g. Rectangle, which can be used to have the geometry of a client as attr)
 - Converting to/from user is always done in a consistent manner (parsing throws std::exceptions)
 - Conversions are defined where the types are defined, e.g. Color conversions are defined in x11-types.h where Color is defined

Open issue: Color constructor that takes a string currently fails silently (as it did previously) and falls back to black. I would suggest to let the exception fall through instead.