### PR TITLE
Do not deny key bindings for unknown symbols

### DIFF
--- a/src/keymanager.cpp
+++ b/src/keymanager.cpp
@@ -26,14 +26,6 @@ int KeyManager::addKeybindCommand(Input input, Output output) {
         return HERBST_INVALID_ARGUMENT;
     }
 
-    // Validate keysym
-    KeyCode keycode = XKeysymToKeycode(g_display, newBinding->keysym);
-    if (!keycode) {
-        output << input.command() << ": No keycode for symbol "
-               << XKeysymToString(newBinding->keysym) << std::endl;
-        return HERBST_INVALID_ARGUMENT;
-    }
-
     input.shift();
     // Store remaining input as the associated command
     newBinding->cmd = {input.begin(), input.end()};


### PR DESCRIPTION
We should not deny the setup of a new keybinding only because the KeySym
is unknown at the time of setup. Instead, unknown KeySyms are skipped
whenever (re)grabbing them.