### PR TITLE
Manage rule consequences as vector of non-pointers

### DIFF
--- a/src/rules.h
+++ b/src/rules.h
@@ -35,24 +35,22 @@ typedef struct {
 typedef struct {
     int     type;
     int value_type;
-    union {
-        char*       str;
-    } value;
+    std::string value;
 } HSConsequence;
 
 class HSRule {
 public:
     HSRule();
     ~HSRule();
-    std::string     label;
-    HSCondition**   conditions = nullptr;
-    int             condition_count = 0;
-    HSConsequence** consequences = nullptr;
-    int             consequence_count = 0;
-    bool            once = false;
-    time_t          birth_time; // timestamp of at creation
+    std::string label;
+    HSCondition** conditions = nullptr;
+    int condition_count = 0;
+    std::vector<HSConsequence> consequences;
+    bool once = false;
+    time_t birth_time; // timestamp of at creation
 
     bool replaceLabel(char op, char* value, Output output);
+    bool addConsequence(int type, char op, char* value, Output output);
 };
 
 typedef struct {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -216,6 +216,9 @@ const char* strlasttoken(const char* str, const char* delim) {
     return str;
 }
 
+bool string_to_bool(const std::string& string, bool oldvalue) {
+    return string_to_bool_error(string.c_str(), oldvalue, nullptr);
+}
 
 bool string_to_bool(const char* string, bool oldvalue) {
     return string_to_bool_error(string, oldvalue, nullptr);

--- a/src/utils.h
+++ b/src/utils.h
@@ -65,6 +65,7 @@ bool window_has_property(Display* dpy, Window window, char* prop_name);
 
 bool string_to_bool_error(const char* string, bool oldvalue, bool* error);
 bool string_to_bool(const char* string, bool oldvalue);
+bool string_to_bool(const std::string& string, bool oldvalue);
 
 const char* strlasttoken(const char* str, const char* delim);
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -85,3 +85,9 @@ def test_rule_labels_are_not_reused(hlwm, rules_count):
     # Remaining rule has a high label number (not zero)
     rules = hlwm.call('list_rules')
     assert rules.stdout == 'label={}\tclass=meh\ttag=moo\t\n'.format(rules_count)
+
+
+def test_cannot_use_invalid_operator_for_consequence(hlwm):
+    call = hlwm.call_xfail('rule', 'class=Foo', 'tag~bar')
+
+    assert call.stderr == 'rule: Unknown rule consequence operation "~"\n'


### PR DESCRIPTION
Along with this change, the consequence value is already turned
into an std::string, eliminating all GLib usage around consequences.