### PR TITLE
CMake: Drop DESCRIPTION argument from project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.1...3.13)
 
 file(STRINGS VERSION VERSION) # read hlwm version from file 'VERSION'
 project(Herbstluftwm
-    VERSION ${VERSION}
-    DESCRIPTION "A manual tiling window manager for X11")
+    VERSION ${VERSION})
 
 # use our cmake dir for include(…) statements
 list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
The DESCRIPTION argument is not understood by CMake 3.5, which satisfies
our version requirements and is the most recent version available on
Ubuntu trusty.