### PR TITLE
Pass Attribute owner directly to constructor

### DIFF
--- a/src/attribute_.h
+++ b/src/attribute_.h
@@ -140,11 +140,29 @@ public:
     // get the actual value. Here, we use C++-style member function pointers such that
     // the type checker fills the template argument 'Owner' automatically
     template <typename Owner>
-    DynAttribute_(const std::string &name, Owner* owner, T (Owner::*getter)())
+    DynAttribute_(const std::string &name, Owner* owner,
+                  // std::function<T(Owner*)> getter // this does not work!
+                  T (Owner::*getter)()
+                  )
         : Attribute(name, false)
         , getter_(std::bind(getter, owner))
     {
         hookable_ = false;
+        // the following will call Attribute::setOwner()
+        // maybe this should be changed at some point
+        owner->addAttribute(this);
+    }
+    template <typename Owner>
+    DynAttribute_(const std::string &name, Owner* owner,
+                  T (Owner::*getter)(),
+                  std::string (Owner::*setter)(T)
+                  )
+        : Attribute(name, false)
+        , getter_(std::bind(getter, owner))
+        , setter_(std::bind(setter, owner, std::placeholders::_1))
+    {
+        hookable_ = false;
+        writeable_ = true;
         // the following will call Attribute::setOwner()
         // maybe this should be changed at some point
         owner->addAttribute(this);

--- a/src/attribute_.h
+++ b/src/attribute_.h
@@ -136,6 +136,20 @@ public:
         writeable_ = true;
     }
 
