### PR TITLE
Move ownership of keybindings list into KeyManager

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -3,24 +3,10 @@
 
 #include <X11/Xlib.h>
 
-#include "glib-backports.h"
+#include "keymanager.h"
 #include "types.h"
 
 #define KEY_COMBI_SEPARATORS "+-"
-
-class HSTag;
-class Client;
-
-class KeyBinding {
-public:
-    KeySym keysym;
-    unsigned int modifiers;
-
-    //! Command to call
-    std::vector<std::string> cmd;
-
-    bool    enabled;  // Is the keybinding already grabbed
-};
 
 unsigned int modifiername2mask(const char* name);
 const char* modifiermask2name(unsigned int mask);
@@ -36,14 +22,12 @@ void key_find_binds(const char* needle, Output output);
 void complete_against_modifiers(const char* needle, char seperator,
                                 char* prefix, Output output);
 void complete_against_keysyms(const char* needle, char* prefix, Output output);
+void ungrab_all();
 void regrab_keys();
 void grab_keybind(KeyBinding* binding);
 void update_numlockmask();
 unsigned int* get_numlockmask_ptr();
 void key_set_keymask(const std::string& keymask);
 void handle_key_press(XEvent* ev);
-
-void key_init();
-void key_destroy();
 
 #endif

--- a/src/keymanager.cpp
+++ b/src/keymanager.cpp
@@ -13,7 +13,13 @@
 using std::vector;
 using std::unique_ptr;
 
-extern vector<unique_ptr<KeyBinding>> g_key_binds;
+KeyManager::KeyManager() {
+    update_numlockmask();
+}
+
+KeyManager::~KeyManager() {
+    ungrab_all();
+}
 
 int KeyManager::addKeybindCommand(Input input, Output output) {
     if (input.size() < 2) {
@@ -39,7 +45,7 @@ int KeyManager::addKeybindCommand(Input input, Output output) {
     grab_keybind(newBinding.get());
 
     // Add keybinding to list
-    g_key_binds.push_back(std::move(newBinding));
+    binds.push_back(std::move(newBinding));
 
     ensureKeymask();
 
@@ -47,7 +53,7 @@ int KeyManager::addKeybindCommand(Input input, Output output) {
 }
 
 int KeyManager::listKeybindsCommand(Output output) {
-    for (auto& binding : g_key_binds) {
+    for (auto& binding : binds) {
         // add keybinding
         output << keybinding_to_string(binding.get());
         // add associated command
@@ -64,7 +70,8 @@ int KeyManager::removeKeybindCommand(Input input, Output output) {
     }
 
     if (arg == "--all" || arg == "-F") {
-        key_remove_all_binds();
+        binds.clear();
+        ungrab_all();
     } else {
         unsigned int modifiers;
         KeySym keysym;

--- a/src/keymanager.h
+++ b/src/keymanager.h
@@ -1,12 +1,37 @@
 #pragma once
 
+#include <X11/Xlib.h>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "object.h"
+#include "types.h"
+
+// TODO: Turn this into a nested class of KeyManager (will be easier later on)
+class KeyBinding {
+public:
+    KeySym keysym;
+    unsigned int modifiers;
+
+    //! Command to call
+    std::vector<std::string> cmd;
+
+    //! Whether this keybinding is currently grabbed
+    bool enabled;
+};
 
 class KeyManager : public Object {
 public:
+    KeyManager();
+    ~KeyManager();
+
     int addKeybindCommand(Input input, Output output);
     int listKeybindsCommand(Output output);
     int removeKeybindCommand(Input input, Output output);
 
     void ensureKeymask();
+
+    //! Currently defined keybindings (TODO: Make this private as soon as possible)
+    std::vector<std::unique_ptr<KeyBinding>> binds;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -708,7 +708,6 @@ static struct {
     void (*init)();
     void (*destroy)();
 } g_modules[] = {
-    { key_init,         key_destroy         },
     { clientlist_init,  clientlist_destroy  },
     { ewmh_init,        ewmh_destroy        },
     { mouse_init,       mouse_destroy       },


### PR DESCRIPTION
For this, the KeyBinding class is moved into keymanager.h, but not yet
turned into a nested class under KeyManager, in order to minimize the
diff here. Changing the class location will be easier later on.

The main goal and benefit here is getting rid of key_init/key_destroy.