### PR TITLE
Drop discouraged "using namespace std;"

### DIFF
--- a/src/arglist.cpp
+++ b/src/arglist.cpp
@@ -1,8 +1,9 @@
 #include "arglist.h"
 
-using namespace std;
+using std::string;
+using std::stringstream;
 
-ArgList::ArgList(const std::initializer_list<std::string> &l)
+ArgList::ArgList(const std::initializer_list<string> &l)
     : container_(std::make_shared<Container>(l))
 { reset(); }
 
@@ -12,7 +13,7 @@ ArgList::ArgList(const ArgList::Container &c)
 
 ArgList::ArgList(const ArgList &al) : container_(al.container_) { reset(); }
 
-ArgList::ArgList(const std::string &s, char delim) {
+ArgList::ArgList(const string &s, char delim) {
     container_ = std::make_shared<Container>(split(s, delim));
     reset();
 }
@@ -23,10 +24,10 @@ ArgList::ArgList(Container::const_iterator from, Container::const_iterator to)
     reset();
 }
 
-ArgList::Container ArgList::split(const std::string &s, char delim) {
+ArgList::Container ArgList::split(const string &s, char delim) {
     Container ret;
-    std::stringstream tmp(s);
-    std::string item;
+    stringstream tmp(s);
+    string item;
     // read "lines" seperated by delim
     while (std::getline(tmp, item, delim))
         ret.push_back(item);
@@ -38,18 +39,18 @@ ArgList::Container ArgList::split(const std::string &s, char delim) {
     return ret;
 }
 
-std::string ArgList::join(ArgList::Container::const_iterator first,
+string ArgList::join(ArgList::Container::const_iterator first,
                           ArgList::Container::const_iterator last,
                           char delim) {
     if (first == last)
         return {};
-    std::stringstream tmp;
+    stringstream tmp;
     tmp << *first;
     for (auto it = first + 1; it != last; ++it)
         tmp << delim << *it;
     return tmp.str();
 }
-std::string ArgList::join(char delim) {
+string ArgList::join(char delim) {
     return join(begin_, container_->cend(), delim);
 }
 

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -17,7 +17,7 @@
 #include "tag.h"
 #include "utils.h"
 
-using namespace std;
+using std::string;
 
 ClientManager::ClientManager(Theme& theme_, Settings& settings_)
     : focus(*this, "focus")
@@ -56,7 +56,7 @@ HSClient* ClientManager::client(Window window)
  *                  a decimal number its decimal window id.
  * \return          Pointer to the resolved client, or null, if client not found
  */
-HSClient* ClientManager::client(const std::string &identifier)
+HSClient* ClientManager::client(const string &identifier)
 {
     if (identifier.empty()) {
         // TODO: the frame doesn't provide us with a shared pointer yet

--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -10,7 +10,8 @@
 #include "tag.h"
 #include "utils.h"
 
-using namespace std;
+using std::vector;
+using std::make_pair;
 
 // rectlist_rotate rotates the list of given rectangles, s.t. the direction dir
 // becomes the direction "right". idx is some distinguished element, whose

--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -12,8 +12,6 @@
 #include "utils.h"
 #include "x11-utils.h"
 
-using namespace std;
-
 FrameDecoration::FrameDecoration(HSTag* tag_, Settings* settings_)
     : visible(false)
     , window_transparent(false)

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -25,8 +25,6 @@
 #include "tagmanager.h"
 #include "utils.h"
 
-using namespace std;
-
 extern MonitorManager* g_monitors;
 
 Monitor::Monitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, HSTag* tag_)
@@ -283,7 +281,7 @@ int rename_monitor_command(int argc, char** argv, Output output) {
             ": Monitor \"" << argv[1] << "\" not found!\n";
         return HERBST_INVALID_ARGUMENT;
     }
-    string error = mon->name.change(argv[2]);
+    std::string error = mon->name.change(argv[2]);
     if (!error.empty()) {
         output << argv[0] << ": " << error << "\n";
         return HERBST_INVALID_ARGUMENT;

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -14,7 +14,7 @@
 #include "tagmanager.h"
 #include "utils.h"
 
-using namespace std;
+using std::string;
 
 MonitorManager* g_monitors;
 
@@ -62,7 +62,7 @@ int MonitorManager::indexInDirection(Monitor* m, Direction dir) {
     RectangleIdxVec rects;
     int relidx = -1;
     FOR (i,0,size()) {
-        rects.push_back(make_pair(i, byIdx(i)->rect));
+        rects.push_back(std::make_pair(i, byIdx(i)->rect));
         if (byIdx(i) == m) relidx = i;
     }
     HSAssert(relidx >= 0);
@@ -137,11 +137,11 @@ Monitor* MonitorManager::byString(string str) {
     return ((idx >= 0) && idx < size()) ? byIdx(idx) : nullptr;
 }
 
-function<int(Input, Output)> MonitorManager::byFirstArg(MonitorCommand cmd)
+std::function<int(Input, Output)> MonitorManager::byFirstArg(MonitorCommand cmd)
 {
     return [this,cmd](Input input, Output output) -> int {
         Monitor *monitor;
-        std::string monitor_name;
+        string monitor_name;
         if (!(input >> monitor_name)) {
             monitor = get_current_monitor();
         } else {
@@ -221,7 +221,7 @@ void MonitorManager::removeMonitor(Monitor* monitor)
 int MonitorManager::addMonitor(Input input, Output output)
 {
     // usage: add_monitor RECTANGLE [TAG [NAME]]
-    std::string rectString, tagName, monitorName;
+    string rectString, tagName, monitorName;
     input >> rectString;
     if (!input) {
         return HERBST_NEED_MORE_ARGS;
@@ -267,7 +267,7 @@ int MonitorManager::addMonitor(Input input, Output output)
     return HERBST_EXIT_SUCCESS;
 }
 
-std::string MonitorManager::isValidMonitorName(std::string name) {
+string MonitorManager::isValidMonitorName(string name) {
     if (isdigit(name[0])) {
         return "Invalid name \"" + name + "\": The monitor name may not start with a number\n";
     }
@@ -293,11 +293,11 @@ void MonitorManager::lock() {
 }
 
 void MonitorManager::unlock() {
-    settings_->monitors_locked = max(0, settings_->monitors_locked() - 1);
+    settings_->monitors_locked = std::max(0, settings_->monitors_locked() - 1);
     lock_number_changed();
 }
 
-std::string MonitorManager::lock_number_changed() {
+string MonitorManager::lock_number_changed() {
     if (settings_->monitors_locked() < 0) {
         return "must be non-negative";
     }

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -20,7 +20,7 @@ RootCommands::RootCommands(Root* root_) : root(root_) {
 }
 
 int RootCommands::get_attr_cmd(Input in, Output output) {
-    std::string attrName;
+    string attrName;
     if (!(in >> attrName)) return HERBST_NEED_MORE_ARGS;
 
     Attribute* a = getAttribute(attrName, output);
@@ -30,25 +30,25 @@ int RootCommands::get_attr_cmd(Input in, Output output) {
 }
 
 int RootCommands::set_attr_cmd(Input in, Output output) {
-    std::string path, new_value;
+    string path, new_value;
     if (!(in >> path >> new_value)) return HERBST_NEED_MORE_ARGS;
 
     Attribute* a = getAttribute(path, output);
     if (!a) return HERBST_INVALID_ARGUMENT;
-    std::string error_message = a->change(new_value);
+    string error_message = a->change(new_value);
     if (error_message.empty()) {
         return 0;
     } else {
         output << in.command() << ": \""
             << in.front() << "\" is not a valid value for "
             << a->name() << ": "
-            << error_message << std::endl;
+            << error_message << endl;
         return HERBST_INVALID_ARGUMENT;
     }
 }
 
 int RootCommands::attr_cmd(Input in, Output output) {
-    std::string path = "", new_value = "";
+    string path = "", new_value = "";
     in >> path >> new_value;
     std::ostringstream dummy_output;
     Object* o = root;
@@ -70,24 +70,24 @@ int RootCommands::attr_cmd(Input in, Output output) {
         return 0;
     } else {
         // another argument -> set the value
-        std::string error_message = a->change(new_value);
+        string error_message = a->change(new_value);
         if (error_message.empty()) {
             return 0;
         } else {
             output << in.command() << ": \""
                 << new_value << "\" is not a valid value for "
                 << a->name() << ": "
-                << error_message << std::endl;
+                << error_message << endl;
             return HERBST_INVALID_ARGUMENT;
         }
     }
 }
 
-Attribute* RootCommands::getAttribute(std::string path, Output output) {
+Attribute* RootCommands::getAttribute(string path, Output output) {
     auto attr_path = Object::splitPath(path);
     auto child = root->child(attr_path.first);
     if (!child) {
-        output << "No such object " << attr_path.first.join('.') << std::endl;
+        output << "No such object " << attr_path.first.join('.') << endl;
         return nullptr;
     }
     Attribute* a = child->attribute(attr_path.second);
@@ -101,20 +101,20 @@ Attribute* RootCommands::getAttribute(std::string path, Output output) {
         }
         output << object_path
                << " has no attribute \"" << attr_path.second << "\""
-               << std::endl;
+               << endl;
         return nullptr;
     }
     return a;
 }
 
 int RootCommands::print_object_tree_command(Input in, Output output) {
-    auto path = Path(in.empty() ? std::string("") : in.front()).toVector();
+    auto path = Path(in.empty() ? string("") : in.front()).toVector();
     while (!path.empty() && path.back().empty()) {
         path.pop_back();
     }
     auto child = root->child(path);
     if (!child) {
-        output << "No such object " << Path(path).join('.') << std::endl;
+        output << "No such object " << Path(path).join('.') << endl;
         return HERBST_INVALID_ARGUMENT;
     }
     child->printTree(output, Path(path).join('.'));
@@ -192,7 +192,7 @@ int RootCommands::sprintf_cmd(Input input, Output output)
 }
 
 
-Attribute* RootCommands::newAttributeWithType(std::string typestr, std::string attr_name, Output output) {
+Attribute* RootCommands::newAttributeWithType(string typestr, string attr_name, Output output) {
     std::map<string, std::function<Attribute*(string)>> name2constructor {
     { "bool",  [](string n) { return new Attribute_<bool>(n, false); }},
     { "color", [](string n) { return new Attribute_<Color>(n, {"black"}); }},

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -12,6 +12,10 @@
 #include "ipc-protocol.h"
 #include "root.h"
 
+using std::endl;
+using std::string;
+using std::vector;
+
 RootCommands::RootCommands(Root* root_) : root(root_) {
 }
 
@@ -189,7 +193,7 @@ int RootCommands::sprintf_cmd(Input input, Output output)
 
 
 Attribute* RootCommands::newAttributeWithType(std::string typestr, std::string attr_name, Output output) {
-    std::map<string, function<Attribute*(string)>> name2constructor {
+    std::map<string, std::function<Attribute*(string)>> name2constructor {
     { "bool",  [](string n) { return new Attribute_<bool>(n, false); }},
     { "color", [](string n) { return new Attribute_<Color>(n, {"black"}); }},
     { "int",   [](string n) { return new Attribute_<int>(n, 0); }},
@@ -308,7 +312,7 @@ int RootCommands::compare_cmd(Input input, Output output)
     //    1 if the first value is greater
     //    0 if the the values match
     //    HERBST_INVALID_ARGUMENT if there was a parsing error
-    map<string, pair<bool, vector<int> > > operators {
+    std::map<string, std::pair<bool, vector<int> > > operators {
         // map operator names to "for numeric types only" and possible return codes
         { "=",  { false, { 0 }, }, },
         { "!=", { false, { -1, 1 } }, },
@@ -317,7 +321,7 @@ int RootCommands::compare_cmd(Input input, Output output)
         { "le", { true, { -1, 0 } }, },
         { "lt", { true, { -1    } }, },
     };
-    map<Type, pair<bool, function<int(string,string,Output)>>> type2compare {
+    std::map<Type, std::pair<bool, std::function<int(string,string,Output)>>> type2compare {
         // map a type name to "is it numeric" and a comperator function
         { Type::ATTRIBUTE_INT,      { true,  parse_and_compare<int> }, },
         { Type::ATTRIBUTE_ULONG,    { true,  parse_and_compare<int> }, },
@@ -360,7 +364,7 @@ int RootCommands::compare_cmd(Input input, Output output)
 void RootCommands::completeObjectPath(Completion& complete, bool attributes,
                                       std::function<bool(Attribute*)> attributeFilter)
 {
-    ArgList objectPathArgs = get<0>(Object::splitPath(complete.needle()));
+    ArgList objectPathArgs = std::get<0>(Object::splitPath(complete.needle()));
     string objectPath = objectPathArgs.join(OBJECT_PATH_SEPARATOR);
     if (objectPath != "") objectPath += OBJECT_PATH_SEPARATOR;
     Object* object = root->child(objectPathArgs);

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -12,8 +12,6 @@
 #include "ipc-protocol.h"
 #include "root.h"
 
-using namespace std;
-
 RootCommands::RootCommands(Root* root_) : root(root_) {
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -12,7 +12,8 @@
 #include "tag.h"
 #include "utils.h"
 
-using namespace std;
+using std::string;
+using std::to_string;
 
 Settings* g_settings = nullptr; // the global settings object
 
@@ -117,13 +118,13 @@ Settings::Settings(Root* root)
         if (layout >= LAYOUT_COUNT) {
             return "layout number must be at most " + to_string(LAYOUT_COUNT - 1);
         }
-        return std::string();
+        return string();
     });
-    tree_style.setValidator([] (std::string new_value) {
+    tree_style.setValidator([] (string new_value) {
         if (utf8_string_length(new_value) < 8) {
-            return std::string("tree_style needs 8 characters");
+            return string("tree_style needs 8 characters");
         }
-        return std::string();
+        return string();
     });
 
     // TODO: the lock level is not a setting! should move somewhere else
@@ -137,7 +138,7 @@ Settings::Settings(Root* root)
     }
 }
 
-std::function<int()> Settings::getIntAttr(Object* root, std::string name) {
+std::function<int()> Settings::getIntAttr(Object* root, string name) {
     return [root, name]() {
         Attribute* a = root->deepAttribute(name);
         if (a) {
@@ -149,7 +150,7 @@ std::function<int()> Settings::getIntAttr(Object* root, std::string name) {
     };
 }
 
-std::function<Color()> Settings::getColorAttr(Object* root, std::string name) {
+std::function<Color()> Settings::getColorAttr(Object* root, string name) {
     return [root, name]() {
         Attribute* a = root->deepAttribute(name);
         if (a) {
@@ -161,7 +162,7 @@ std::function<Color()> Settings::getColorAttr(Object* root, std::string name) {
     };
 }
 
-std::function<string(int)> Settings::setIntAttr(Object* root, std::string name) {
+std::function<string(int)> Settings::setIntAttr(Object* root, string name) {
     return [root, name](int val) {
         Attribute* a = root->deepAttribute(name);
         if (a) {
@@ -174,7 +175,7 @@ std::function<string(int)> Settings::setIntAttr(Object* root, std::string name) 
         }
     };
 }
-std::function<string(Color)> Settings::setColorAttr(Object* root, std::string name) {
+std::function<string(Color)> Settings::setColorAttr(Object* root, string name) {
     return [root, name](Color val) {
         Attribute* a = root->deepAttribute(name);
         if (a) {
@@ -189,7 +190,7 @@ std::function<string(Color)> Settings::setColorAttr(Object* root, std::string na
 }
 
 int Settings::set_cmd(Input input, Output output) {
-    std::string set_name, value;
+    string set_name, value;
     if (!(input >> set_name >> value))
         return HERBST_NEED_MORE_ARGS;
 
@@ -204,7 +205,7 @@ int Settings::set_cmd(Input input, Output output) {
         output << input.command()
                << ": Invalid value \"" << value
                << "\" for setting \"" << set_name << "\": "
-               << msg << endl;
+               << msg << std::endl;
         return HERBST_INVALID_ARGUMENT;
     }
     return 0;
@@ -277,7 +278,7 @@ int Settings::cycle_value_cmd(Input argv, Output output) {
         output << argv.command()
                << ": Invalid value for setting \""
                << set_name << "\": "
-               << msg << endl;
+               << msg << std::endl;
         return HERBST_INVALID_ARGUMENT;
     }
     return 0;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -15,10 +15,10 @@
 #include "tagmanager.h"
 #include "utils.h"
 
-using namespace std;
+using std::make_shared;
+using std::shared_ptr;
 
 static bool    g_tag_flags_dirty = true;
-
 
 HSTag::HSTag(std::string name_, Settings* settings)
     : index(this, "index", 0)

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -12,8 +12,6 @@
 #include "stack.h"
 #include "utils.h"
 
-using namespace std;
-
 TagManager* global_tags;
 
 TagManager::TagManager(Settings* settings)
@@ -93,7 +91,7 @@ int TagManager::removeTag(Input input, Output output) {
     all_monitors_replace_previous_tag(tagToRemove, targetTag);
 
     // Collect all clients in tag
-    vector<HSClient*> clients;
+    std::vector<HSClient*> clients;
     tagToRemove->frame->foreachClient([&clients](HSClient* client) {
         clients.push_back(client);
     });
@@ -117,7 +115,7 @@ int TagManager::removeTag(Input input, Output output) {
     }
 
     // Remove tag
-    string removedName = tagToRemove->name;
+    std::string removedName = tagToRemove->name;
     removeIndexed(index_of(tagToRemove));
     ewmh_update_current_desktop();
     ewmh_update_desktops();
@@ -160,7 +158,7 @@ HSTag* TagManager::ensure_tags_are_available() {
     }
 }
 
-HSTag* TagManager::byIndexStr(const string& index_str, bool skip_visible_tags) {
+HSTag* TagManager::byIndexStr(const std::string& index_str, bool skip_visible_tags) {
     int index = stoi(index_str);
     // index must be treated relative, if it's first char is + or -
     bool is_relative = index_str[0] == '+' || index_str[0] == '-';

--- a/src/tilingresult.cpp
+++ b/src/tilingresult.cpp
@@ -1,6 +1,6 @@
 #include "tilingresult.h"
 
-using namespace std;
+using std::make_pair;
 
 TilingStep::TilingStep(Rectangle rect)
     : geometry(rect)

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -9,7 +9,7 @@ using std::string;
 using std::to_string;
 
 int Tmp::mktemp(Input input, Output output) {
-    std::string type, identifier;
+    string type, identifier;
     if (!(input >> type >> identifier)) {
         return HERBST_NEED_MORE_ARGS;
     }

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -5,6 +5,9 @@
 #include "ipc-protocol.h"
 #include "rootcommands.h"
 
+using std::string;
+using std::to_string;
+
 int Tmp::mktemp(Input input, Output output) {
     std::string type, identifier;
     if (!(input >> type >> identifier)) {

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -5,8 +5,6 @@
 #include "ipc-protocol.h"
 #include "rootcommands.h"
 
-using namespace std;
-
 int Tmp::mktemp(Input input, Output output) {
     std::string type, identifier;
     if (!(input >> type >> identifier)) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -15,13 +15,12 @@
 #include "globals.h"
 #include "settings.h"
 
-using namespace std;
-
 #if defined(__MACH__) && ! defined(CLOCK_REALTIME)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
 
+using std::string;
 
 time_t get_monotonic_timestamp() {
     struct timespec ts;
@@ -153,7 +152,7 @@ bool intervals_intersect(int a_left, int a_right, int b_left, int b_right) {
     return (b_left < a_right) && (a_left < b_right);
 }
 
-size_t utf8_string_length(const std::string& str) {
+size_t utf8_string_length(const string& str) {
    // utf-strlen from stackoverflow:
    // http://stackoverflow.com/questions/5117393/utf-8-strings-length-in-linux-c
    size_t i = 0, j = 0;
@@ -164,7 +163,7 @@ size_t utf8_string_length(const std::string& str) {
    return j;
 }
 
-std::string utf8_string_at(const std::string& str, size_t n) {
+string utf8_string_at(const string& str, size_t n) {
     // utf-strlen from stackoverflow:
     // http://stackoverflow.com/questions/5117393/utf-8-strings-length-in-linux-c
     //
@@ -178,7 +177,7 @@ std::string utf8_string_at(const std::string& str, size_t n) {
     //    std::cout << "\'"<< ch << "\' -> " << ((ch&0xc0) == 0x80) << std::endl;
     //}
     size_t i = 0, byte_offset = 0;
-    std::string result;
+    string result;
     // find the beginning of the n'th character
     // find the n'th character ch, with (ch & 0xc0) == 0x80
     while (i < n) {
@@ -209,7 +208,7 @@ const char* strlasttoken(const char* str, const char* delim) {
     return str;
 }
 
-bool string_to_bool(const std::string& str, bool oldvalue) {
+bool string_to_bool(const string& str, bool oldvalue) {
     return string_to_bool_error(str.c_str(), oldvalue, nullptr);
 }
 
@@ -395,7 +394,7 @@ void set_window_double_border(Display *dpy, Window win, int ibw,
 
 static void subtree_print_to(HSTreeInterface* intface, const char* indent,
                           char* rootprefix, Output output) {
-    std::string tree_style = g_settings->tree_style();
+    string tree_style = g_settings->tree_style();
     HSTree root = intface->data;
     size_t child_count = intface->child_count(root);
     if (child_count == 0) {
@@ -441,7 +440,7 @@ static void subtree_print_to(HSTreeInterface* intface, const char* indent,
 static void subtree_print_to(Ptr(TreeInterface) intface, const string& indent,
                           const string& rootprefix, Output output) {
     size_t child_count = intface->childCount();
-    std::string tree_style = g_settings->tree_style();
+    string tree_style = g_settings->tree_style();
     if (child_count == 0) {
         output << rootprefix;
         output << utf8_string_at(tree_style, 6);


### PR DESCRIPTION
In some cases, for rarely used symbols, "std::" is added to the
point-of-use.

In every other case, a "using std::…" statement is added.

For consistency, any existing "std::" prefixes are removed if they're
not necessary thanks to a corresponding "using" statement.