### PR TITLE
Clean up and extend test cases for stack

### DIFF
--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,4 +1,5 @@
 import re
+import pytest
 
 def helper_get_stack_as_list(hlwm):
     # extract all window IDs out of the stack command
@@ -8,22 +9,29 @@ def helper_get_stack_as_list(hlwm):
 # raise_on_focus_temporarily = true). So we test the stacking in floating
 # mode.
 
-def test_latest_client_on_top(hlwm, create_client):
+@pytest.mark.parametrize('count', [2, 5])
+def test_clients_stacked_in_reverse_order_of_creation(hlwm, create_clients, count):
     hlwm.call('floating', 'on')
-    # new clients always appear on top of the stacking order
-    # really create clients in the right oder
-    c1 = create_client()
-    c2 = create_client()
-    assert helper_get_stack_as_list(hlwm)[0:2] == [c2,c1]
 
-def test_raise_first_client(hlwm, create_clients):
+    clients = create_clients(count)
+
+    clients.reverse()
+    assert helper_get_stack_as_list(hlwm)[:-1] == clients
+
+
+def test_raise_client_already_on_top(hlwm, create_clients):
     hlwm.call('floating', 'on')
-    [c1,c2] = create_clients(2)
+    c1, c2 = create_clients(2)
+
     hlwm.call('raise', c2)
-    assert helper_get_stack_as_list(hlwm)[0:2] == [c2,c1]
 
-def test_raise_second_client(hlwm, create_clients):
+    assert helper_get_stack_as_list(hlwm)[:-1] == [c2, c1]
+
+
+def test_raise_bottom_client(hlwm, create_clients):
     hlwm.call('floating', 'on')
-    [c1,c2] = create_clients(2)
+    c1, c2 = create_clients(2)
+
     hlwm.call('raise', c1)
-    assert helper_get_stack_as_list(hlwm)[0:2] == [c1,c2]
+
+    assert helper_get_stack_as_list(hlwm)[:-1] == [c1, c2]


### PR DESCRIPTION
In addition to some (mostly cosmetic) cleanup, this also verifies the
stack more strictly, which confirms the absence of a subtle,
almost-merged mistake in slice_create_frame().