### PR TITLE
Simplify signature for key_set_keymask()

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -168,7 +168,7 @@ void Client::window_unfocus_last() {
         tag_update_each_focus_layer();
 
         // Enable all keys in the root window
-        key_set_keymask(get_current_monitor()->tag, 0);
+        key_set_keymask(0);
     }
     lastfocus = 0;
 }
@@ -211,7 +211,7 @@ void Client::window_focus() {
     }
     tag_update_focus_layer(get_current_monitor()->tag);
     grab_client_buttons(this, true);
-    key_set_keymask(this->tag(), this);
+    key_set_keymask(this->keymask_());
     this->set_urgent(false);
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -168,7 +168,7 @@ void Client::window_unfocus_last() {
         tag_update_each_focus_layer();
 
         // Enable all keys in the root window
-        key_set_keymask(0);
+        key_set_keymask("");
     }
     lastfocus = 0;
 }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -337,10 +337,10 @@ static void key_set_keymask_helper(KeyBinding* b, regex_t *keymask_regex) {
     }
 }
 
-void key_set_keymask(HSTag *tag, Client *client) {
+void key_set_keymask(const std::string& keymask) {
     regex_t     keymask_regex;
-    if (client && client->keymask_ != "") {
-        int status = regcomp(&keymask_regex, ((std::string)client->keymask_).c_str(), REG_EXTENDED);
+    if (keymask != "") {
+        int status = regcomp(&keymask_regex, keymask.c_str(), REG_EXTENDED);
         if (status == 0) {
             for (auto& binding : g_key_binds) {
                 key_set_keymask_helper(binding.get(), &keymask_regex);
@@ -350,7 +350,7 @@ void key_set_keymask(HSTag *tag, Client *client) {
             char buf[ERROR_STRING_BUF_SIZE];
             regerror(status, &keymask_regex, buf, ERROR_STRING_BUF_SIZE);
             HSDebug("keymask: Can not parse regex \"%s\" from keymask: %s",
-                    ((std::string)client->keymask_).c_str(), buf);
+                    keymask.c_str(), buf);
         }
     }
     // Enable all keys again

--- a/src/key.h
+++ b/src/key.h
@@ -40,7 +40,7 @@ void regrab_keys();
 void grab_keybind(KeyBinding* binding);
 void update_numlockmask();
 unsigned int* get_numlockmask_ptr();
-void key_set_keymask(HSTag * tag, Client *client);
+void key_set_keymask(const std::string& keymask);
 void handle_key_press(XEvent* ev);
 
 void key_init();


### PR DESCRIPTION
The tag was not used at all, and instead of the entire client, only the
keymask itself is relevant.