### PR TITLE
 Cleanup interface of Input

### DIFF
--- a/src/arglist.cpp
+++ b/src/arglist.cpp
@@ -53,15 +53,3 @@ ArgList &ArgList::operator>>(string &val) {
     }
     return *this;
 }
-
-ArgList ArgList::replaced(const std::string& from, const std::string& to) const {
-    int i = 0;
-    vector<std::string> new_list(size());
-    for (auto v : *this) {
-        if (v == from) new_list[i] = to;
-        else new_list[i] = v;
-        ++i;
-    }
-    return ArgList(new_list);
-}
-

--- a/src/arglist.h
+++ b/src/arglist.h
@@ -47,14 +47,12 @@ public:
         return Container(begin_, c_->cend());
     }
     //! try read a value if possible
-    ArgList& operator>>(std::string& val);
+    virtual ArgList& operator>>(std::string& val);
 
     //! tell whether all previous operator>>() succeeded
     operator bool() const {
         return !shiftedTooFar_;
     }
-    //! construct a new ArgList with every occurence of 'from' replaced by 'to'
-    ArgList replaced(const std::string& from, const std::string& to) const;
 
 protected:
     //! shift state pointing into c_

--- a/src/arglist.h
+++ b/src/arglist.h
@@ -63,6 +63,7 @@ protected:
      * @note This is a shared pointer to make object copy-able:
      * 1. payload is shared (no redundant copies)
      * 2. begin_ stays valid
