### PR TITLE
IWYU: Remove unnecessary includes

### DIFF
--- a/src/attribute.h
+++ b/src/attribute.h
@@ -5,7 +5,6 @@
 
 #include <string>
 #include <vector>
-#include <functional>
 
 class Object;
 class Signal;

--- a/src/byname.cpp
+++ b/src/byname.cpp
@@ -1,6 +1,5 @@
 
 #include "byname.h"
-#include "hook.h"
 #include <cassert>
 #include "attribute.h"
 

--- a/src/byname.h
+++ b/src/byname.h
@@ -1,8 +1,8 @@
 #ifndef __HLWM_BY_NAME_H_
 #define __HLWM_BY_NAME_H_
 
-#include <memory>
 #include <map>
+
 #include "object.h"
 #include "hook.h"
 

--- a/src/childbyindex.h
+++ b/src/childbyindex.h
@@ -1,7 +1,6 @@
 #ifndef CHILDBYINDEX_H
 #define CHILDBYINDEX_H
 
-#include <unordered_map>
 #include <string>
 #include "object.h"
 #include "attribute_.h"

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -12,17 +12,13 @@
 #include "mouse.h"
 #include "ewmh.h"
 #include "ipc-protocol.h"
-#include "object.h"
 #include "decoration.h"
 #include "key.h"
 #include "utils.h"
 // system
 #include "glib-backports.h"
-#include <cassert>
 #include <cstdio>
 #include <cstdlib>
-#include <sys/types.h>
-#include <regex.h>
 #include <cstring>
 #include <sstream>
 // gui

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -3,7 +3,6 @@
 #include "command.h"
 #include "completion.h"
 #include "utils.h"
-#include "settings.h"
 #include "layout.h"
 #include "tag.h"
 #include "key.h"
@@ -19,7 +18,6 @@
 #include <cstdlib>
 #include <cstdio>
 #include <search.h>
-#include <unistd.h>
 #include <sstream>
 
 extern char** environ;

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -3,14 +3,6 @@
 #include "globals.h"
 #include "settings.h"
 #include "ewmh.h"
-#include "root.h"
-#include "utils.h"
-
-#include <cstdio>
-#include <cstring>
-#include <sstream>
-#include <memory>
-
 
 std::map<Window,HSClient*> Decoration::decwin2client;
 

--- a/src/entity.h
+++ b/src/entity.h
@@ -2,8 +2,6 @@
 #define ENTITY
 
 #include <string>
