### PR TITLE
Make ChildByIndex assume ownership of children

### DIFF
--- a/src/childbyindex.h
+++ b/src/childbyindex.h
@@ -70,6 +70,9 @@ public:
         for (size_t idx = 0; idx < data.size(); idx++) {
             removeChild(std::to_string(idx));
         }
+        for (auto child : data) {
+            delete child;
+        }
         data.erase(data.begin(), data.end());
     }
 


### PR DESCRIPTION
This plugs the remaining leaks as detected by ASAN: When destroying
a MonitorManager or TagManager, no dtor takes care of deleting their children.

IMO, this patch only qualifies as a temporary solution, and it probably only works
because MonitorManager and TagManager happen to be the only subclasses
of ChildByIndex.

For what it's worth, it does facilitate enabling ASAN for test execution in the CI build.