### PR TITLE
Remove status-success=WIP from .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,6 @@ pull_request_rules:
       conditions:
           - base=winterbreeze
           - status-success=continuous-integration/travis-ci/pr
-          - status-success=WIP
           - "#approved-reviews-by>=1"
       actions:
           merge:


### PR DESCRIPTION
Apparently, Mergify is fixated on the configuration file as it is in the
default branch, regardless of a PR's base branch. So without this,
Mergify will waits for status-sucess=WIP in PRs made against
winterbreeze.