-#include <memory>
-
 
 enum class Type {
     VIRTUAL,

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -12,11 +12,9 @@
 #include "glib-backports.h"
 #include <cstring>
 #include <cstdio>
-#include <stdint.h>
 #include <limits>
 
 #include <X11/Xlib.h>
-#include <X11/Xproto.h>
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
 

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -2,8 +2,6 @@
 #define __HERBSTLUFT_EWMH_H_
 
 #include <X11/Xlib.h>
-#include <X11/Xproto.h>
-#include <X11/Xatom.h>
 #include <array>
 
 #define ENUM_WITH_ALIAS(Identifier, Alias) \

--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -1,7 +1,6 @@
 #include "floating.h"
 
 #include <cstdlib>
-#include <cstdio>
 #include <algorithm>
 
 #include "client.h"

--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -9,9 +9,7 @@
 #include "ewmh.h"
 #include "client.h"
 
-#include <X11/Xatom.h>
 #include <X11/Xlib.h>
-#include <X11/Xproto.h>
 #include <X11/Xutil.h>
 
 using namespace std;

--- a/src/framedecoration.h
+++ b/src/framedecoration.h
@@ -5,7 +5,6 @@
 
 class HSTag;
 struct Slice;
-class FrameDecoration;
 class Settings;
 
 class FrameDecorationData {

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -1,7 +1,6 @@
 #include "globals.h"
 #include "utils.h"
 #include "ipc-protocol.h"
-#include "layout.h"
 #include "tag.h"
 
 #include <cassert>

--- a/src/hookmanager.cpp
+++ b/src/hookmanager.cpp
@@ -1,8 +1,4 @@
 #include "hookmanager.h"
-#include "hook.h"
-//#include "namedhook.h"
-#include "root.h"
-
 
 HookManager::HookManager()
     : add_("add"), remove_("remove") {

--- a/src/ipc-server.cpp
+++ b/src/ipc-server.cpp
@@ -9,7 +9,6 @@
 #include "glib-backports.h"
 
 #include <X11/Xlib.h>
-#include <X11/Xproto.h>
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -4,7 +4,6 @@
 #include "utils.h"
 #include "ipc-protocol.h"
 #include "command.h"
-#include "utils.h"
 
 #include <cstdio>
 #include <cstring>

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1,13 +1,9 @@
 #include "client.h"
 #include "globals.h"
 #include "utils.h"
-#include "x11-utils.h"
-#include "hook.h"
-#include "ewmh.h"
 #include "ipc-protocol.h"
 #include "settings.h"
 #include "layout.h"
-#include "stack.h"
 #include "monitor.h"
 #include "floating.h"
 #include "tagmanager.h"
@@ -17,13 +13,10 @@
 #include <glib.h>
 #include "glib-backports.h"
 #include <cstdlib>
-#include <cstdio>
 #include <cstring>
 #include <cassert>
-#include <stdint.h>
 
 #include <memory>
-#include <iomanip>
 #include <sstream>
 #include <algorithm>
 

--- a/src/layout.h
+++ b/src/layout.h
@@ -5,7 +5,6 @@
 #include "glib-backports.h"
 #include "types.h"
 #include <cstdlib>
-#include <X11/Xlib.h>
 #include <functional>
 #include "tilingresult.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,6 @@
 #include "ewmh.h"
 #include "stack.h"
 #include "client.h"
-#include "object.h"
-#include "decoration.h"
 #include "xconnection.h"
 #include "tagmanager.h"
 #include "monitormanager.h"
@@ -22,7 +20,6 @@
 #include "rootcommands.h"
 #include "tmp.h"
 #include "rulemanager.h"
-#include "completion.h"
 // standard
 #include <cstring>
 #include <cstdio>

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -1,7 +1,5 @@
 #include <cassert>
 #include <cstring>
-#include <cstdio>
-#include <cctype>
 #include <sstream>
 #ifdef XINERAMA
 #include <X11/extensions/Xinerama.h>
@@ -11,7 +9,6 @@
 #include "globals.h"
 #include "ipc-protocol.h"
 #include "utils.h"
-#include "mouse.h"
 #include "hook.h"
 #include "layout.h"
 #include "tag.h"
@@ -22,7 +19,6 @@
 #include "client.h"
 #include "rectangle.h"
 #include "monitormanager.h"
-#include "root.h"
 #include "clientmanager.h"
 #include "tagmanager.h"
 

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -10,7 +10,6 @@
 class HSTag;
 class Settings;
 class MonitorManager;
-struct Slice;
 class Stack;
 
 class Monitor : public Object {

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -12,15 +12,11 @@
 #include "x11-utils.h"
 
 #include <cstdlib>
-#include <cstdio>
 #include <cstring>
 #include "glib-backports.h"
 
 // gui
 #include <X11/Xlib.h>
-#include <X11/Xproto.h>
-#include <X11/Xutil.h>
-#include <X11/Xatom.h>
 #include <X11/cursorfont.h>
 
 static Point2D          g_button_drag_start;

--- a/src/namedhook.cpp
+++ b/src/namedhook.cpp
@@ -1,8 +1,4 @@
 #include "namedhook.h"
-#include "object.h"
-
-#include <algorithm>
-#include <iostream>
 
 #ifdef ENABLE_NAMED_HOOK
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -3,7 +3,6 @@
 #include "utils.h"
 #include "cassert"
 #include "globals.h"
-#include "ipc-protocol.h"
 #include "hook.h"
 #include "attribute.h"
 

--- a/src/object.h
+++ b/src/object.h
@@ -5,8 +5,6 @@
 
 #include <map>
 #include <vector>
-#include <functional>
-
 
 #define OBJECT_PATH_SEPARATOR '.'
 #define USER_ATTRIBUTE_PREFIX "my_"

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -3,21 +3,15 @@
 #include "hookmanager.h"
 #include "clientmanager.h"
 #include "monitormanager.h"
-#include "monitor.h"
-#include "attribute.h"
-#include "ipc-protocol.h"
 #include "globals.h"
 #include "settings.h"
 #include "tmp.h"
 #include "decoration.h"
-#include "client.h"
 #include "rootcommands.h"
 #include "utils.h"
 #include "rulemanager.h"
 
 #include <memory>
-#include <stdexcept>
-#include <sstream>
 
 std::shared_ptr<Root> Root::root_;
 

--- a/src/root.h
+++ b/src/root.h
@@ -1,13 +1,11 @@
 #ifndef ROOT_H
 #define ROOT_H
 
-#include "types.h"
 #include "object.h"
 #include "child.h"
 
 // new object tree root.
 
-class Attribute;
 class TagManager;
 class HookManager;
 class ClientManager;

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <map>
 #include <functional>
-#include <sstream>
 #include <cstring>
 #include <iostream>
 

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -1,15 +1,12 @@
 #include "rules.h"
+
 #include "globals.h"
 #include "utils.h"
 #include "ewmh.h"
 #include "client.h"
-#include "ipc-protocol.h"
 #include "hook.h"
 
-#include <cstring>
 #include <cstdio>
-#include <sys/types.h>
-#include <list>
 #include <algorithm>
 
 /// TYPES ///

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -9,10 +9,7 @@
 #include "utils.h"
 #include "completion.h"
 
-#include <cstring>
-#include <cstdio>
 #include <sstream>
-#include <algorithm>
 
 
 using namespace std;

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -9,7 +9,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <cstring>
 #include <cassert>
 #include <iomanip>
 

--- a/src/stack.h
+++ b/src/stack.h
@@ -4,8 +4,7 @@
 #include <X11/Xlib.h>
 #include "glib-backports.h"
 #include <array>
-#include <memory>
-#include "x11-types.h"
+
 #include "types.h"
 
 enum HSLayer {

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -1,7 +1,4 @@
-#include <cassert>
 #include <cstring>
-#include <cstdio>
-#include <sstream>
 
 #include "tag.h"
 #include "tagmanager.h"
@@ -14,13 +11,9 @@
 #include "hook.h"
 #include "layout.h"
 #include "stack.h"
-#include "ewmh.h"
 #include "monitor.h"
 #include "settings.h"
 #include "utils.h"
-
-#include "childbyindex.h"
-#include <sstream>
 
 using namespace std;
 

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -9,7 +9,6 @@
 #include "client.h"
 #include "layout.h"
 #include "stack.h"
-#include "settings.h"
 #include "utils.h"
 
 using namespace std;

--- a/src/tilingresult.cpp
+++ b/src/tilingresult.cpp
@@ -1,5 +1,4 @@
 #include "tilingresult.h"
-#include "utils.h"
 
 using namespace std;
 

--- a/src/tilingresult.h
+++ b/src/tilingresult.h
@@ -1,8 +1,8 @@
 #ifndef __HLWM_TILINGSTEP_H_
 #define __HLWM_TILINGSTEP_H_
 
-#include <tuple>
 #include <list>
+
 #include "x11-types.h"
 #include "framedecoration.h"
 

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -1,6 +1,5 @@
-
 #include "tmp.h"
-#include "utils.h"
+
 #include "rootcommands.h"
 #include "command.h"
 #include "ipc-protocol.h"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,8 +3,6 @@
 // standard
 #include <string>
 #include <sstream>
-#include <stdarg.h>
-#include <cstdio>
 #include <cstring>
 #include <cstdlib>
 // gui

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -6,7 +6,6 @@
 #include <X11/Xutil.h>
 
 #include <iostream>
-#include <sstream>
 #include <iomanip>
 #include <cstdio>
 #include <cassert>

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -6,7 +6,6 @@
 #include <string>
 #include <iostream>
 #include <sstream>
-#include <memory>
 #include <X11/Xlib.h>
 
 class Color {

--- a/src/x11-utils.cpp
+++ b/src/x11-utils.cpp
@@ -1,6 +1,5 @@
 #include "x11-utils.h"
 #include "globals.h"
-#include <cstdio>
 
 #include<X11/extensions/shape.h>
 

--- a/src/x11-utils.h
+++ b/src/x11-utils.h
@@ -1,7 +1,6 @@
 #ifndef __HERBST_X11_UTILS_H_
 #define __HERBST_X11_UTILS_H_
 
-#include <cstddef>
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -1,12 +1,8 @@
 #include "xconnection.h"
 #include "globals.h"
-#include "utils.h"
 
 #include <X11/Xlib.h>
 #include <X11/Xproto.h>
-#include <X11/Xutil.h>
-#include <X11/Xatom.h>
-#include <X11/cursorfont.h>
 
 #include <iostream>
 


### PR DESCRIPTION
This removes #includes that are not required by the including file,
usually for these reasons:
 * the #include was needed in the past but not anymore
 * the same #include already exists in (and is needed by) the module header

Note that this explicitly does *not* remove any #includes based on whether
the build would still work without them (because that would be wrong).