### PR TITLE
FrameTree class for global actions on the entire tree

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(herbstluftwm PRIVATE
     ewmh.cpp ewmh.h
     floating.cpp floating.h
     framedecoration.cpp framedecoration.h
+    frametree.h frametree.cpp
     hookmanager.cpp hookmanager.h
     ipc-protocol.h
     ipc-server.cpp ipc-server.h

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -6,6 +6,7 @@
 #include "client.h"
 #include "completion.h"
 #include "ewmh.h"
+#include "frametree.h"
 #include "globals.h"
 #include "ipc-protocol.h"
 #include "layout.h"
@@ -152,14 +153,14 @@ Client* ClientManager::manage_client(Window win, bool visible_already) {
     client->slice = slice_create_client(client);
     client->tag()->stack->insert_slice(client->slice);
     // insert window to the tag
-    client->tag()->frame->lookup(changes.tree_index.c_str())
+    client->tag()->frame->root_->lookup(changes.tree_index.c_str())
                  ->insertClient(client);
     if (changes.focus) {
         // give focus to window if wanted
         // TODO: make this faster!
         // WARNING: this solution needs O(C + exp(D)) time where W is the count
         // of clients on this tag and D is the depth of the binary layout tree
-        client->tag()->frame->focusClient(client);
+        client->tag()->frame->root_->focusClient(client);
     }
 
     ewmh_window_update_tag(client->window_, client->tag());
@@ -213,7 +214,7 @@ void ClientManager::force_unmanage(Client* client) {
         client->tag()->stack->remove_slice(client->slice);
     }
     // remove from tag
-    client->tag()->frame->removeClient(client);
+    client->tag()->frame->root_->removeClient(client);
     // ignore events from it
     XSelectInput(g_display, client->window_, 0);
     //XUngrabButton(g_display, AnyButton, AnyModifier, win);

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -153,7 +153,7 @@ Client* ClientManager::manage_client(Window win, bool visible_already) {
     client->slice = slice_create_client(client);
     client->tag()->stack->insert_slice(client->slice);
     // insert window to the tag
-    client->tag()->frame->root_->lookup(changes.tree_index.c_str())
+    client->tag()->frame->lookup(changes.tree_index.c_str())
                  ->insertClient(client);
     if (changes.focus) {
         // give focus to window if wanted

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -153,7 +153,7 @@ Client* ClientManager::manage_client(Window win, bool visible_already) {
     client->slice = slice_create_client(client);
     client->tag()->stack->insert_slice(client->slice);
     // insert window to the tag
-    client->tag()->frame->lookup(changes.tree_index.c_str())
+    FrameTree::focusedFrame(client->tag()->frame->lookup(changes.tree_index))
                  ->insertClient(client);
     if (changes.focus) {
         // give focus to window if wanted

--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 
 #include "client.h"
+#include "frametree.h"
 #include "layout.h"
 #include "monitor.h"
 #include "settings.h"

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -1,0 +1,15 @@
+#include "frametree.h"
+
+#include "layout.h"
+
+FrameTree::FrameTree(HSTag* tag, Settings* settings)
+    : tag_(tag)
+    , settings_(settings)
+{
+    root_ = std::make_shared<HSFrameLeaf>(tag, settings, std::shared_ptr<HSFrameSplit>());
+}
+
+void FrameTree::foreachClient(std::function<void(Client*)> action)
+{
+    root_->foreachClient(action);
+}

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -19,7 +19,8 @@ void FrameTree::foreachClient(std::function<void(Client*)> action)
 
 void FrameTree::dump(std::shared_ptr<HSFrame> frame, Output output)
 {
-    auto onLeaf = [&output](std::shared_ptr<HSFrameLeaf> l) {
+    auto l = frame->isLeaf();
+    if (l) {
         output << LAYOUT_DUMP_BRACKETS[0]
                << "clients"
                << LAYOUT_DUMP_WHITESPACES[0]
@@ -31,8 +32,9 @@ void FrameTree::dump(std::shared_ptr<HSFrame> frame, Output output)
                    << std::hex << client->x11Window() << std::dec;
         }
         output << LAYOUT_DUMP_BRACKETS[1];
-    };
-    auto onSplit = [&output](std::shared_ptr<HSFrameSplit> s) {
+    }
+    auto s = frame->isSplit();
+    if (s) {
         output
             << LAYOUT_DUMP_BRACKETS[0]
             << "split"
@@ -47,8 +49,7 @@ void FrameTree::dump(std::shared_ptr<HSFrame> frame, Output output)
         output << LAYOUT_DUMP_WHITESPACES[0];
         FrameTree::dump(s->b_, output);
         output << LAYOUT_DUMP_BRACKETS[1];
-    };
-    frame->switchcase(onLeaf, onSplit);
+    }
 }
 
 

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -48,7 +48,7 @@ void FrameTree::dump(std::shared_ptr<HSFrame> frame, Output output)
         FrameTree::dump(s->b_, output);
         output << LAYOUT_DUMP_BRACKETS[1];
     };
-    frame->switchcase(onSplit, onLeaf);
+    frame->switchcase(onLeaf, onSplit);
 }
 
 
@@ -62,6 +62,10 @@ std::shared_ptr<HSFrame> FrameTree::lookup(const std::string& path) {
     }
     for (char c : path) {
         node = node->switchcase<std::shared_ptr<HSFrame>>(
+            [](std::shared_ptr<HSFrameLeaf> l) {
+                // nothing to do on a leaf
+                return l;
+            },
             [c](std::shared_ptr<HSFrameSplit> l) {
                 switch (c) {
                     case '0': return l->a_;
@@ -70,10 +74,6 @@ std::shared_ptr<HSFrame> FrameTree::lookup(const std::string& path) {
                     case '.': /* fallthru */
                     default: return (l->selection_ == 0) ? l->a_ : l->b_;
                 }
-            },
-            [](std::shared_ptr<HSFrameLeaf> l) {
-                // nothing to do on a leaf
-                return l;
             }
         );
     }

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -1,5 +1,6 @@
 #include "frametree.h"
 
+#include "client.h"
 #include "layout.h"
 
 FrameTree::FrameTree(HSTag* tag, Settings* settings)
@@ -15,3 +16,39 @@ void FrameTree::foreachClient(std::function<void(Client*)> action)
 {
     root_->foreachClient(action);
 }
+
+void FrameTree::dump(std::shared_ptr<HSFrame> frame, Output output)
+{
+
+    auto onLeaf = [&output](std::shared_ptr<HSFrameLeaf> l) {
+        output << LAYOUT_DUMP_BRACKETS[0]
+               << "clients"
+               << LAYOUT_DUMP_WHITESPACES[0]
+               << g_layout_names[l->layout] << ":"
+               << l->selection;
+        for (auto client : l->clients) {
+            output << LAYOUT_DUMP_WHITESPACES[0]
+                   << "0x"
+                   << std::hex << client->x11Window() << std::dec;
+        }
+        output << LAYOUT_DUMP_BRACKETS[1];
+    };
+    auto onSplit = [&output](std::shared_ptr<HSFrameSplit> s) {
+        output
+            << LAYOUT_DUMP_BRACKETS[0]
+            << "split"
+            << LAYOUT_DUMP_WHITESPACES[0]
+            << g_align_names[s->align_]
+            << LAYOUT_DUMP_SEPARATOR
+            << ((double)s->fraction_) / (double)FRACTION_UNIT
+            << LAYOUT_DUMP_SEPARATOR
+            << s->selection_
+            << LAYOUT_DUMP_WHITESPACES[0];
+        FrameTree::dump(s->a_, output);
+        output << LAYOUT_DUMP_WHITESPACES[0];
+        FrameTree::dump(s->b_, output);
+        output << LAYOUT_DUMP_BRACKETS[1];
+    };
+    frame->switchcase(onSplit, onLeaf);
+}
+

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -7,6 +7,8 @@ FrameTree::FrameTree(HSTag* tag, Settings* settings)
     , settings_(settings)
 {
     root_ = std::make_shared<HSFrameLeaf>(tag, settings, std::shared_ptr<HSFrameSplit>());
+    (void) tag_;
+    (void) settings_;
 }
 
 void FrameTree::foreachClient(std::function<void(Client*)> action)

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -83,6 +83,17 @@ std::shared_ptr<HSFrame> FrameTree::lookup(const std::string& path) {
 /*! get the frame leaf that is focused within this frame tree.
  */
 std::shared_ptr<HSFrameLeaf> FrameTree::focusedFrame() {
-    return {};
+    return focusedFrame(root_);
+}
+
+/*! get the focused frame within the subtree of the given node
+ */
+std::shared_ptr<HSFrameLeaf> FrameTree::focusedFrame(std::shared_ptr<HSFrame> node) {
+    while (node->isLeaf() == nullptr) {
+        // node must be a frame split
+        auto s = node->isSplit();
+        node = (s->selection_ == 0) ? s->a_ : s->b_;
+    }
+    return node->isLeaf();
 }
 

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -22,6 +22,7 @@ public:
 
     static void dump(std::shared_ptr<HSFrame> frame, Output output);
     std::shared_ptr<HSFrame> lookup(const std::string& path);
+    static std::shared_ptr<HSFrameLeaf> focusedFrame(std::shared_ptr<HSFrame> node);
     std::shared_ptr<HSFrameLeaf> focusedFrame();
 public: // soon to be come private:
     std::shared_ptr<HSFrame> root_;

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <functional>
+#include "types.h"
 
 class Client;
 class HSFrame;
@@ -16,6 +17,8 @@ class FrameTree {
 public:
     FrameTree(HSTag* tag, Settings* settings);
     void foreachClient(std::function<void(Client*)> action);
+
+    static void dump(std::shared_ptr<HSFrame> frame, Output output);
 public: // soon to be come private:
     std::shared_ptr<HSFrame> root_;
 private:

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -2,11 +2,13 @@
 #define HERBSTLUFT_FRAME_TREE_H
 
 #include <memory>
+#include <string>
 #include <functional>
 #include "types.h"
 
 class Client;
 class HSFrame;
+class HSFrameLeaf;
 class HSTag;
 class Settings;
 
@@ -19,6 +21,8 @@ public:
     void foreachClient(std::function<void(Client*)> action);
 
     static void dump(std::shared_ptr<HSFrame> frame, Output output);
+    std::shared_ptr<HSFrame> lookup(const std::string& path);
+    std::shared_ptr<HSFrameLeaf> focusedFrame();
 public: // soon to be come private:
     std::shared_ptr<HSFrame> root_;
 private:

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -1,0 +1,26 @@
+#ifndef HERBSTLUFT_FRAME_TREE_H
+#define HERBSTLUFT_FRAME_TREE_H
+
+#include <memory>
+#include <functional>
+
+class Client;
+class HSFrame;
+class HSTag;
+class Settings;
+
+/*! A class representing an entire tree of frames that provides
+ * the tiling commands and other common actions on the frame tree
+ */
+class FrameTree {
+public:
+    FrameTree(HSTag* tag, Settings* settings);
+    void foreachClient(std::function<void(Client*)> action);
+public: // soon to be come private:
+    std::shared_ptr<HSFrame> root_;
+private:
+    HSTag* tag_;
+    Settings* settings_;
+};
+
+#endif

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -158,37 +158,6 @@ HSFrameLeaf::~HSFrameLeaf() {
     delete decoration;
 }
 
-void HSFrameLeaf::dump(Output output) {
-    output << LAYOUT_DUMP_BRACKETS[0]
-           << "clients"
-           << LAYOUT_DUMP_WHITESPACES[0]
-           << g_layout_names[layout] << ":"
-           << selection;
-    for (auto client : clients) {
-        output << LAYOUT_DUMP_WHITESPACES[0]
-               << "0x"
-               << std::hex << client->x11Window() << std::dec;
-    }
-    output << LAYOUT_DUMP_BRACKETS[1];
-}
-
-void HSFrameSplit::dump(Output output) {
-    output
-        << LAYOUT_DUMP_BRACKETS[0]
-        << "split"
-        << LAYOUT_DUMP_WHITESPACES[0]
-        << g_align_names[align_]
-        << LAYOUT_DUMP_SEPARATOR
-        << ((double)fraction_) / (double)FRACTION_UNIT
-        << LAYOUT_DUMP_SEPARATOR
-        << selection_
-        << LAYOUT_DUMP_WHITESPACES[0];
-    a_->dump(output);
-    output << LAYOUT_DUMP_WHITESPACES[0];
-    b_->dump(output);
-    output << LAYOUT_DUMP_BRACKETS[1];
-}
-
 int find_layout_by_name(char* name) {
     for (size_t i = 0; i < LENGTH(g_layout_names); i++) {
         if (!g_layout_names[i]) {

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -85,35 +85,6 @@ void HSFrameSplit::insertClient(Client* client) {
     else                b_->insertClient(client);
 }
 
-shared_ptr<HSFrame> HSFrameLeaf::lookup(const char*) {
-    return shared_from_this(); // we are last one left
-}
-
-shared_ptr<HSFrame> HSFrameSplit::lookup(const char* index) {
-    if (!index || index[0] == '\0') {
-        return shared_from_this();
-    }
-
-    auto selected = (selection_ == 0) ? a_ : b_;
-    auto not_selected = (selection_ == 0) ? b_ : a_;
-
-    if (index[0] == '@') {
-        // Special case: always follow selection
-        return selected->lookup("@");
-    }
-
-    shared_ptr<HSFrame> new_root;
-    switch (index[0]) {
-        case '0': new_root = a_; break;
-        case '1': new_root = b_; break;
-        case '/': new_root = not_selected; break;
-        case '.': /* fallthru */
-        default: new_root = selected;
-    }
-
-    return new_root->lookup(index + 1);
-}
-
 shared_ptr<HSFrameLeaf> HSFrameSplit::frameWithClient(Client* client) {
     auto found = a_->frameWithClient(client);
     if (found) return found;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -80,11 +80,6 @@ void HSFrameLeaf::insertClient(Client* client) {
     // the client now
 }
 
-void HSFrameSplit::insertClient(Client* client) {
-    if (selection_ == 0) a_->insertClient(client);
-    else                b_->insertClient(client);
-}
-
 shared_ptr<HSFrameLeaf> HSFrameSplit::frameWithClient(Client* client) {
     auto found = a_->frameWithClient(client);
     if (found) return found;
@@ -518,7 +513,7 @@ int frame_current_bring(int argc, char** argv, Output output) {
     auto frame = tag->frame->root_->frameWithClient(client);
     if (!frame->isFocused()) {
         frame->removeClient(client);
-        tag->frame->root_->insertClient(client);
+        tag->frame->focusedFrame()->insertClient(client);
     }
     focus_client(client, false, false);
     return 0;
@@ -1022,7 +1017,7 @@ int frame_move_window_command(int argc, char** argv, Output output) {
         if (client && neighbour) { // if neighbour was found
             // move window to neighbour
             frame->removeClient(client);
-            neighbour->insertClient(client);
+            FrameTree::focusedFrame(neighbour)->insertClient(client);
             neighbour->frameWithClient(client)->select(client);
 
             // change selection in parent

--- a/src/layout.h
+++ b/src/layout.h
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <functional>
 #include <memory>
+#include <cassert>
 
 #include "glib-backports.h"
 #include "tilingresult.h"
@@ -96,21 +97,8 @@ public:
         }
         // if it is not a split, it must be a leaf
         auto l = isLeaf();
-        // assert(l != nullptr)
+        assert(l);
         return onLeaf(l);
-    }
-    /*! The same for ReturnType = void
-     */
-    void switchcase(std::function<void(std::shared_ptr<HSFrameLeaf>)> onLeaf,
-                    std::function<void(std::shared_ptr<HSFrameSplit>)> onSplit) {
-        auto s = isSplit();
-        if (s) {
-            onSplit(s);
-        }
-        // if it is not a split, it must be a leaf
-        auto l = isLeaf();
-        // assert(l != nullptr)
-        onLeaf(l);
     }
 
     friend class HSFrameSplit;

--- a/src/layout.h
+++ b/src/layout.h
@@ -56,7 +56,6 @@ protected:
     HSFrame(HSTag* tag, Settings* settings, std::weak_ptr<HSFrameSplit> parent);
     virtual ~HSFrame();
 public:
-    virtual void insertClient(Client* client) = 0;
     virtual std::shared_ptr<HSFrameLeaf> frameWithClient(Client* client) = 0;
     virtual bool removeClient(Client* client) = 0;
 
@@ -118,7 +117,7 @@ public:
     ~HSFrameLeaf() override;
 
     // inherited:
-    void insertClient(Client* client) override;
+    void insertClient(Client* client);
     std::shared_ptr<HSFrameLeaf> frameWithClient(Client* client) override;
     bool removeClient(Client* client) override;
     void moveClient(int new_index);
@@ -178,7 +177,6 @@ public:
                  std::shared_ptr<HSFrame> a_, std::shared_ptr<HSFrame> b_);
     ~HSFrameSplit() override;
     // inherited:
-    void insertClient(Client* client) override;
     std::shared_ptr<HSFrameLeaf> frameWithClient(Client* client) override;
     bool removeClient(Client* client) override;
 

--- a/src/layout.h
+++ b/src/layout.h
@@ -56,7 +56,6 @@ protected:
     virtual ~HSFrame();
 public:
     virtual void insertClient(Client* client) = 0;
-    virtual std::shared_ptr<HSFrame> lookup(const char* path) = 0;
     virtual std::shared_ptr<HSFrameLeaf> frameWithClient(Client* client) = 0;
     virtual bool removeClient(Client* client) = 0;
 
@@ -98,9 +97,8 @@ public:
         }
         // if it is not a split, it must be a leaf
         auto l = isLeaf();
-        if (l) {
-            return onLeaf(l);
-        }
+        // assert(l != nullptr)
+        return onLeaf(l);
     }
     /*! The same for ReturnType = void
      */
@@ -112,9 +110,8 @@ public:
         }
         // if it is not a split, it must be a leaf
         auto l = isLeaf();
-        if (l) {
-            onLeaf(l);
-        }
+        // assert(l != nullptr)
+        onLeaf(l);
     }
 
     friend class HSFrameSplit;
@@ -135,7 +132,6 @@ public:
 
     // inherited:
     void insertClient(Client* client) override;
-    std::shared_ptr<HSFrame> lookup(const char* path) override;
     std::shared_ptr<HSFrameLeaf> frameWithClient(Client* client) override;
     bool removeClient(Client* client) override;
     void moveClient(int new_index);
@@ -197,7 +193,6 @@ public:
     ~HSFrameSplit() override;
     // inherited:
     void insertClient(Client* client) override;
-    std::shared_ptr<HSFrame> lookup(const char* path) override;
     std::shared_ptr<HSFrameLeaf> frameWithClient(Client* client) override;
     bool removeClient(Client* client) override;
 

--- a/src/layout.h
+++ b/src/layout.h
@@ -15,14 +15,6 @@
 #define LAYOUT_DUMP_SEPARATOR_STR ":" /* must be a string with one char */
 #define LAYOUT_DUMP_SEPARATOR LAYOUT_DUMP_SEPARATOR_STR[0]
 
-#define TAG_SET_FLAG(tag, flag) \
-    ((tag)->flags |= (flag))
-
-enum {
-    TAG_FLAG_URGENT = 0x01, // is there a urgent window?
-    TAG_FLAG_USED   = 0x02, // the opposite of empty
-};
-
 enum {
     ALIGN_VERTICAL = 0,
     ALIGN_HORIZONTAL,
@@ -242,10 +234,6 @@ HSFrame* get_toplevel_frame(HSFrame* frame);
 
 void print_frame_tree(std::shared_ptr<HSFrame> frame, Output output);
 void dump_frame_tree(std::shared_ptr<HSFrame> frame, Output output);
-// create apply a described layout to a frame and its subframes
-// returns pointer to string that was not parsed yet
-// or NULL on an error
-char* load_frame_tree(std::shared_ptr<HSFrame> frame, char* description, Output errormsg);
 int find_layout_by_name(char* name);
 int find_align_by_name(char* name);
 

--- a/src/layout.h
+++ b/src/layout.h
@@ -89,8 +89,8 @@ public:
      * The return value is passed through.
      */
     template <typename ReturnType>
-    ReturnType switchcase(std::function<ReturnType(std::shared_ptr<HSFrameSplit>)> onSplit,
-                          std::function<ReturnType(std::shared_ptr<HSFrameLeaf>)> onLeaf) {
+    ReturnType switchcase(std::function<ReturnType(std::shared_ptr<HSFrameLeaf>)> onLeaf,
+                          std::function<ReturnType(std::shared_ptr<HSFrameSplit>)> onSplit) {
         auto s = isSplit();
         if (s) {
             return onSplit(s);
@@ -102,8 +102,8 @@ public:
     }
     /*! The same for ReturnType = void
      */
-    void switchcase(std::function<void(std::shared_ptr<HSFrameSplit>)> onSplit,
-                    std::function<void(std::shared_ptr<HSFrameLeaf>)> onLeaf) {
+    void switchcase(std::function<void(std::shared_ptr<HSFrameLeaf>)> onLeaf,
+                    std::function<void(std::shared_ptr<HSFrameSplit>)> onSplit) {
         auto s = isSplit();
         if (s) {
             onSplit(s);

--- a/src/layout.h
+++ b/src/layout.h
@@ -60,7 +60,6 @@ public:
     virtual bool removeClient(Client* client) = 0;
 
     virtual bool isFocused();
-    virtual std::shared_ptr<HSFrameLeaf> getFocusedFrame() = 0;
     virtual TilingResult computeLayout(Rectangle rect) = 0;
     virtual bool focusClient(Client* client) = 0;
     virtual Client* focusedClient() = 0;
@@ -136,7 +135,6 @@ public:
     bool removeClient(Client* client) override;
     void moveClient(int new_index);
 
-    std::shared_ptr<HSFrameLeaf> getFocusedFrame() override;
     TilingResult computeLayout(Rectangle rect) override;
     bool focusClient(Client* client) override;
 
@@ -196,7 +194,6 @@ public:
     std::shared_ptr<HSFrameLeaf> frameWithClient(Client* client) override;
     bool removeClient(Client* client) override;
 
-    std::shared_ptr<HSFrameLeaf> getFocusedFrame() override;
     TilingResult computeLayout(Rectangle rect) override;
     bool focusClient(Client* client) override;
 

--- a/src/layout.h
+++ b/src/layout.h
@@ -222,11 +222,6 @@ extern int* g_window_gap;
 // functions
 void layout_init();
 void layout_destroy();
-// for frames
-HSFrame* frame_create_empty(HSFrame* parent, HSTag* parenttag);
-void frame_insert_client(HSFrame* frame, Client* client);
-HSFrame* frame_current_selection();
-HSFrame* frame_current_selection_below(HSFrame* frame);
 // finds the subframe of frame that contains the window
 HSFrameLeaf* find_frame_with_client(HSFrame* frame, Client* client);
 // removes window from a frame/subframes
@@ -235,8 +230,6 @@ bool frame_remove_client(HSFrame* frame, Client* client);
 // destroys a frame and all its childs
 // then all Windows in it are collected and returned
 // YOU have to g_free the resulting window-buf
-void frame_destroy(HSFrame* frame, Client*** buf, size_t* count);
-bool frame_split(HSFrame* frame, int align, int fraction);
 int frame_split_command(Input input, Output output);
 int frame_change_fraction_command(int argc, char** argv, Output output);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -286,6 +286,7 @@ int print_layout_command(int argc, char** argv, Output output) {
     assert(tag);
 
     std::shared_ptr<HSFrame> frame = tag->frame->lookup(argc >= 3 ? argv[2] : "");
+    assert(frame);
     if (argc > 0 && !strcmp(argv[0], "dump")) {
         FrameTree::dump(frame, output);
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include "clientmanager.h"
 #include "command.h"
 #include "ewmh.h"
+#include "frametree.h"
 #include "globals.h"
 #include "hook.h"
 #include "ipc-protocol.h"
@@ -284,7 +285,7 @@ int print_layout_command(int argc, char** argv, Output output) {
     }
     assert(tag);
 
-    std::shared_ptr<HSFrame> frame = tag->frame->lookup(argc >= 3 ? argv[2] : "");
+    std::shared_ptr<HSFrame> frame = tag->frame->root_->lookup(argc >= 3 ? argv[2] : "");
     if (argc > 0 && !strcmp(argv[0], "dump")) {
         frame->dump(output);
     } else {
@@ -312,18 +313,18 @@ int load_command(int argc, char** argv, Output output) {
         tag = m->tag;
     }
     assert(tag != nullptr);
-    char* rest = load_frame_tree(tag->frame, layout_string, output);
+    const char* rest = "To be implemented...";
     tag_set_flags_dirty(); // we probably changed some window positions
     // arrange monitor
     Monitor* m = find_monitor_with_tag(tag);
     if (m) {
-        tag->frame->setVisibleRecursive(true);
+        tag->frame->root_->setVisibleRecursive(true);
         if (get_current_monitor() == m) {
-            frame_focus_recursive(tag->frame);
+            frame_focus_recursive(tag->frame->root_);
         }
         m->applyLayout();
     } else {
-        tag->frame->setVisibleRecursive(false);
+        tag->frame->root_->setVisibleRecursive(false);
     }
     if (!rest) {
         output << argv[0] << ": Error while parsing!\n";
@@ -780,7 +781,7 @@ void enternotify(Root* root, XEvent* event) {
         Client* c = get_client_from_window(ce->window);
         std::shared_ptr<HSFrameLeaf> target;
         if (c && c->tag()->floating == false
-              && (target = c->tag()->frame->frameWithClient(c))
+              && (target = c->tag()->frame->root_->frameWithClient(c))
               && target->getLayout() == LAYOUT_MAX
               && target->focusedClient() != c) {
             // don't allow focus_follows_mouse if another window would be

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -312,6 +312,7 @@ int load_command(int argc, char** argv, Output output) {
         Monitor* m = get_current_monitor();
         tag = m->tag;
     }
+    (void) layout_string;
     assert(tag != nullptr);
     const char* rest = "To be implemented...";
     tag_set_flags_dirty(); // we probably changed some window positions

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -287,7 +287,7 @@ int print_layout_command(int argc, char** argv, Output output) {
 
     std::shared_ptr<HSFrame> frame = tag->frame->root_->lookup(argc >= 3 ? argv[2] : "");
     if (argc > 0 && !strcmp(argv[0], "dump")) {
-        frame->dump(output);
+        FrameTree::dump(frame, output);
     } else {
         print_frame_tree(frame, output);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -285,7 +285,7 @@ int print_layout_command(int argc, char** argv, Output output) {
     }
     assert(tag);
 
-    std::shared_ptr<HSFrame> frame = tag->frame->root_->lookup(argc >= 3 ? argv[2] : "");
+    std::shared_ptr<HSFrame> frame = tag->frame->lookup(argc >= 3 ? argv[2] : "");
     if (argc > 0 && !strcmp(argv[0], "dump")) {
         FrameTree::dump(frame, output);
     } else {

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "ewmh.h"
+#include "frametree.h"
 #include "globals.h"
 #include "ipc-protocol.h"
 #include "layout.h"
@@ -52,7 +53,7 @@ void MonitorManager::ensure_monitors_are_available() {
     HSTag* tag = tags_->ensure_tags_are_available();
     // add monitor with first tag
     Monitor* m = addMonitor(rect, tag);
-    m->tag->frame->setVisibleRecursive(true);
+    m->tag->frame->root_->setVisibleRecursive(true);
     cur_monitor = 0;
 
     monitor_update_focus_objects();
@@ -201,8 +202,8 @@ void MonitorManager::removeMonitor(Monitor* monitor)
 
     // Hide all clients visible in monitor
     assert(monitor->tag != nullptr);
-    assert(monitor->tag->frame != nullptr);
-    monitor->tag->frame->setVisibleRecursive(false);
+    assert(monitor->tag->frame->root_ != nullptr);
+    monitor->tag->frame->root_->setVisibleRecursive(false);
 
     g_monitors->removeIndexed(monitorIdx);
 
@@ -260,7 +261,7 @@ int MonitorManager::addMonitor(Input input, Output output)
     }
 
     monitor->applyLayout();
-    tag->frame->setVisibleRecursive(true);
+    tag->frame->root_->setVisibleRecursive(true);
     emit_tag_changed(tag, g_monitors->size() - 1);
     drop_enternotify_events();
 

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -7,6 +7,7 @@
 
 #include "client.h"
 #include "command.h"
+#include "frametree.h"
 #include "glib-backports.h"
 #include "globals.h"
 #include "ipc-protocol.h"
@@ -509,7 +510,7 @@ void client_snap_vector(Client* client, Monitor* monitor,
     }
 
     // snap to other clients
-    tag->frame->foreachClient([&d] (Client* c) { client_snap_helper(c, &d); });
+    tag->frame->root_->foreachClient([&d] (Client* c) { client_snap_helper(c, &d); });
 
     // write back results
     if (abs(d.dx) < abs(distance)) {

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -28,9 +28,9 @@ HSTag::HSTag(std::string name_, Settings* settings)
     , frame_count(this, "frame_count", &HSTag::computeFrameCount)
     , client_count(this, "client_count", &HSTag::computeClientCount)
     , curframe_windex(this, "curframe_windex",
-        [this] () { return frame->root_->getFocusedFrame()->getSelection(); } )
+        [this] () { return frame->focusedFrame()->getSelection(); } )
     , curframe_wcount(this, "curframe_wcount",
-        [this] () { return frame->root_->getFocusedFrame()->clientCount(); } )
+        [this] () { return frame->focusedFrame()->clientCount(); } )
 {
     stack = make_shared<Stack>();
     frame = make_shared<FrameTree>(this, settings);

--- a/src/tag.h
+++ b/src/tag.h
@@ -7,15 +7,23 @@
 #include "glib-backports.h"
 #include "object.h"
 
+#define TAG_SET_FLAG(tag, flag) \
+    ((tag)->flags |= (flag))
+
+enum {
+    TAG_FLAG_URGENT = 0x01, // is there a urgent window?
+    TAG_FLAG_USED   = 0x02, // the opposite of empty
+};
+
 class Stack;
-class HSFrame;
+class FrameTree;
 class Settings;
 
 class HSTag : public Object {
 public:
     HSTag(std::string name, Settings* settings);
     ~HSTag() override;
-    std::shared_ptr<HSFrame>        frame;  // the master frame
+    std::shared_ptr<FrameTree>        frame;  // the master frame
     Attribute_<unsigned long> index;
     Attribute_<bool>         floating;
     Attribute_<std::string>  name;   // name of this tag

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -103,7 +103,7 @@ int TagManager::removeTag(Input input, Output output) {
         client->setTag(targetTag);
         client->tag()->stack->insert_slice(client->slice);
         ewmh_window_update_tag(client->window_, client->tag());
-        targetTag->frame->root_->insertClient(client);
+        targetTag->frame->focusedFrame()->insertClient(client);
     }
 
     // Make transferred clients visible if target tag is visible
@@ -210,7 +210,7 @@ void TagManager::moveClient(Client* client, HSTag* target) {
     Monitor* monitor_target = find_monitor_with_tag(target);
     tag_source->frame->root_->removeClient(client);
     // insert window into target
-    target->frame->root_->insertClient(client);
+    target->frame->focusedFrame()->insertClient(client);
     // enfoce it to be focused on the target tag
     target->frame->root_->focusClient(client);
     client->tag()->stack->remove_slice(client->slice);

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -47,3 +47,19 @@ def test_focus_wrap(hlwm, running_clients, running_clients_num):
         assert int(hlwm.get_attr('tags.0.curframe_windex')) == expected_idx
         if i < running_clients_num - 1:
             hlwm.call('focus down')
+
+
+@pytest.mark.parametrize("path", '@ 0 1 00 11 . / /. ./'.split(' '))
+@pytest.mark.parametrize("running_clients_num", [3])
+@pytest.mark.parametrize("num_splits", [0, 1, 2])
+def test_dump(hlwm, running_clients, path, running_clients_num, num_splits):
+    for i in range(0, num_splits):
+        hlwm.call('split explode')
+    layout = hlwm.call('dump').stdout
+    layout_part = hlwm.call('dump "" ' + path).stdout
+    if num_splits > 0:
+        assert layout_part in layout
+        assert len(layout_part) < len(layout)
+    else:
+        assert layout_part == layout
+


### PR DESCRIPTION
The FrameTree class is intended to be a common entry point for other modules that want to modify the tree. So FrameTree keeps track of the entire frame tree (insert clients, ask for the focused frame, ask for the focused client). Formerly, these methods (e.g. lookup, dump, getFocusedFrame) were part of three classes (HSFrame, HSFrameLeaf, HSFrameSplit). Instead, they are now only a single method in FrameTree.

Additionally, the frame commands (shift, split, remove frame,...) will become methods in FrameTree. (They are still global functions in layout.h/layout.cpp)