### PR TITLE
Rename RuleManager::removeRule() to removeRules()

### DIFF
--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -123,7 +123,7 @@ int RuleManager::unruleCommand(Input input, Output output) {
         rule_label_index_ = 0;
     } else {
         // Remove rule specified by argument
-        auto removedCount = removeRule(arg);
+        auto removedCount = removeRules(arg);
         if (removedCount == 0) {
             output << "Couldn't find any rules with label \"" << arg << "\"";
             return HERBST_INVALID_ARGUMENT;
@@ -149,7 +149,7 @@ int RuleManager::listRulesCommand(Output output) {
  *
  * \returns number of removed rules
  */
-size_t RuleManager::removeRule(std::string label) {
+size_t RuleManager::removeRules(std::string label) {
     auto countBefore = rules_.size();
 
     for (auto ruleIter = rules_.begin(); ruleIter != rules_.end();) {

--- a/src/rulemanager.h
+++ b/src/rulemanager.h
@@ -17,7 +17,7 @@ public:
     HSClientChanges evaluateRules(HSClient* client);
 
 private:
-    size_t removeRule(std::string label);
+    size_t removeRules(std::string label);
     std::tuple<std::string, char, std::string> tokenize_arg(std::string arg);
 
     //! Ever-incrementing index for labeling new rules


### PR DESCRIPTION
This more accurately reflects what the method does (i.e., not only
remove the first match).