### PR TITLE
Fix missed occurrences of std::string

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -470,7 +470,7 @@ void try_complete_prefix_partial(const char* needle, const char* to_check,
                                  const char* prefix, Output output) {
     try_complete_suffix(needle, to_check, "\n", prefix, output);
 }
-void try_complete_prefix_partial(const string& needle, const std::string& to_check,
+void try_complete_prefix_partial(const string& needle, const string& to_check,
                                  const string& prefix, Output output) {
     try_complete_suffix(needle.c_str(), to_check.c_str(), "\n", prefix.c_str(), output);
 }

--- a/src/completion.cpp
+++ b/src/completion.cpp
@@ -53,7 +53,7 @@ void Completion::none() {
 }
 
 //! Return the given string posix sh escaped if in shell output mode
-string Completion::escape(const std::string& str) {
+string Completion::escape(const string& str) {
     return str;
 }
 
@@ -62,7 +62,7 @@ bool Completion::noParameterExpected() const {
     return noParameterExpected_;
 }
 
-bool Completion::prefixOf(const string& shorter, const std::string& longer)
+bool Completion::prefixOf(const string& shorter, const string& longer)
 {
     auto res = std::mismatch(shorter.begin(), shorter.end(), longer.begin());
     return res.first == shorter.end();

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -70,7 +70,7 @@ string Monitor::getTagString() {
     return tag->name();
 }
 
-string Monitor::setTagString(std::string new_tag_string) {
+string Monitor::setTagString(string new_tag_string) {
     HSTag* new_tag = find_tag(new_tag_string.c_str());
     if (!new_tag) {
         return "no tag named \"" + new_tag_string + "\" exists.";

--- a/src/namedhook.cpp
+++ b/src/namedhook.cpp
@@ -1,5 +1,9 @@
 #include "namedhook.h"
 
+#include <string>
+
+using std::string;
+
 #ifdef ENABLE_NAMED_HOOK
 
 NamedHook::NamedHook(const string &path) :
@@ -79,7 +83,7 @@ void NamedHook::emit(HookEvent event, const string &name)
     });
 }
 
-void NamedHook::emit(const string &old, const std::string &current)
+void NamedHook::emit(const string &old, const string &current)
 {
     if (!old.empty()) {
         if (current.empty()) {

--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -166,7 +166,7 @@ size_t RuleManager::removeRules(string label) {
     return countAfter - countBefore;
 }
 
-std::tuple<string, char, std::string> RuleManager::tokenize_arg(std::string arg) {
+std::tuple<string, char, string> RuleManager::tokenize_arg(string arg) {
     if (arg.substr(0, 2) == "--") {
         arg.erase(0, 2);
     }

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -46,7 +46,7 @@ void HSTag::setIndexAttribute(unsigned long new_index) {
 }
 
 
-string HSTag::validateNewName(std::string newName) {
+string HSTag::validateNewName(string newName) {
     for (auto t : *global_tags) {
         if (t != this && t->name == newName) {
             return string("Tag \"") + newName + "\" already exists ";

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -19,7 +19,7 @@ Input Input::fromHere()
     return Input(cmd, toVector());
 }
 
-void Input::replace(const string &from, const std::string &to)
+void Input::replace(const string &from, const string &to)
 {
     for (auto &v : *container_)
         if (v == from)


### PR DESCRIPTION
These were missed due to a mistake in the regexp used in the CI check
for std:: prefixes (will be fixed separately).