### PR TITLE
Tests: Also return Popen object in create_client()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,7 @@ class HlwmBridge:
         winid = self.wait_for_window_of(wmclass)
 
         self.client_procs.append(proc)
-        return winid
+        return winid, proc
 
     def complete(self, cmd, partial=False, position=None):
         """
@@ -173,7 +173,7 @@ class HlwmBridge:
         return sorted(children)
 
     def create_clients(self, num):
-        return [self.create_client() for i in range(num)]
+        return [self.create_client()[0] for i in range(num)]
 
     def wait_for_window_of(self, wmclass):
         """Wait for a rule hook of the form "here_is_" + wmclass """

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -3,8 +3,8 @@ import pytest
 
 def test_first_client_gets_focus(hlwm):
     hlwm.call_xfail('get_attr clients.focus.winid')
-    client = hlwm.create_client()
-    assert hlwm.get_attr('clients.focus.winid') == client
+    winid, _ = hlwm.create_client()
+    assert hlwm.get_attr('clients.focus.winid') == winid
 
 
 def test_alter_fullscreen(hlwm):


### PR DESCRIPTION
This allows callers to inspect the state of the client process.