+    // each time a dynamic attribute is read, the getter_ is called in order to
+    // get the actual value. Here, we use C++-style member function pointers such that
+    // the type checker fills the template argument 'Owner' automatically
+    template <typename Owner>
+    DynAttribute_(const std::string &name, Owner* owner, T (Owner::*getter)())
+        : Attribute(name, false)
+        , getter_(std::bind(getter, owner))
+    {
+        hookable_ = false;
+        // the following will call Attribute::setOwner()
+        // maybe this should be changed at some point
+        owner->addAttribute(this);
+    }
+
     Type type() override { return Attribute_<T>::staticType(); }
 
     Signal_<T>& changed() override {

--- a/src/attribute_.h
+++ b/src/attribute_.h
@@ -23,6 +23,32 @@ public:
     {
     }
 
+    //! A read-only attribute of owner of type T
+    Attribute_(const std::string &name, Object* owner, const T &payload)
+        : Attribute(name, false)
+        , payload_ (payload)
+    {
+        // the following will call Attribute::setOwner()
+        // maybe this should be changed at some point,
+        // e.g. when we got rid of Object::wireAttributes()
+        owner->addAttribute(this);
+    }
+
+    //! A writable attribute of owner of type T
+    template <typename Owner>
+    Attribute_(const std::string &name, Owner* owner, const T &payload,
+               std::string(Owner::*validator)(T))
+        : Attribute(name, true)
+        , payload_ (payload)
+        , validator_(validator)
+    {
+        // the following will call Attribute::setOwner()
+        // maybe this should be changed at some point,
+        // e.g. when we got rid of Object::wireAttributes()
+        owner->addAttribute(this);
+        writeable_ = true;
+    }
+
     // set the method called for validation of external changes
     // this implicitely makes the attribute writeable
     void setValidator(Validator v) {
@@ -125,6 +151,13 @@ public:
     {
         hookable_ = false;
     }
+    DynAttribute_(const std::string &name, Object* owner, std::function<T()> getter)
+        : Attribute(name, false)
+        , getter_(getter)
+    {
+        hookable_ = false;
+        owner->addAttribute(this);
+    }
 
     // in this case, also write operations are delegated
     DynAttribute_(const std::string &name, std::function<T()> getter, std::function<std::string(T)> setter)
@@ -149,7 +182,8 @@ public:
     {
         hookable_ = false;
         // the following will call Attribute::setOwner()
-        // maybe this should be changed at some point
+        // maybe this should be changed at some point,
+        // e.g. when we got rid of Object::wireAttributes()
         owner->addAttribute(this);
     }
     template <typename Owner>
@@ -164,7 +198,8 @@ public:
         hookable_ = false;
         writeable_ = true;
         // the following will call Attribute::setOwner()
-        // maybe this should be changed at some point
+        // maybe this should be changed at some point,
+        // e.g. when we got rid of Object::wireAttributes()
         owner->addAttribute(this);
     }
 

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -44,42 +44,21 @@ void monitor_init() {
 HSMonitor::HSMonitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, HSTag* tag_)
     : tag(tag_)
     , tag_previous(tag_)
+    , name      (this, "name", "",
+           [monman_](std::string n) { return monman_->isValidMonitorName(n); })
+    , index     (this, "index", 0)
     , tag_string(this, "tag", &HSMonitor::getTagString, &HSMonitor::setTagString)
+    , pad_up    (this, "pad_up", 0)
+    , pad_right (this, "pad_right", 0)
+    , pad_down  (this, "pad_down", 0)
+    , pad_left  (this, "pad_left", 0)
+    , lock_tag  (this, "lock_tag", false)
     , dirty(true)
-    , lock_tag("lock_tag", false) // TODO
     , mouse { 0, 0 }
     , rect(rect_)
     , settings(settings_)
     , monman(monman_)
 {
-    wireAttributes({
-        &index,
-        &name,
-        &pad_up,
-        &pad_right,
-        &pad_down,
-        &pad_left,
-        &lock_tag,
-    });
-
-    name.setValidator([this] (std::string new_name) {
-        if (isdigit(new_name[0])) {
-            return std::string("The monitor name may not start with a number");
-        }
-        if (new_name == name())
-            return std::string();
-        for (auto m : *monman) {
-            if (m->name() == new_name) {
-                stringstream output;
-                output << "Monitor " << m->index()
-                       << " already has the name \""
-                       << new_name << "\"";
-                return output.str();
-            }
-        }
-        return std::string();
-    });
-
     for (auto i : {&pad_up, &pad_left, &pad_right, &pad_down}) {
         i->setWriteable();
         i->changed().connect(this, &HSMonitor::applyLayout);

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -44,9 +44,7 @@ void monitor_init() {
 HSMonitor::HSMonitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, HSTag* tag_)
     : tag(tag_)
     , tag_previous(tag_)
-    , tag_string("tag",
-                 std::bind(&HSMonitor::getTagString, this),
-                 std::bind(&HSMonitor::setTagString, this, std::placeholders::_1))
+    , tag_string("tag", this, &HSMonitor::getTagString)
     , dirty(true)
     , lock_tag("lock_tag", false) // TODO
     , mouse { 0, 0 }
@@ -57,7 +55,6 @@ HSMonitor::HSMonitor(Settings* settings_, MonitorManager* monman_, Rectangle rec
     wireAttributes({
         &index,
         &name,
-        &tag_string,
         &pad_up,
         &pad_right,
         &pad_down,

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -44,7 +44,7 @@ void monitor_init() {
 HSMonitor::HSMonitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, HSTag* tag_)
     : tag(tag_)
     , tag_previous(tag_)
-    , tag_string("tag", this, &HSMonitor::getTagString, &HSMonitor::setTagString)
+    , tag_string(this, "tag", &HSMonitor::getTagString, &HSMonitor::setTagString)
     , dirty(true)
     , lock_tag("lock_tag", false) // TODO
     , mouse { 0, 0 }

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -44,7 +44,7 @@ void monitor_init() {
 HSMonitor::HSMonitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, HSTag* tag_)
     : tag(tag_)
     , tag_previous(tag_)
-    , tag_string("tag", this, &HSMonitor::getTagString)
+    , tag_string("tag", this, &HSMonitor::getTagString, &HSMonitor::setTagString)
     , dirty(true)
     , lock_tag("lock_tag", false) // TODO
     , mouse { 0, 0 }

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -57,7 +57,7 @@ HSMonitor::HSMonitor(Settings* settings_, MonitorManager* monman_, Rectangle rec
     , mouse { 0, 0 }
     , rect(rect_)
     , settings(settings_)
-    , monman(monman_)
+    //, monman(monman_)
 {
     for (auto i : {&pad_up, &pad_left, &pad_right, &pad_down}) {
         i->setWriteable();

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -56,7 +56,7 @@ private:
     std::string getTagString();
     std::string setTagString(std::string new_tag);
     Settings* settings;
-    MonitorManager* monman;
+    //MonitorManager* monman;
 };
 
 void monitor_init();

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -27,16 +27,16 @@ public:
     HSTag*      tag;    // currently viewed tag
     HSTag*      tag_previous;    // previously viewed tag
     struct HSSlice*    slice;  // slice in the monitor stack
-    Attribute_<std::string>   name = {"name", {}};
-    Attribute_<unsigned long> index = {"index", 0};
+    Attribute_<std::string>   name;
+    Attribute_<unsigned long> index;
     DynAttribute_<std::string>   tag_string;
-    Attribute_<int>         pad_up = {"pad_up", 0};
-    Attribute_<int>         pad_right = {"pad_right", 0};
-    Attribute_<int>         pad_down = {"pad_down", 0};
-    Attribute_<int>         pad_left = {"pad_left", 0};
+    Attribute_<int>         pad_up;
+    Attribute_<int>         pad_right;
+    Attribute_<int>         pad_down;
+    Attribute_<int>         pad_left;
+    Attribute_<bool>        lock_tag;
     bool        dirty;
     bool        lock_frames;
-    Attribute_<bool>        lock_tag;
     struct {
         // last saved mouse position
         int x;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -34,7 +34,7 @@ void tag_destroy() {
 
 
 HSTag::HSTag(std::string name_, Settings* settings)
-    : frame_count("frame_count", std::bind(&HSTag::computeFrameCount, this))
+    : frame_count("frame_count", this, &HSTag::computeFrameCount)
     , client_count("client_count", this, &HSTag::computeClientCount)
     , curframe_windex("curframe_windex",
         [this] () { return frame->getFocusedFrame()->getSelection(); } )

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -35,28 +35,17 @@ void tag_destroy() {
 
 HSTag::HSTag(std::string name_, Settings* settings)
     : index(this, "index", 0)
-    , floating(this, "floating", false)
-    , name(this, "name", name_)
+    , floating(this, "floating", false, [](bool){return "";})
+    , name(this, "name", name_, &HSTag::validateNewName)
     , frame_count(this, "frame_count", &HSTag::computeFrameCount)
     , client_count(this, "client_count", &HSTag::computeClientCount)
-    , curframe_windex("curframe_windex",
+    , curframe_windex(this, "curframe_windex",
         [this] () { return frame->getFocusedFrame()->getSelection(); } )
-    , curframe_wcount("curframe_wcount",
+    , curframe_wcount(this, "curframe_wcount",
         [this] () { return frame->getFocusedFrame()->clientCount(); } )
 {
     stack = make_shared<HSStack>();
     frame = make_shared<HSFrameLeaf>(this, settings, shared_ptr<HSFrameSplit>());
-    wireAttributes({
-        &name,
-        &floating,
-        &frame_count,
-        &curframe_windex,
-        &curframe_wcount,
-    });
-    floating.setWriteable();
-    name.setValidator([this] (std::string new_name) {
-        return this->validateNewName(new_name);
-    });
 }
 
 HSTag::~HSTag() {

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -35,7 +35,7 @@ void tag_destroy() {
 
 HSTag::HSTag(std::string name_, Settings* settings)
     : frame_count("frame_count", std::bind(&HSTag::computeFrameCount, this))
-    , client_count("client_count", std::bind(&HSTag::computeClientCount, this))
+    , client_count("client_count", this, &HSTag::computeClientCount)
     , curframe_windex("curframe_windex",
         [this] () { return frame->getFocusedFrame()->getSelection(); } )
     , curframe_wcount("curframe_wcount",
@@ -48,7 +48,6 @@ HSTag::HSTag(std::string name_, Settings* settings)
         &name,
         &floating,
         &frame_count,
-        &client_count,
         &curframe_windex,
         &curframe_wcount,
     });

--- a/src/tag.h
+++ b/src/tag.h
@@ -31,6 +31,8 @@ private:
     int computeClientCount();
     //! get the number of clients on this tag
     int computeFrameCount();
+    //! check whether a name is valid and return error message otherwise
+    std::string isValidName(std::string newName);
 };
 
 void tag_init();

--- a/src/tag.h
+++ b/src/tag.h
@@ -16,9 +16,9 @@ public:
     HSTag(std::string name, Settings* settings);
     ~HSTag() override;
     std::shared_ptr<HSFrame>        frame;  // the master frame
-    Attribute_<unsigned long> index = {"index", 0};
-    Attribute_<bool>         floating = {"floating", false};
-    Attribute_<std::string>  name = {"name", {}};   // name of this tag
+    Attribute_<unsigned long> index;
+    Attribute_<bool>         floating;
+    Attribute_<std::string>  name;   // name of this tag
     DynAttribute_<int> frame_count;
     DynAttribute_<int> client_count;
     DynAttribute_<int> curframe_windex;
@@ -32,7 +32,7 @@ private:
     //! get the number of clients on this tag
     int computeFrameCount();
     //! check whether a name is valid and return error message otherwise
-    std::string isValidName(std::string newName);
+    std::string validateNewName(std::string newName);
 };
 
 void tag_init();


### PR DESCRIPTION
This new approach makes the signature for Attribute_ and DynAttribute_ very uniform. HSTag and HSMonitor are already adapted to the new framework. Other classes still use the old constructors that are kept for the time being for compatibility reasons.