### PR TITLE
Add CI check to enforce "using std::..." style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ jobs:
           dist: xenial
           python: "3.6"
           before_install:
+              - ./ci-check-using-std.sh
               - export CC=gcc-8 CXX=g++-8
               - linkerfix="-fuse-ld=gold" # needed to avoid linker error
               - export LDFLAGS="$linkerfix" LDXXFLAGS="$linkerfix"

--- a/ci-check-using-std.sh
+++ b/ci-check-using-std.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+###
+# Searches the code for the use of "std::" prefixes in symbol reference that
+# should be pulled into the namespace with "using std::…;".
+#
+# The list of symbols to enforce this for is assembled on-the-fly by looking
+# for occurrences of "using std::…;"
+###
+
+set -o pipefail
+set -o nounset
+
+reporoot=$(realpath "$(dirname "$0")")
+
+# Assemble list of std symbols to pull in:
+usethis=$(grep -r --no-filename 'using std::' "$reporoot/src/"*.cpp \
+    | sed -r 's/^\s*using std::(.*);/\1/' \
+    | sort -u)
+
+# Fall back to hardcoded list until the rule is actually enforced:
+usethis="string"
+
+found_something=0
+for symbol in $usethis; do
+    # Find offending occurences of "std::" prefixes:
+    grep -r --color=auto "[^(using ) ]std::$symbol" src/*.cpp
+    grepret=$?
+    if [[ $grepret == 0 ]]; then
+        found_something=1
+    fi
+done
+
+if [[ $found_something != 0 ]]; then
+    echo >&2 "Found redundant uses of std:: prefixes (see above)"
+    exit 1
+fi


### PR DESCRIPTION
This only enforces it for string (for now), to allow a gradual transition.