### PR TITLE
Make KeyBinding a class, use Input for keybind cmd

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -11,22 +11,24 @@
 class HSTag;
 class Client;
 
-typedef struct KeyBinding {
+class KeyBinding {
+public:
     KeySym keysym;
     unsigned int modifiers;
-    int     cmd_argc; // number of arguments for command
-    char**  cmd_argv; // arguments for command to call
+
+    //! Command to call
+    std::vector<std::string> cmd;
+
     bool    enabled;  // Is the keybinding already grabbed
-} KeyBinding;
+};
 
 unsigned int modifiername2mask(const char* name);
 const char* modifiermask2name(unsigned int mask);
 
 bool string2modifiers(const std::string& string, unsigned int* modmask);
 bool string2key(const std::string& str, unsigned int* modmask, KeySym* keysym);
-int keybind(int argc, char** argv, Output output);
+int keybind(Input input, Output output);
 int keyunbind(int argc, char** argv, Output output); //removes a keybinding
-void keybinding_free(KeyBinding* binding);
 
 int key_list_binds(Output output);
 int list_keysyms(int argc, char** argv, Output output);


### PR DESCRIPTION
For this, the global g_key_binds is turned into a vector of unique_ptrs
to KeyBinding.

In future work, most of the standalone functions may be turned into
methods of KeyBinding.

This also extends the keybinding test suite a bit.