### PR TITLE
Use std::regex for keymask, add tests

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -168,7 +168,7 @@ void Client::window_unfocus_last() {
         tag_update_each_focus_layer();
 
         // Enable all keys in the root window
-        key_set_keymask(get_current_monitor()->tag, 0);
+        key_set_keymask("");
     }
     lastfocus = 0;
 }
@@ -211,7 +211,7 @@ void Client::window_focus() {
     }
     tag_update_focus_layer(get_current_monitor()->tag);
     grab_client_buttons(this, true);
-    key_set_keymask(this->tag(), this);
+    key_set_keymask(this->keymask_());
     this->set_urgent(false);
 }
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -337,10 +337,10 @@ static void key_set_keymask_helper(KeyBinding* b, regex_t *keymask_regex) {
     }
 }
 
-void key_set_keymask(HSTag *tag, Client *client) {
+void key_set_keymask(const std::string& keymask) {
     regex_t     keymask_regex;
-    if (client && client->keymask_ != "") {
-        int status = regcomp(&keymask_regex, ((std::string)client->keymask_).c_str(), REG_EXTENDED);
+    if (keymask != "") {
+        int status = regcomp(&keymask_regex, keymask.c_str(), REG_EXTENDED);
         if (status == 0) {
             for (auto& binding : g_key_binds) {
                 key_set_keymask_helper(binding.get(), &keymask_regex);
@@ -350,7 +350,7 @@ void key_set_keymask(HSTag *tag, Client *client) {
             char buf[ERROR_STRING_BUF_SIZE];
             regerror(status, &keymask_regex, buf, ERROR_STRING_BUF_SIZE);
             HSDebug("keymask: Can not parse regex \"%s\" from keymask: %s",
-                    ((std::string)client->keymask_).c_str(), buf);
+                    keymask.c_str(), buf);
         }
     }
     // Enable all keys again

--- a/src/key.h
+++ b/src/key.h
@@ -40,7 +40,7 @@ void regrab_keys();
 void grab_keybind(KeyBinding* binding);
 void update_numlockmask();
 unsigned int* get_numlockmask_ptr();
-void key_set_keymask(HSTag * tag, Client *client);
+void key_set_keymask(const std::string& keymask);
 void handle_key_press(XEvent* ev);
 
 void key_init();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ class HlwmBridge:
         winid = self.wait_for_window_of(wmclass)
 
         self.client_procs.append(proc)
-        return winid
+        return winid, proc
 
     def complete(self, cmd, partial=False, position=None):
         """
@@ -174,7 +174,7 @@ class HlwmBridge:
         return sorted(children)
 
     def create_clients(self, num):
-        return [self.create_client() for i in range(num)]
+        return [self.create_client()[0] for i in range(num)]
 
     def wait_for_window_of(self, wmclass):
         """Wait for a rule hook of the form "here_is_" + wmclass """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import shlex
 import subprocess
 import sys
 import textwrap
+import time
 
 import pytest
 
@@ -271,3 +272,14 @@ def running_clients(hlwm, running_clients_num):
     "running_clients_num" test parameter.
     """
     return hlwm.create_clients(running_clients_num)
+
+
+@pytest.fixture()
+def keyboard():
+    class KeyBoard:
+        def press(self, s):
+            subprocess.call('xdotool key x'.split())
+            # Bad workaround for keypress injection not being synchronous:
+            time.sleep(.5)
+
+    return KeyBoard()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,7 +279,5 @@ def keyboard():
     class KeyBoard:
         def press(self, key_spec):
             subprocess.call(['xdotool', 'key', key_spec])
-            # Bad workaround for keypress injection not being synchronous:
-            time.sleep(.5)
 
     return KeyBoard()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -277,8 +277,8 @@ def running_clients(hlwm, running_clients_num):
 @pytest.fixture()
 def keyboard():
     class KeyBoard:
-        def press(self, s):
-            subprocess.call('xdotool key x'.split())
+        def press(self, key_spec):
+            subprocess.call(['xdotool', 'key', key_spec])
             # Bad workaround for keypress injection not being synchronous:
             time.sleep(.5)
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -3,8 +3,8 @@ import pytest
 
 def test_first_client_gets_focus(hlwm):
     hlwm.call_xfail('get_attr clients.focus.winid')
-    client = hlwm.create_client()
-    assert hlwm.get_attr('clients.focus.winid') == client
+    winid, _ = hlwm.create_client()
+    assert hlwm.get_attr('clients.focus.winid') == winid
 
 
 def test_alter_fullscreen(hlwm):

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -61,20 +61,20 @@ def test_keyunbind_nonexistent_binding(hlwm):
     assert unbind.stdout == 'keyunbind: Key "n" is not bound\n'
 
 
-def test_trigger_single_key_binding(hlwm):
+def test_trigger_single_key_binding(hlwm, keyboard):
     hlwm.call('keybind x use tag2')
     hlwm.call('add tag2')
     assert hlwm.get_attr('monitors.0.tag') != 'tag2'
 
-    subprocess.call('xdotool key x'.split())
+    keyboard.press('x')
 
     assert hlwm.get_attr('monitors.0.tag') == 'tag2'
 
 
-def test_trigger_selfremoving_binding(hlwm):
+def test_trigger_selfremoving_binding(hlwm, keyboard):
     hlwm.call('keybind x keyunbind x')
 
-    subprocess.call('xdotool key x'.split())
+    keyboard.press('x')
 
     assert hlwm.call('list_keybinds').stdout == ''
 


### PR DESCRIPTION
This implicitly fixes a memory leak in the old regex code (missing
regfree).

The new test is prepared to cover multiple scenarios, only one of which
works in current keymask implementation.