### PR TITLE
Add -Wextra to debug build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ function (add_debugflags)
 		-g -Og
 		-pedantic -Wall -Werror
 		-Wnull-dereference -Wdouble-promotion -Wformat=2
+		-Wextra -Wno-unused-parameter
 		-Wno-sign-compare -Wno-narrowing -Wno-error=cast-function-type
 		-fsanitize=address,leak,undefined
 		-fno-omit-frame-pointer)

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -256,7 +256,7 @@ void complete_against_mouse_buttons(const char* needle, char* prefix, Output out
 }
 
 MouseBinding* mouse_binding_find(unsigned int modifiers, unsigned int button) {
-    MouseBinding mb = { 0 };
+    MouseBinding mb = {};
     mb.modifiers = modifiers;
     mb.button = button;
     GList* elem = g_list_find_custom(g_mouse_binds, &mb,

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -288,12 +288,12 @@ static void slice_to_window_buf(HSSlice* s, struct s2wb* data) {
 
 void HSStack::to_window_buf(Window* buf, int len,
                          bool real_clients, int* remain_len) {
-    struct s2wb data = {
-        /* .len = */ len,
-        /* .buf = */ buf,
-        /* .missing = */ 0,
-        /* .real_clients = */ real_clients,
-    };
+    struct s2wb data = {};
+    data.len = len;
+    data.buf = buf;
+    data.missing = 0;
+    data.real_clients = real_clients;
+
     for (int i = 0; i < LAYER_COUNT; i++) {
         data.layer = (HSLayer)i;
         for (auto slice : top[i]) {


### PR DESCRIPTION
This fixes two occurrences of a missing-field-initializers warning,
which is part of -Wextra.

A suppression unused-parameter is added because it is part of -Wextra
but triggers a lot of false positives (in the sense that those are no
bugs).