### PR TITLE
Remove std:: prefixes for smart pointer symbols

### DIFF
--- a/ci-check-using-std.sh
+++ b/ci-check-using-std.sh
@@ -14,20 +14,18 @@ set -o nounset
 reporoot=$(realpath "$(dirname "$0")")
 
 # Assemble list of std symbols to pull in:
+# (exclude some that are not enforced yet)
 usethis=$(grep --no-filename 'using std::' "$reporoot/src/"*.cpp \
     | sed -r 's/^\s*using std::(.*);/\1/' \
-    | sort -u)
-
-# Fall back to hardcoded list until the rule is actually enforced:
-usethis=" \
-    make_shared \
-    make_unique \
-    shared_ptr \
-    string \
-    unique_ptr \
-    vector \
-    weak_ptr \
-    "
+    | sort -u \
+    | grep -xv dynamic_pointer_cast \
+    | grep -xv endl \
+    | grep -xv function \
+    | grep -xv make_pair \
+    | grep -xv pair \
+    | grep -xv stringstream \
+    | grep -xv to_string \
+    )
 
 found_something=0
 # set -x

--- a/ci-check-using-std.sh
+++ b/ci-check-using-std.sh
@@ -19,7 +19,15 @@ usethis=$(grep --no-filename 'using std::' "$reporoot/src/"*.cpp \
     | sort -u)
 
 # Fall back to hardcoded list until the rule is actually enforced:
-usethis="string vector"
+usethis=" \
+    make_shared \
+    make_unique \
+    shared_ptr \
+    string \
+    unique_ptr \
+    vector \
+    weak_ptr \
+    "
 
 found_something=0
 # set -x

--- a/src/arglist.cpp
+++ b/src/arglist.cpp
@@ -2,27 +2,28 @@
 
 #include "utils.h"
 
+using std::make_shared;
 using std::string;
 using std::stringstream;
 
 ArgList::ArgList(const std::initializer_list<string> &l)
-    : container_(std::make_shared<Container>(l))
+    : container_(make_shared<Container>(l))
 { reset(); }
 
 ArgList::ArgList(const ArgList::Container &c)
-    : container_(std::make_shared<Container>(c))
+    : container_(make_shared<Container>(c))
 { reset(); }
 
 ArgList::ArgList(const ArgList &al) : container_(al.container_) { reset(); }
 
 ArgList::ArgList(const string &s, char delim) {
-    container_ = std::make_shared<Container>(split(s, delim));
+    container_ = make_shared<Container>(split(s, delim));
     reset();
 }
 
 ArgList::ArgList(Container::const_iterator from, Container::const_iterator to)
 {
-    container_ = std::make_shared<Container>(from, to);
+    container_ = make_shared<Container>(from, to);
     reset();
 }
 

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -7,6 +7,7 @@
 #include "tag.h"
 #include "utils.h"
 
+using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
@@ -14,7 +15,7 @@ FrameTree::FrameTree(HSTag* tag, Settings* settings)
     : tag_(tag)
     , settings_(settings)
 {
-    root_ = std::make_shared<HSFrameLeaf>(tag, settings, std::shared_ptr<HSFrameSplit>());
+    root_ = make_shared<HSFrameLeaf>(tag, settings, shared_ptr<HSFrameSplit>());
     (void) tag_;
     (void) settings_;
 }
@@ -24,7 +25,7 @@ void FrameTree::foreachClient(std::function<void(Client*)> action)
     root_->foreachClient(action);
 }
 
