### PR TITLE
Tests: Offer custom command param in create_client

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,14 +93,14 @@ class HlwmBridge:
     def get_attr(self, attribute_path, check=True):
         return self.call(['get_attr', attribute_path]).stdout
 
-    def create_client(self, title=None):
+    def create_client(self, term_command='sleep infinity', title=None):
         """
         Launch a client that will be terminated on shutdown.
         """
         self.next_client_id += 1
         wmclass = 'client_{}'.format(self.next_client_id)
         title = ['-title', str(title)] if title else []
-        command = ['xterm'] + title + ['-hold', '-class', wmclass, '-e', 'true']
+        command = ['xterm'] + title + ['-class', wmclass, '-e', term_command]
 
         # enforce a hook when the window appears
         self.call(['rule', 'once', 'class='+wmclass, 'hook=here_is_'+wmclass])

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -63,19 +63,19 @@ def test_stack_tree(hlwm):
   - 
     - Monitor 1 ("monitor2") with tag "tag2"
       - Focus-Layer
-        - Client 0x800022 "true"
+        - Client 0x800022 "sleep infinity"
       - Fullscreen-Layer
       - Normal Layer
-        - Client 0x800022 "true"
+        - Client 0x800022 "sleep infinity"
       - Frame Layer
         - Window 0x200012
         - Window 0x20000a
     - Monitor 0 with tag "default"
       - Focus-Layer
-        - Client 0x600022 "true"
+        - Client 0x600022 "sleep infinity"
       - Fullscreen-Layer
       - Normal Layer
-        - Client 0x600022 "true"
+        - Client 0x600022 "sleep infinity"
       - Frame Layer
         - Window 0x200008
 '''


### PR DESCRIPTION
Instead of running "true" in an xterm with -hold, we now run "sleep
infinity". This allows the custom command to decide when the client
terminates.