### PR TITLE
Remove empty childbyindex.cpp (fix IWYU complaint)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ target_sources(herbstluftwm PRIVATE
     arglist.cpp arglist.h
     attribute.cpp attribute.h attribute_.h
     byname.cpp byname.h
-    childbyindex.cpp childbyindex.h
+    childbyindex.h
     child.h
     completion.h
     entity.cpp entity.h

--- a/src/childbyindex.cpp
+++ b/src/childbyindex.cpp
@@ -1,1 +1,0 @@
-#include "childbyindex.h"


### PR DESCRIPTION
For unclear reasons, this file made IWYU suggest that childbyindex.h
needed to include signal.h.