-void FrameTree::dump(std::shared_ptr<HSFrame> frame, Output output)
+void FrameTree::dump(shared_ptr<HSFrame> frame, Output output)
 {
     auto l = frame->isLeaf();
     if (l) {
@@ -62,19 +63,19 @@ void FrameTree::dump(std::shared_ptr<HSFrame> frame, Output output)
 
 /*! look up a specific frame in the frame tree
  */
-std::shared_ptr<HSFrame> FrameTree::lookup(const string& path) {
-    std::shared_ptr<HSFrame> node = root_;
+shared_ptr<HSFrame> FrameTree::lookup(const string& path) {
+    shared_ptr<HSFrame> node = root_;
     // the string "@" is a special case
     if (path == "@") {
         return focusedFrame();
     }
     for (char c : path) {
-        node = node->switchcase<std::shared_ptr<HSFrame>>(
-            [](std::shared_ptr<HSFrameLeaf> l) {
+        node = node->switchcase<shared_ptr<HSFrame>>(
+            [](shared_ptr<HSFrameLeaf> l) {
                 // nothing to do on a leaf
                 return l;
             },
-            [c](std::shared_ptr<HSFrameSplit> l) {
+            [c](shared_ptr<HSFrameSplit> l) {
                 switch (c) {
                     case '0': return l->a_;
                     case '1': return l->b_;
@@ -90,13 +91,13 @@ std::shared_ptr<HSFrame> FrameTree::lookup(const string& path) {
 
 /*! get the frame leaf that is focused within this frame tree.
  */
-std::shared_ptr<HSFrameLeaf> FrameTree::focusedFrame() {
+shared_ptr<HSFrameLeaf> FrameTree::focusedFrame() {
     return focusedFrame(root_);
 }
 
 /*! get the focused frame within the subtree of the given node
  */
-std::shared_ptr<HSFrameLeaf> FrameTree::focusedFrame(std::shared_ptr<HSFrame> node) {
+shared_ptr<HSFrameLeaf> FrameTree::focusedFrame(shared_ptr<HSFrame> node) {
     while (node->isLeaf() == nullptr) {
         // node must be a frame split
         auto s = node->isSplit();
@@ -257,11 +258,11 @@ shared_ptr<TreeInterface> FrameTree::treeInterface(
     return frame->switchcase<shared_ptr<TreeInterface>>(
         [focus] (shared_ptr<HSFrameLeaf> l) {
             return std::static_pointer_cast<TreeInterface>(
-                    std::make_shared<LeafTI>(l, focus));
+                    make_shared<LeafTI>(l, focus));
         },
         [focus] (shared_ptr<HSFrameSplit> s) {
             return std::static_pointer_cast<TreeInterface>(
-                    std::make_shared<SplitTI>(s, focus));
+                    make_shared<SplitTI>(s, focus));
         }
     );
 }

--- a/src/hookmanager.cpp
+++ b/src/hookmanager.cpp
@@ -24,7 +24,7 @@ void HookManager::ls(Path path, Output out)
 
 void HookManager::add(const string &path)
 {
-    //auto h = std::make_shared<NamedHook>(path);
+    //auto h = make_shared<NamedHook>(path);
     //h->hook_into(Root::get());
     //addChild(h, "???");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,8 @@
 #include "utils.h"
 #include "xconnection.h"
 
+using std::make_shared;
+using std::shared_ptr;
 using std::string;
 using std::unique_ptr;
 
@@ -98,7 +100,7 @@ void maprequest(Root* root, XEvent* event);
 void propertynotify(Root* root, XEvent* event);
 void unmapnotify(Root* root, XEvent* event);
 
-unique_ptr<CommandTable> commands(std::shared_ptr<Root> root) {
+unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
     RootCommands* root_commands = root->root_commands.get();
 
     ClientManager* clients = root->clients();
@@ -287,7 +289,7 @@ int print_layout_command(int argc, char** argv, Output output) {
     }
     assert(tag);
 
-    std::shared_ptr<HSFrame> frame = tag->frame->lookup(argc >= 3 ? argv[2] : "");
+    shared_ptr<HSFrame> frame = tag->frame->lookup(argc >= 3 ? argv[2] : "");
     assert(frame);
     if (argc > 0 && !strcmp(argv[0], "dump")) {
         FrameTree::dump(frame, output);
@@ -782,7 +784,7 @@ void enternotify(Root* root, XEvent* event) {
         && root->settings()->focus_follows_mouse()
         && ce->focus == false) {
         Client* c = get_client_from_window(ce->window);
-        std::shared_ptr<HSFrameLeaf> target;
+        shared_ptr<HSFrameLeaf> target;
         if (c && c->tag()->floating == false
               && (target = c->tag()->frame->root_->frameWithClient(c))
               && target->getLayout() == LAYOUT_MAX
@@ -918,7 +920,7 @@ int main(int argc, char* argv[]) {
     g_root = X->root();
     XSelectInput(g_display, g_root, ROOT_EVENT_MASK);
 
-    auto root = std::make_shared<Root>(g);
+    auto root = make_shared<Root>(g);
     Root::setRoot(root);
     //test_object_system();
 

--- a/src/namedhook.cpp
+++ b/src/namedhook.cpp
@@ -1,7 +1,9 @@
 #include "namedhook.h"
 
+#include <memory>
 #include <string>
 
+using std::shared_ptr;
 using std::string;
 
 #ifdef ENABLE_NAMED_HOOK
@@ -173,7 +175,7 @@ void NamedHook::complete_chain() {
     }
 }
 
-void NamedHook::debug_hook(std::shared_ptr<Object> sender, HookEvent event,
+void NamedHook::debug_hook(shared_ptr<Object> sender, HookEvent event,
                       const string &name)
 {
     if (sender) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -264,7 +264,7 @@ void Object::removeHook(Hook* hook)
     //hooks_.erase(std::remove_if(
     //                hooks_.begin(),
     //                hooks_.end(),
-    //                [hook_locked](std::weak_ptr<Hook> el) {
+    //                [hook_locked](weak_ptr<Hook> el) {
     //                    return el.lock() == hook_locked;
     //                }), hooks_.end());
     hooks_.erase(std::remove(

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -16,7 +16,9 @@
 #include "tmp.h"
 #include "utils.h"
 
-std::shared_ptr<Root> Root::root_;
+using std::shared_ptr;
+
+shared_ptr<Root> Root::root_;
 
 Root::Root(Globals g)
     : clients(*this, "clients")

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <iostream>
 #include <map>
+#include <memory>
 
 #include "attribute_.h"
 #include "command.h"
@@ -14,6 +15,7 @@
 
 using std::endl;
 using std::string;
+using std::unique_ptr;
 using std::vector;
 
 RootCommands::RootCommands(Root* root_) : root(root_) {
@@ -238,7 +240,7 @@ int RootCommands::new_attr_cmd(Input input, Output output)
     Attribute* a = newAttributeWithType(type, attr_name, output);
     if (!a) return HERBST_INVALID_ARGUMENT;
     obj->addAttribute(a);
-    userAttributes_.push_back(std::unique_ptr<Attribute>(a));
+    userAttributes_.push_back(unique_ptr<Attribute>(a));
     return 0;
 }
 
@@ -260,7 +262,7 @@ int RootCommands::remove_attr_cmd(Input input, Output output)
         std::remove_if(
             userAttributes_.begin(),
             userAttributes_.end(),
-            [a](const std::unique_ptr<Attribute>& p) { return p.get() == a; }),
+            [a](const unique_ptr<Attribute>& p) { return p.get() == a; }),
         userAttributes_.end());
     return 0;
 }


### PR DESCRIPTION
Along the way, turn the CI check blacklist into a whitelist of remaining
symbols.