### PR TITLE
Improve herbstclient output passthrough in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     include:
         - name: "Ubuntu 16.04, gcc-8, run tests"
           dist: xenial
-          python: "3.7"
+          python: "3.6"
           before_install:
               - export CC=gcc-8 CXX=g++-8
               - linkerfix="-fuse-ld=gold" # needed to avoid linker error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,9 +48,13 @@ class HlwmBridge:
                                   )
         except subprocess.TimeoutExpired:
             self.hlwm_process.investigate_timeout('calling ' + str(args))
-        print(list(args))
-        print(proc.stdout)
-        print(proc.stderr, file=sys.stderr)
+
+        outcome = 'succeeded' if proc.returncode == 0 else 'failed'
+        allout = proc.stdout + proc.stderr
+        if allout:
+            print(f'Client command {args} {outcome} with output:\n{allout}')
+        else:
+            print(f'Client command {args} {outcome} (no output)')
 
         if expect_success:
             assert proc.returncode == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py36
 skipsdist = true
 
 ###


### PR DESCRIPTION
This removes the python version selection from .travis.yml because
it doesn't work as expected, so no f-strings for us.