+     * 3. The C-style compatibility layer DEPENDS on the shared_ptr!
      */
     std::shared_ptr<Container> c_;
 };

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -225,7 +225,6 @@ int ClientManager::clientSetAttribute(string attribute,
                                       Input input,
                                       Output output)
 {
-    input.shift();
     string value = input.empty() ? "toggle" : input.front();
     HSClient* c = get_current_client();
     if (c) {

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -300,17 +300,18 @@ struct {
 function <int(Input,Output)> CommandBinding::commandFromCFunc(
         function <int(int argc, char**argv, Output output)> func) {
     return [func](Input args, Output out) {
-        shared_ptr<char*> argv(new char*[args.size()], default_delete<char*[]>());
+        shared_ptr<char*> argv(new char*[args.size() + 1],
+                default_delete<char*[]>());
 
+        // Most of the commands want a char**, not a const char**. Let's
+        // hope, they don't actually modify it.
+        argv.get()[0] = const_cast<char*>(args.command().c_str());
         auto elem = args.begin();
-        for (size_t i = 0; i < args.size(); i++) {
-            // Most of the commands want a char**, not a const char**. Let's
-            // hope, they don't actually modify it.
-            argv.get()[i] = const_cast<char*>(elem->c_str());
-            ++elem;
+        for (size_t i = 0; i < args.size(); i++, elem++) {
+            argv.get()[i+1] = const_cast<char*>(elem->c_str());
         }
 
-        return func(args.size(), argv.get(), out);
+        return func(args.size() + 1, argv.get(), out);
     };
 }
 
@@ -338,15 +339,15 @@ CommandBinding::CommandBinding(int func())
 
 // Implementation of CommandTable
 int CommandTable::callCommand(Input args, Output out) const {
-    if (args.empty()) {
-        return HERBST_COMMAND_NOT_FOUND;
+    if (args.command().empty()) {
+        // may happen if you call sprintf, but nothing afterwards
+        return HERBST_NEED_MORE_ARGS;
     }
 
-    const string cmd_name = *args.begin();
-    const auto cmd = map.find(cmd_name);
+    const auto cmd = map.find(args.command());
 
     if (cmd == map.end()) {
-        out << "error: Command \"" << cmd_name << "\" not found\n";
+        out << "error: Command \"" << args.command() << "\" not found\n";
         return HERBST_COMMAND_NOT_FOUND;
     }
 
@@ -382,21 +383,21 @@ shared_ptr<const CommandTable> Commands::get() {
 // Old C-ish interface to commands:
 
 int call_command(int argc, char** argv, Output output) {
+    if (argc < 1)
+        return HERBST_COMMAND_NOT_FOUND;
 
+    string cmd(argv[0]);
     vector<string> args;
-    args.reserve(argc);
-
-    for (int i = 0; i < argc; i++) {
-        args.emplace_back(argv[i]);
+    for (int i = 1; i < argc; i++) {
+        args.push_back(argv[i]);
     }
 
-    return Commands::call(ArgList(args), output);
+    return Commands::call(Input(cmd, args), output);
 }
 
 int call_command_no_output(int argc, char** argv) {
     std::ostringstream output;
-    int status = call_command(argc, argv, output);
-    return status;
+    return call_command(argc, argv, output);
 }
 
 int list_commands(int, char**, Output output)

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -300,6 +300,11 @@ struct {
 function <int(Input,Output)> CommandBinding::commandFromCFunc(
         function <int(int argc, char**argv, Output output)> func) {
     return [func](Input args, Output out) {
+        /* Note that instead of copying the arguments, we point to their
+         * original location here. This only works because Input stores its
+         * payload in shared pointers and other references to them are held
+         * until the command is finished.
+         */
         shared_ptr<char*> argv(new char*[args.size() + 1],
                 default_delete<char*[]>());
 

--- a/src/command.h
+++ b/src/command.h
@@ -13,12 +13,12 @@ using namespace std;
 // returns a command binding that internalizes object to given a command that
 // calls the member function of the given object
 #define BIND_OBJECT(OBJECT, MEMBER) \
-    (CommandBinding([OBJECT](ArgList in, Output out) { \
+    (CommandBinding([OBJECT](Input in, Output out) { \
         return OBJECT->MEMBER(in, out); \
     }))
 
 #define BIND_PARAMETER(PARAM, FUNCTION) \
-    (CommandBinding([PARAM](ArgList in, Output out) { \
+    (CommandBinding([PARAM](Input in, Output out) { \
         return FUNCTION(PARAM, in, out); \
     }))
 
@@ -39,7 +39,7 @@ class CommandBinding {
 public:
     CommandBinding(function<int(Input, Output)> cmd)
         : command(cmd) {}
-    // A command that taks an argument list and produces output
+    // A command that takes an argument list and produces output
     CommandBinding(int cmd(Input, Output))
         : command(cmd) {}
     // A command that doesn't produce ouput
@@ -62,7 +62,7 @@ public:
     CommandBinding(int func());
 
     /** Call the stored command */
-    int operator()(ArgList args, Output out) const { return command(args, out); }
+    int operator()(Input args, Output out) const { return command(args, out); }
 
 private:
     // FIXME: Remove after C++ transition

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -640,7 +640,7 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
                 /* ignore recognized long option */
                 break;
             case 'v':
-                version({{}}, std::cout);
+                version({"version"}, std::cout);
                 exit(0);
             case 'c':
                 g_autostart_path = optarg;

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -269,7 +269,6 @@ HSMonitor* string_to_monitor(const char* str) {
 int HSMonitor::move_cmd(Input input, Output output) {
     // usage: move_monitor INDEX RECT [PADUP [PADRIGHT [PADDOWN [PADLEFT]]]]
     // moves monitor with number to RECT
-    input.shift();
     if (input.empty()) {
         return HERBST_NEED_MORE_ARGS;
     }

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -133,7 +133,6 @@ function<int(Input, Output)> MonitorManager::byFirstArg(HSMonitorCommand cmd)
 {
     return [this,cmd](Input input, Output output) -> int {
         HSMonitor *monitor;
-        input.shift();
         if (input.empty()) {
             monitor = get_current_monitor();
         } else {
@@ -160,12 +159,10 @@ void MonitorManager::relayoutTag(HSTag *tag)
 
 int MonitorManager::removeMonitor(Input input, Output output)
 {
-    if (input.size() < 2) {
+    string monitorIdxString;
+    if (!(input >> monitorIdxString)) {
         return HERBST_NEED_MORE_ARGS;
     }
-
-    input.shift();
-    string monitorIdxString = input.front();
     auto monitor = byString(monitorIdxString);
 
     if (monitor == nullptr) {

--- a/src/rectangle.cpp
+++ b/src/rectangle.cpp
@@ -135,7 +135,6 @@ RectangleVec disjoin_rects(const RectangleVec &buf) {
 /* end of TODO to remove RectList */
 
 int disjoin_rects_command(Input input, Output output) {
-    input.shift();
     if (input.empty()) {
         return HERBST_NEED_MORE_ARGS;
     }

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -104,8 +104,7 @@ Attribute* RootCommands::getAttribute(std::string path, Output output) {
     return a;
 }
 
-int RootCommands::print_object_tree_command(ArgList in, Output output) {
-    in.shift();
+int RootCommands::print_object_tree_command(Input in, Output output) {
     auto path = Path(in.empty() ? std::string("") : in.front()).toVector();
     while (!path.empty() && path.back() == "") {
         path.pop_back();
@@ -126,10 +125,12 @@ int RootCommands::substitute_cmd(Input input, Output output)
     if (!(input >> ident >> path )) {
         return HERBST_NEED_MORE_ARGS;
     }
-    if (input.empty()) return HERBST_NEED_MORE_ARGS;
     Attribute* a = getAttribute(path, output);
     if (!a) return HERBST_INVALID_ARGUMENT;
-    return Commands::call(input.replaced(ident, a->str()), output);
+
+    auto carryover = input.fromHere();
+    carryover.replace(ident, a->str());
+    return Commands::call(carryover, output);
 }
 
 int RootCommands::sprintf_cmd(Input input, Output output)
@@ -174,7 +175,10 @@ int RootCommands::sprintf_cmd(Input input, Output output)
     if (lastpos < format.size()) {
         blobs += format.substr(lastpos, format.size()-lastpos);
     }
-    return Commands::call(input.replaced(ident, blobs), output);
+
+    auto carryover = input.fromHere();
+    carryover.replace(ident, blobs);
+    return Commands::call(carryover, output);
 }
 
 

--- a/src/rootcommands.h
+++ b/src/rootcommands.h
@@ -26,7 +26,7 @@ public:
     int get_attr_cmd(Input args, Output output);
     int set_attr_cmd(Input args, Output output);
     int attr_cmd(Input args, Output output);
-    int print_object_tree_command(ArgList args, Output output);
+    int print_object_tree_command(Input args, Output output);
 
     int substitute_cmd(Input input, Output output);
     int sprintf_cmd(Input input, Output output);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -193,26 +193,20 @@ std::function<string(Color)> Settings::setColorAttr(Object* root, std::string na
     };
 }
 
-int Settings::set_cmd(Input argv, Output output) {
-    argv.shift();
-    if (argv.empty()) {
+int Settings::set_cmd(Input input, Output output) {
+    std::string set_name, value;
+    if (!(input >> set_name >> value))
         return HERBST_NEED_MORE_ARGS;
-    }
-    auto set_name = argv.front();
-    argv.shift();
-    if (argv.empty()) {
-        return HERBST_NEED_MORE_ARGS;
-    }
-    auto value = argv.front();
+
     auto attr = attribute(set_name);
     if (!attr) {
-        output << argv.command() <<
+        output << input.command() <<
             ": Setting \"" << set_name << "\" not found\n";
         return HERBST_SETTING_NOT_FOUND;
     }
     auto msg = attr->change(value);
     if (msg != "") {
-        output << argv.command()
+        output << input.command()
                << ": Invalid value \"" << value
                << "\" for setting \"" << set_name << "\": "
                << msg << endl;
@@ -222,7 +216,6 @@ int Settings::set_cmd(Input argv, Output output) {
 }
 
 int Settings::toggle_cmd(Input argv, Output output) {
-    argv.shift();
     if (argv.empty()) {
         return HERBST_NEED_MORE_ARGS;
     }
@@ -251,7 +244,6 @@ int Settings::toggle_cmd(Input argv, Output output) {
 }
 
 int Settings::cycle_value_cmd(Input argv, Output output) {
-    argv.shift();
     if (argv.empty()) {
         return HERBST_NEED_MORE_ARGS;
     }
@@ -278,7 +270,6 @@ int Settings::cycle_value_cmd(Input argv, Output output) {
 }
 
 int Settings::get_cmd(Input argv, Output output) {
-    argv.shift();
     if (argv.empty()) {
         return HERBST_NEED_MORE_ARGS;
     }

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -52,11 +52,10 @@ HSTag* TagManager::add_tag(const std::string& name) {
 }
 
 int TagManager::tag_add_command(Input input, Output output) {
-    input.shift();
     if (input.empty()) {
         return HERBST_NEED_MORE_ARGS;
     }
-    if ("" == input.front()) {
+    if (input.front().empty()) {
         output << input.command() << ": An empty tag name is not permitted\n";
         return HERBST_INVALID_ARGUMENT;
     }
@@ -66,12 +65,10 @@ int TagManager::tag_add_command(Input input, Output output) {
 }
 
 int TagManager::removeTag(Input input, Output output) {
-    if (input.size() < 2) {
+    std::string tagNameToRemove;
+    if (!(input >> tagNameToRemove)) {
         return HERBST_NEED_MORE_ARGS;
     }
-    input.shift();
-    auto tagNameToRemove = input.front();
-    input.shift();
     auto targetTagName = input.empty() ? get_current_monitor()->tag->name : input.front();
 
     auto targetTag = find(targetTagName);
@@ -132,13 +129,10 @@ int TagManager::removeTag(Input input, Output output) {
 }
 
 int TagManager::tag_rename_command(Input input, Output output) {
-    if (input.size() < 3) {
+    std::string old_name, new_name;
+    if (!(input >> old_name >> new_name)) {
         return HERBST_NEED_MORE_ARGS;
     }
-    input.shift();
-    auto old_name = input.front();
-    input.shift();
-    auto new_name = input.front();
     if (new_name == "") {
         output << input.command() << ": An empty tag name is not permitted\n";
         return HERBST_INVALID_ARGUMENT;
@@ -246,10 +240,9 @@ void TagManager::moveClient(HSClient* client, HSTag* target) {
 }
 
 int TagManager::tag_move_window_command(Input argv, Output output) {
-    if (argv.size() < 2) {
+    if (argv.empty()) {
         return HERBST_NEED_MORE_ARGS;
     }
-    argv.shift();
     HSTag* target = find(argv.front());
     if (!target) {
         output << argv.command() << ": Tag \"" << argv.front() << "\" not found\n";
@@ -260,10 +253,9 @@ int TagManager::tag_move_window_command(Input argv, Output output) {
 }
 
 int TagManager::tag_move_window_by_index_command(Input argv, Output output) {
-    if (argv.size() < 2) {
+    if (argv.empty()) {
         return HERBST_NEED_MORE_ARGS;
     }
-    argv.shift();
     auto tagIndex = argv.front();
     argv.shift();
     bool skip_visible = (!argv.empty() && argv.front() == "--skip-visible");

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -24,7 +24,11 @@ int Tmp::mktemp(Input input, Output output) {
     if (!a) return HERBST_INVALID_ARGUMENT;
     addAttribute(a);
     string path = string(TMP_OBJECT_PATH) + "." + attr_name;
-    int retval = Commands::call(input.replaced(identifier, path), output);
+
+    auto carryover = input.fromHere();
+    carryover.replace(identifier, path);
+    int retval = Commands::call(carryover, output);
+
     a->detachFromOwner();
     delete a;
     number_active--;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -21,6 +21,6 @@ void Input::replace(const std::string &from, const std::string &to)
         if (v == from)
             v = to;
 
-    if (command_ == from)
-        command_ = to;
+    if (*command_ == from)
+        *command_ = to;
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,25 +1,26 @@
 #include "types.h"
 
-
-Input::Input(const ArgList& argv)
-    : ArgList(argv)
+Input &Input::operator>>(std::string &val)
 {
-}
-
-Input& Input::operator>>(std::string& val) {
-    // if we are on the beginning, skip the command name;
-    if (c_->begin() == begin_) {
-        shift();
-    }
     ArgList::operator>>(val);
     return *this;
 }
 
-std::string Input::command() const {
-    // access the first element without any shifts.
-    if (c_->begin() != c_->end()) {
-        return *c_->begin();
-    } else {
-        return {};
-    }
+Input Input::fromHere()
+{
+    std::string cmd;
+    if (!(*this >> cmd))
+        return {{}, {}};
+
+    return Input(cmd, toVector());
+}
+
+void Input::replace(const std::string &from, const std::string &to)
+{
+    for (auto &v : *c_)
+        if (v == from)
+            v = to;
+
+    if (command_ == from)
+        command_ = to;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -28,12 +28,22 @@ using Output = std::ostream&;
  */
 class Input : public ArgList {
 public:
-    //! Initialize from a C-style main() argv array:
-    //! argv[0] is the command name and the remaining entries are the
-    //! parameters
-    Input(const ArgList& argv);
-    Input& operator>>(std::string& val);
-    std::string command() const;
+    Input(const std::string command, const Container &c = {})
+        : ArgList(c), command_(command) {}
+
+    std::string command() const { return command_; }
+
+    Input &operator>>(std::string &val) override;
+
+    //! construct a new Input where the first (current) arg is the command
+    Input fromHere();
+
+    //! Replace every occurence of 'from' by 'to'
+    //! @note this includes the command itself
+    void replace(const std::string &from, const std::string &to);
+
+protected:
+    std::string command_;
 };
 
 /* Primitive types that can be converted from/to user input/output */

--- a/src/types.h
+++ b/src/types.h
@@ -29,9 +29,9 @@ using Output = std::ostream&;
 class Input : public ArgList {
 public:
     Input(const std::string command, const Container &c = {})
-        : ArgList(c), command_(command) {}
+        : ArgList(c), command_(std::make_shared<std::string>(command)) {}
 
-    std::string command() const { return command_; }
+    const std::string& command() const { return *command_; }
 
     Input &operator>>(std::string &val) override;
 
@@ -43,7 +43,10 @@ public:
     void replace(const std::string &from, const std::string &to);
 
 protected:
-    std::string command_;
+    //! Command name
+    //! A shared pointer to avoid copies when passing Input around
+    //! @note The C-style compatibility layer DEPENDS on the shared_ptr!
+    std::shared_ptr<std::string> command_;
 };
 
 /* Primitive types that can be converted from/to user input/output */

--- a/tests/test_root_commands.py
+++ b/tests/test_root_commands.py
@@ -16,6 +16,26 @@ def test_object_tree(hlwm):
     assert len(t2) > len(t3)
 
 
+def test_substitute(hlwm):
+    expected_output = hlwm.get_attr('tags.count') + '\n'
+
+    call = hlwm.call('substitute X tags.count echo X')
+
+    assert call.stdout == expected_output
+
+
+def test_substitute_missing_attribute__command_treated_as_attribute(hlwm):
+    call = hlwm.call_xfail('substitute X echo X')
+
+    assert call.stderr == 'The root object has no attribute "echo"\n'
+
+
+def test_substitute_command_missing(hlwm):
+    call = hlwm.call_xfail('substitute X tags.count')
+
+    assert call.stderr == 'substitute: not enough arguments\n'
+
+
 def test_sprintf(hlwm):
     expected_count = hlwm.get_attr('tags.count')
     expected_wmname = hlwm.get_attr('settings.wmname')
@@ -34,6 +54,12 @@ def test_sprintf_too_few_attributes__command_treated_as_attribute(hlwm):
 
 def test_sprintf_too_few_attributes_in_total(hlwm):
     call = hlwm.call_xfail('sprintf X %s/%s tags.count')
+
+    assert call.stderr == 'sprintf: not enough arguments\n'
+
+
+def test_sprintf_command_missing(hlwm):
+    call = hlwm.call_xfail('sprintf X %s tags.count')
 
     assert call.stderr == 'sprintf: not enough arguments\n'
 


### PR DESCRIPTION
Input is an ArgList that also stores the name of the command that
was called. It can only be constructed from a command name and (optionally) a
list of arguments to prevent wrong use.

All accessors from ArgList can be used. operator>> is overridden to
return the correct reference.