### PR TITLE
Clean up responsibilities of KeyCombo helpers

### DIFF
--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -62,9 +62,7 @@ bool KeyCombo::matches(const std::regex& regex) const {
  */
 unsigned int KeyCombo::modifierMaskFromTokens(const vector<string>& tokens) {
     unsigned int modifiers = 0;
-
-    for (auto iter = tokens.begin(); iter != tokens.end(); iter++) {
-        auto modName = *iter;
+    for (auto& modName : tokens) {
         modifiers |= getMaskForModifierName(modName);
     }
     return modifiers;

--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -56,36 +56,29 @@ bool KeyCombo::matches(const std::regex& regex) const {
 }
 
 /*!
- * Parses the modifiers part of a key combo string into a mask value.
+ * Determines a modifier mask value from a list of key combo tokens
  *
  * \throws meaningful exceptions on parsing errors
  */
-unsigned int KeyCombo::string2modifiers(const string& str) {
-    auto splitted = splitKeySpec(str);
-
-    if (splitted.empty()) {
-        throw std::runtime_error("Empty keysym");
-    }
-
+unsigned int KeyCombo::modifierMaskFromTokens(const vector<string>& tokens) {
     unsigned int modifiers = 0;
-    // all parts except last one are modifiers
-    for (auto iter = splitted.begin(); iter + 1 != splitted.end(); iter++) {
-        modifiers |= getMaskForModifierName(*iter);
+
+    for (auto iter = tokens.begin(); iter != tokens.end(); iter++) {
+        auto modName = *iter;
+        modifiers |= getMaskForModifierName(modName);
     }
     return modifiers;
 }
 
 /*!
- * Parses the keysym part of a key combo string into a KeySym.
+ * Parses a given key sym string into an X11 KeySym.
  *
  * \throws meaningful exceptions on parsing errors
  */
-KeySym KeyCombo::string2keysym(const string& str) {
-    // last one is the key
-    auto lastToken = splitKeySpec(str).back();
-    auto keysym = XStringToKeysym(lastToken.c_str());
+KeySym KeyCombo::keySymFromString(const string& str) {
+    auto keysym = XStringToKeysym(str.c_str());
     if (keysym == NoSymbol) {
-        throw std::runtime_error("Unknown KeySym \"" + lastToken + "\"");
+        throw std::runtime_error("Unknown KeySym \"" + str + "\"");
     }
     return keysym;
 }
@@ -100,10 +93,19 @@ KeySym KeyCombo::string2keysym(const string& str) {
  *
  * \throws meaningful exceptions on parsing errors
  */
-KeyCombo KeyCombo::fromString(const std::string& str) {
+KeyCombo KeyCombo::fromString(const string& str) {
     KeyCombo combo;
-    combo.modifiers = string2modifiers(str);
-    combo.keysym = string2keysym(str);
+    auto tokens = tokensFromString(str);
+
+    if (tokens.empty()) {
+        throw std::runtime_error("Empty keysym");
+    }
+
+    auto modifierSlice = vector<string>({tokens.begin(), tokens.end() - 1});
+    auto keySymString = tokens.back();
+
+    combo.modifiers = modifierMaskFromTokens(modifierSlice);
+    combo.keysym = keySymFromString(keySymString);
     return combo;
 }
 
@@ -113,7 +115,8 @@ bool KeyCombo::operator==(const KeyCombo& other) const {
     return sameMods && sameKeySym;
 }
 
-vector<string> KeyCombo::splitKeySpec(string keySpec)
+//! Splits a given key combo string into a list of tokens
+vector<string> KeyCombo::tokensFromString(string keySpec)
 {
     // Normalize spec to use a single separator:
     char baseSep = KEY_COMBI_SEPARATORS[0];

--- a/src/keycombo.h
+++ b/src/keycombo.h
@@ -30,15 +30,15 @@ public:
     std::string str() const;
     bool matches(const std::regex& regex) const;
     bool operator==(const KeyCombo& other) const;
-    static unsigned int string2modifiers(const std::string& str);
-    static KeySym string2keysym(const std::string& str);
+    static std::vector<std::string> tokensFromString(std::string keySpec);
+    static unsigned int modifierMaskFromTokens(const std::vector<std::string>& tokens);
+    static KeySym keySymFromString(const std::string& str);
     static KeyCombo fromString(const std::string& str);
 
     KeySym keysym;
     unsigned int modifiers;
 
 private:
-    static std::vector<std::string> splitKeySpec(std::string keySpec);
     static unsigned int getMaskForModifierName(std::string name);
     static std::vector<std::string> getNamesForModifierMask(unsigned int mask);
 };

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -165,17 +165,19 @@ int mouse_bind_command(int argc, char** argv, Output output) {
         return HERBST_NEED_MORE_ARGS;
     }
     unsigned int modifiers = 0;
-    char* string = argv[1];
+    char* str = argv[1];
 
     try {
-        modifiers = KeyCombo::string2modifiers(string);
+        auto tokens = KeyCombo::tokensFromString(str);
+        auto modifierSlice = std::vector<std::string>({tokens.begin(), tokens.end() - 1});
+        modifiers = KeyCombo::modifierMaskFromTokens(modifierSlice);
     } catch (std::runtime_error &error) {
         output << argv[0] << error.what();
         return HERBST_INVALID_ARGUMENT;
     }
 
     // last one is the mouse button
-    const char* last_token = strlasttoken(string, KEY_COMBI_SEPARATORS);
+    const char* last_token = strlasttoken(str, KEY_COMBI_SEPARATORS);
     unsigned int button = string2button(last_token);
     if (button == 0) {
         output << argv[0] <<


### PR DESCRIPTION
Dealing with the structure of a KeyCombo (i.e., last token is keysym,
others are modifiers) is now part of fromString(). This makes the
renamed helpers for parsing modifiers and keysyms more flexible for
other use cases (completion in particular).

The helper for splitting a string into tokens is made public for future
use in completion code in KeyManager.

As a small cleanup, a local variable in mouse.cpp is renamed from
"string" to "str" to avoid shadowing the type.