### PR TITLE
Introduce IWYU mapping file

### DIFF
--- a/.hlwm.imp
+++ b/.hlwm.imp
@@ -1,0 +1,5 @@
+# Custom mapping file for include-what-you-use
+[
+    { include: ["<bits/getopt_core.h>", "private", "<getopt.h>", "public"]}
+
+]

--- a/ci-build.py
+++ b/ci-build.py
@@ -69,7 +69,7 @@ if args.iwyu:
     sp.check_call('fix_include --dry_run --sort_only --reorder /hlwm/src/*.h', shell=True)
 
     # Run include-what-you-use (just printing the result for now)
-    sp.check_call('iwyu_tool -p . -j "$(nproc)"', shell=True, cwd=build_dir)
+    sp.check_call(f'iwyu_tool -p . -j "$(nproc)" -- --mapping_file=/hlwm/.hlwm.imp', shell=True, cwd=build_dir)
 
 if args.run_tests:
     tox_env = os.environ.copy()


### PR DESCRIPTION
This adds our first useful mapping: Stopping IWYU from telling us to
include <bits/getopt_core.h> when <getopt.h> is the prescribed public
header.