### PR TITLE
Do not use random build directory in ci-build.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ jobs:
                 --volume=$PWD:/hlwm:rw
                 --volume=$HOME/.tox-cache:/hlwm/.tox:rw
                 disco sh -c '
-                    /hlwm/ci-build.py --cxx=clang++-7 --cc=clang-7 --build-type=Debug --ccache=/.ccaches/clang-7 --iwyu &&
-                    /hlwm/ci-build.py --check-using-std --cxx=g++-8 --cc=gcc-8 --build-type=Debug --ccache=/.ccaches/gcc-8 --run-tests
+                    /hlwm/ci-build.py --build-dir=build-clang-7 --cxx=clang++-7 --cc=clang-7 --build-type=Debug --ccache=/.ccaches/clang-7 --iwyu &&
+                    /hlwm/ci-build.py --build-dir=build-gcc-8 --check-using-std --cxx=g++-8 --cc=gcc-8 --build-type=Debug --ccache=/.ccaches/gcc-8 --run-tests
                 '
 
         - name: "Build with ancient GCC on Ubuntu 14.04"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ jobs:
                 --volume=$PWD:/hlwm:rw
                 --volume=$HOME/.tox-cache:/hlwm/.tox:rw
                 disco sh -c '
-                    /hlwm/ci-build.py --build-dir=build-clang-7 --cxx=clang++-7 --cc=clang-7 --build-type=Debug --ccache=/.ccaches/clang-7 --iwyu &&
-                    /hlwm/ci-build.py --build-dir=build-gcc-8 --check-using-std --cxx=g++-8 --cc=gcc-8 --build-type=Debug --ccache=/.ccaches/gcc-8 --run-tests
+                    /hlwm/ci-build.py --build-dir=/hlwm/build-clang-7 --cxx=clang++-7 --cc=clang-7 --build-type=Debug --ccache=/.ccaches/clang-7 --iwyu &&
+                    /hlwm/ci-build.py --build-dir=/hlwm/build-gcc-8 --check-using-std --cxx=g++-8 --cc=gcc-8 --build-type=Debug --ccache=/.ccaches/gcc-8 --run-tests
                 '
 
         - name: "Build with ancient GCC on Ubuntu 14.04"

--- a/ci-build.py
+++ b/ci-build.py
@@ -7,6 +7,7 @@ import tempfile
 from pathlib import Path
 
 parser = argparse.ArgumentParser()
+parser.add_argument('--build-dir', type=str, required=True)
 parser.add_argument('--build-type', type=str, choices=('Release', 'Debug'), required=True)
 parser.add_argument('--run-tests', action='store_true')
 parser.add_argument('--build-docs', action='store_true')
@@ -18,11 +19,11 @@ parser.add_argument('--ccache', nargs='?', metavar='ccache dir', type=str,
                     const=os.environ.get('CCACHE_DIR') or True)
 args = parser.parse_args()
 
+build_dir = Path(args.build_dir)
+build_dir.mkdir(exist_ok=True)
+
 if args.check_using_std:
     sp.check_call(['./ci-check-using-std.sh'], cwd='/hlwm')
-
-temp_dir = tempfile.TemporaryDirectory(dir='/hlwm', prefix='build.')
-build_dir = temp_dir.name
 
 if args.ccache:
     if args.ccache is not True:
@@ -32,9 +33,6 @@ if args.ccache:
     conf = Path(os.environ.get('CCACHE_DIR') or (Path.home() / '.ccache')) / 'ccache.conf'
     if conf.exists():
         conf.unlink()
-
-    # Ignore the working directory on cache lookups
-    sp.check_call('ccache -o hash_dir=false', shell=True)
 
     # Set a reasonable size limit
     sp.check_call('ccache --max-size=500M', shell=True)


### PR DESCRIPTION
This change is a preparation for adding --coverage to the Debug flags.
It is necessary because ccache does not handle random cwds well in
conjunction with --coverage (known issue:
https://github.com/ccache/ccache/issues/268)