### PR TITLE
Explicitly use bash in tests for read -n

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,7 +120,7 @@ class HlwmBridge:
         self.next_client_id += 1
         wmclass = 'client_{}'.format(self.next_client_id)
         title = ['-title', str(title)] if title else []
-        command = ['xterm'] + title + ['-class', wmclass, '-e', term_command]
+        command = ['xterm'] + title + ['-class', wmclass, '-e', 'bash', '-c', term_command]
 
         # enforce a hook when the window appears
         self.call(['rule', 'once', 'class='+wmclass, 'hook=here_is_'+wmclass])

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -63,19 +63,19 @@ def test_stack_tree(hlwm):
   - 
     - Monitor 1 ("monitor2") with tag "tag2"
       - Focus-Layer
-        - Client <windowid> "sleep infinity"
+        - Client <windowid> "bash"
       - Fullscreen-Layer
       - Normal Layer
-        - Client <windowid> "sleep infinity"
+        - Client <windowid> "bash"
       - Frame Layer
         - Window <windowid>
         - Window <windowid>
     - Monitor 0 with tag "default"
       - Focus-Layer
-        - Client <windowid> "sleep infinity"
+        - Client <windowid> "bash"
       - Fullscreen-Layer
       - Normal Layer
-        - Client <windowid> "sleep infinity"
+        - Client <windowid> "bash"
       - Frame Layer
         - Window <windowid>
 '''


### PR DESCRIPTION
We use 'read -n 1' in the test cases, which is a bash specific option.
To let the test cases run if bash is not the default shell, explicitly
use bash.