### PR TITLE
Drop glib from the disjoin_rects algorithm

### DIFF
--- a/src/rectangle.cpp
+++ b/src/rectangle.cpp
@@ -43,7 +43,7 @@ static RectangleVec disjoin_from_subset(Rectangle large, Rectangle center)
     // +-----------------------+
     // coordinates of the bottom right corner of large
     int br_x = large.x + large.width, br_y = large.y + large.height;
-    Rectangle (*r)(int,int,int,int) = Rectangle::fromCorners;
+    auto r = Rectangle::fromCorners;
     Rectangle top   = r(large.x, large.y, large.x + large.width, center.y);
     Rectangle left  = r(large.x, center.y, center.x, center.y + center.height);
     Rectangle right = r(center.x + center.width, center.y, br_x, center.y + center.height);

--- a/src/rectangle.cpp
+++ b/src/rectangle.cpp
@@ -1,9 +1,12 @@
 #include "rectangle.h"
 
+#include <queue>
+
 #include "ipc-protocol.h"
 #include "utils.h"
 
 using std::endl;
+using std::vector;
 
 static bool rects_intersect(const Rectangle &a, const Rectangle &b) {
     bool is = true;
@@ -25,48 +28,7 @@ static Rectangle intersection_area(const Rectangle &a, const Rectangle &b) {
     return {tr.x, tr.y, br.x - tr.x, br.y - tr.y};
 }
 
-/* TODO: rewrite with std container instead of RectList */
-#include <glib.h>
-
-typedef struct RectList {
-    Rectangle rect;
-    struct RectList* next;
-} RectList;
-
-void rectlist_free(RectList* head) {
-    if (!head) return;
-    RectList* next = head->next;
-    g_free(head);
-    rectlist_free(next);
-}
-
-static int rectlist_length_acc(RectList* head, int acc) {
-    if (!head) return acc;
-    else return rectlist_length_acc(head->next, acc + 1);
-}
-
-int rectlist_length(RectList* head) {
-    return rectlist_length_acc(head, 0);
-}
-
-static RectList* rectlist_create_simple(int x1, int y1, int x2, int y2) {
-    if (x1 >= x2 || y1 >= y2) {
-        return nullptr;
-    }
-    RectList* r = g_new0(RectList, 1);
-    r->rect.x = x1;
-    r->rect.y = y1;
-    r->rect.width  = x2 - x1;
-    r->rect.height = y2 - y1;
-    r->next = nullptr;
-    return r;
-}
-
-// forward decl for circular calls
-RectList* reclist_insert_disjoint(RectList* head, RectList* element);
-
-static RectList* insert_rect_border(RectList* head,
-                                    Rectangle large, Rectangle center)
+static RectangleVec disjoin_from_subset(Rectangle large, Rectangle center)
 {
     // given a large rectangle and a center which guaranteed to be a subset of
     // the large rect, the task is to split "large" into pieces and insert them
@@ -79,63 +41,64 @@ static RectList* insert_rect_border(RectList* head,
     // |------+--------+-------|
     // |        bottom         |
     // +-----------------------+
-    RectList *top, *left, *right, *bottom;
     // coordinates of the bottom right corner of large
     int br_x = large.x + large.width, br_y = large.y + large.height;
-    RectList* (*r)(int,int,int,int) = rectlist_create_simple;
-    top   = r(large.x, large.y, large.x + large.width, center.y);
-    left  = r(large.x, center.y, center.x, center.y + center.height);
-    right = r(center.x + center.width, center.y, br_x, center.y + center.height);
-    bottom= r(large.x, center.y + center.height, br_x, br_y);
+    Rectangle (*r)(int,int,int,int) = Rectangle::fromCorners;
+    Rectangle top   = r(large.x, large.y, large.x + large.width, center.y);
+    Rectangle left  = r(large.x, center.y, center.x, center.y + center.height);
+    Rectangle right = r(center.x + center.width, center.y, br_x, center.y + center.height);
+    Rectangle bottom= r(large.x, center.y + center.height, br_x, br_y);
 
-    RectList* parts[] = { top, left, right, bottom };
-    for (unsigned int i = 0; i < LENGTH(parts); i++) {
-        head = reclist_insert_disjoint(head, parts[i]);
+    RectangleVec parts = { top, left, right, bottom };
+    RectangleVec res;
+    for (auto& rect : parts ) {
+        if (rect.width <= 0 || rect.height <= 0) {
+            continue;
+        }
+        res.push_back(rect);
     }
-    return head;
-}
-
-// insert a new element without any intersections into the given list
-RectList* reclist_insert_disjoint(RectList* head, RectList* element) {
-    if (!element) {
-        return head;
-    } else if (!head) {
-        // if the list is empty, then intersection-free insertion is trivial
-        element->next = nullptr;
-        return element;
-    } else if (!rects_intersect(head->rect, element->rect)) {
-        head->next = reclist_insert_disjoint(head->next, element);
-        return head;
-    } else {
-        // element intersects with the head rect
-        auto center = intersection_area(head->rect, element->rect);
-        auto large = head->rect;
-        head->rect = center;
-        head->next = insert_rect_border(head->next, large, center);
-        head->next = insert_rect_border(head->next, element->rect, center);
-        g_free(element);
-        return head;
-    }
+    return res;
 }
 
 RectangleVec disjoin_rects(const RectangleVec &buf) {
-    RectList* cur;
-    struct RectList* rects = nullptr;
-    for (auto& rect : buf) {
-        cur = g_new0(RectList, 1);
-        cur->rect = rect;
-        rects = reclist_insert_disjoint(rects, cur);
+    std::queue<Rectangle> q; // rectangles not inserted yet
+    for (const auto& r : buf) {
+        q.push(r);
     }
-    cur = rects;
-    RectangleVec ret(rectlist_length(rects));
-    FOR (i,0,ret.size()) {
-        ret[i] = cur->rect;
-        cur = cur->next;
+    RectangleVec result; // rectangles that are disjoint
+    while (!q.empty()) {
+        auto rectToInsert = q.front();
+        q.pop();
+        // find some rectangle in 'result' that intersects with rectToInsert
+        size_t i;
+        for (i = 0; i < result.size(); i++) {
+            if (rects_intersect(result[i], rectToInsert)) {
+                break;
+            }
+        }
+        if (i >= result.size()) {
+            // no intersection means, we can insert it without any issue
+            result.push_back(rectToInsert);
+        } else {
+            // if there's an intersection
+            Rectangle center = intersection_area(result[i], rectToInsert);
+            // then cut both rectangles into pieces according to the intersection:
+            // 1. all rectangles of 'result' are invariantly disjoint, and so we can add them
+            // to the result
+            for (const auto& r : disjoin_from_subset(result[i], center)) {
+                result.push_back(r);
+            }
+            // and we can replace result[i] by the intersection
+            result[i] = center;
+            // 2. the other pieces of rectToInsert possibly intersect with other rectangles,
+            // so process them later
+            for (const auto& r : disjoin_from_subset(rectToInsert, center)) {
+                q.push(r);
+            }
+        }
     }
-    rectlist_free(rects);
-    return ret;
+    return result;
 }
-/* end of TODO to remove RectList */
 
 int disjoin_rects_command(Input input, Output output) {
     if (input.empty()) {

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -81,6 +81,15 @@ Rectangle Rectangle::fromStr(const string &source) {
     };
 }
 
+Rectangle Rectangle::fromCorners(int x1, int y1, int x2, int y2) {
+    Rectangle r;
+    r.x = x1;
+    r.y = y1;
+    r.width  = x2 - x1;
+    r.height = y2 - y1;
+    return r;
+}
+
 Rectangle Rectangle::adjusted(int dx, int dy) const
 {
     return adjusted(dx, dy, dx, dy);

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -64,6 +64,8 @@ struct Point2D {
 struct Rectangle {
     static Rectangle fromStr(const std::string &source);
 
+    static Rectangle fromCorners(int x1, int y1, int x2, int y2);
+
     Point2D tl() const { return {x, y}; }
     Point2D br() const { return {x + width, y + height}; }
 


### PR DESCRIPTION
This drops the glib dependency in rectangle.cpp. The new algorithm is
much different than the original code, but makes the whole algorithm
simpler, shorter, and hopefully much easier to read.