### PR TITLE
Extract functionality into KeyCombo class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(herbstluftwm PRIVATE
     ipc-protocol.h
     ipc-server.cpp ipc-server.h
     key.cpp key.h
+    keycombo.cpp keycombo.h
     keymanager.cpp keymanager.h
     layout.cpp layout.h
     monitor.cpp monitor.h

--- a/src/key.h
+++ b/src/key.h
@@ -11,9 +11,6 @@
 unsigned int modifiername2mask(const char* name);
 const char* modifiermask2name(unsigned int mask);
 
-bool string2modifiers(const std::string& string, unsigned int* modmask);
-bool string2key(const std::string& str, unsigned int* modmask, KeySym* keysym);
-
 int list_keysyms(int argc, char** argv, Output output);
 bool key_remove_bind_with_keysym(unsigned int modifiers, KeySym sym);
 void key_remove_all_binds();

--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -1,0 +1,166 @@
+#include "keycombo.h"
+
+#include <X11/Xlib.h>
+#include <algorithm>
+#include <iostream>
+#include <stdexcept>
+
+#include "globals.h"
+
+using std::vector;
+using std::string;
+
+#define KEY_COMBI_SEPARATORS "+-"
+
+const vector<KeyCombo::ModifierNameAndMask> KeyCombo::modifierMasks = {
+    { "Mod1",       Mod1Mask },
+    { "Mod2",       Mod2Mask },
+    { "Mod3",       Mod3Mask },
+    { "Mod4",       Mod4Mask },
+    { "Mod5",       Mod5Mask },
+    { "Alt",        Mod1Mask },
+    { "Super",      Mod4Mask },
+    { "Shift",      ShiftMask },
+    { "Control",    ControlMask },
+    { "Ctrl",       ControlMask },
+};
+
+/*!
+ * Provides a canonical string representation of the key combo
+ */
+std::string KeyCombo::str() const {
+    std::stringstream str;
+
+    /* add modifiers */
+    for (auto& modName : getNamesForModifierMask(modifiers)) {
+        str << modName << KEY_COMBI_SEPARATORS[0];
+    }
+
+    /* add keysym */
+    const char* name = XKeysymToString(keysym);
+    if (!name) {
+        HSWarning("XKeysymToString failed! using \'?\' instead\n");
+        name = "?";
+    }
+    str << name;
+
+    return str.str();
+}
+
+/*!
+ * Returns true if the string representation of this KeyCombo matches the given
+ * regex
+ */
+bool KeyCombo::matches(const std::regex& regex) const {
+    return std::regex_match(str(), regex);
+}
+
+/*!
+ * Parses the modifiers part of a key combo string into a mask value.
+ *
+ * \throws meaningful exceptions on parsing errors
+ */
+unsigned int KeyCombo::string2modifiers(const string& str) {
+    auto splitted = splitKeySpec(str);
+
+    if (splitted.empty()) {
+        throw std::runtime_error("Empty keysym");
+    }
+
+    unsigned int modifiers = 0;
+    // all parts except last one are modifiers
+    for (auto iter = splitted.begin(); iter + 1 != splitted.end(); iter++) {
+        modifiers |= getMaskForModifierName(*iter);
+    }
+    return modifiers;
+}
+
+/*!
+ * Parses the keysym part of a key combo string into a KeySym.
+ *
+ * \throws meaningful exceptions on parsing errors
+ */
+KeySym KeyCombo::string2keysym(const string& str) {
+    // last one is the key
+    auto lastToken = splitKeySpec(str).back();
+    auto keysym = XStringToKeysym(lastToken.c_str());
+    if (keysym == NoSymbol) {
+        throw std::runtime_error("Unknown KeySym \"" + lastToken + "\"");
+    }
+    return keysym;
+}
+
+/*!
+ * Creates a KeyCombo from a given string representation
+ *
+ * Example inputs: "Mod1-space", "Mod4+f", "f"
+ *
+ * In order to avoid throwing exceptions from constructors (they often get
+ * called implicitly), this is implemented as a static method.
+ *
+ * \throws meaningful exceptions on parsing errors
+ */
+KeyCombo KeyCombo::fromString(const std::string& str) {
+    KeyCombo combo;
+    combo.modifiers = string2modifiers(str);
+    combo.keysym = string2keysym(str);
+    return combo;
+}
+
+bool KeyCombo::operator==(const KeyCombo& other) const {
+    bool sameMods = modifiers == other.modifiers;
+    bool sameKeySym = keysym == other.keysym;
+    return sameMods && sameKeySym;
+}
+
+vector<string> KeyCombo::splitKeySpec(string keySpec)
+{
+    // Normalize spec to use a single separator:
+    char baseSep = KEY_COMBI_SEPARATORS[0];
+    for (auto &sep : KEY_COMBI_SEPARATORS) {
+        std::replace(keySpec.begin(), keySpec.end(), sep, baseSep);
+    }
+
+    // Split spec into tokens:
+    vector<string> tokens;
+    string token;
+    std::istringstream tokenStream(keySpec);
+    while (std::getline(tokenStream, token, baseSep)) {
+        tokens.push_back(token);
+    }
+    return tokens;
+}
+
+/*!
+ * Provides the mask value for a given modifier name (internal helper)
+ *
+ * \throws std::runtime_error if modifier name is unknown
+ */
+unsigned int KeyCombo::getMaskForModifierName(string name) {
+    // Simple, linear search for matching list entry:
+    for (auto& entry : modifierMasks) {
+        if (entry.name == name) {
+            return entry.mask;
+        }
+    }
+
+    throw std::runtime_error("Unknown modifier \"" + name + "\"");
+}
+
+/*!
+ * Provides the names of modifiers that are set in a given mask.
+ */
+vector<string> KeyCombo::getNamesForModifierMask(unsigned int mask) {
+    vector<string> names;
+    for (auto& entry : modifierMasks) {
+        if (entry.mask & mask) {
+            names.push_back(entry.name);
+
+            // remove match from mask
+            mask = mask & ~ entry.mask;
+        }
+    }
+
+    return names;
+}
+

--- a/src/keycombo.h
+++ b/src/keycombo.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <X11/X.h>
+#include <regex>
+#include <string>
+#include <vector>
+
+/*!
+ * Represents a keypress combination of a keysym and modifiers (optional).
+ *
+ * Handles the parsing and creation of string representations of itself.
+ */
+class KeyCombo {
+public:
+    KeyCombo() = default;
+
+    typedef struct {
+        std::string name;
+        unsigned int mask;
+    } ModifierNameAndMask;
+
+    /*!
+     * List of existing modifiers and their corresponding key masks.
+     *
+     * This is not an std::map because even though it is a surjective relation,
+     * we need well-defined reverse lookups for stringification.
+     */
+    static const std::vector<ModifierNameAndMask> modifierMasks;
+
+    std::string str() const;
+
+    bool matches(const std::regex& regex) const;
+
+    static unsigned int string2modifiers(const std::string& str);
+    static KeySym string2keysym(const std::string& str);
+    static KeyCombo fromString(const std::string& str);
+
+    KeySym keysym;
+    unsigned int modifiers;
+
+    bool operator==(const KeyCombo& other) const;
+
+private:
+    static std::vector<std::string> splitKeySpec(std::string keySpec);
+    static unsigned int getMaskForModifierName(std::string name);
+    static std::vector<std::string> getNamesForModifierMask(unsigned int mask);
+};

--- a/src/keymanager.h
+++ b/src/keymanager.h
@@ -5,14 +5,14 @@
 #include <string>
 #include <vector>
 
+#include "keycombo.h"
 #include "object.h"
 #include "types.h"
 
 // TODO: Turn this into a nested class of KeyManager (will be easier later on)
 class KeyBinding {
 public:
-    KeySym keysym;
-    unsigned int modifiers;
+    KeyCombo keyCombo;
 
     //! Command to call
     std::vector<std::string> cmd;

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -164,11 +164,14 @@ int mouse_bind_command(int argc, char** argv, Output output) {
     }
     unsigned int modifiers = 0;
     char* string = argv[1];
-    if (!string2modifiers(string, &modifiers)) {
-        output << argv[0] <<
-            ": Modifier \"" << string << "\" does not exist\n";
+
+    try {
+        modifiers = KeyCombo::string2modifiers(string);
+    } catch (std::runtime_error &error) {
+        output << argv[0] << error.what();
         return HERBST_INVALID_ARGUMENT;
     }
+
     // last one is the mouse button
     const char* last_token = strlasttoken(string, KEY_COMBI_SEPARATORS);
     unsigned int button = string2button(last_token);

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -18,13 +18,13 @@ def test_list_keybinds(hlwm, sep):
 def test_keybind_unknown_modifier(hlwm):
     call = hlwm.call_xfail('keybind Moep1-x quit')
 
-    assert call.stderr == 'keybind: No such KeySym/modifier\n'
+    assert call.stderr == 'keybind: Unknown modifier "Moep1"\n'
 
 
 def test_keybind_unknown_keysym(hlwm):
     call = hlwm.call_xfail('keybind Mod1-_ quit')
 
-    assert call.stderr == 'keybind: No such KeySym/modifier\n'
+    assert call.stderr == 'keybind: Unknown KeySym "_"\n'
 
 
 def test_replace_keybind(hlwm):


### PR DESCRIPTION
This encapsulates most stringification/parsing code for key combinations
into the KeyCombo class.

The keybinding_to_string() function remains for now, as it is still
needed for the completion code.