### PR TITLE
ClientManager: Use fwd decl of HSTag, drop include

### DIFF
--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -4,15 +4,15 @@
 #include <X11/X.h>
 #include <unordered_map>
 
-#include "client.h"
 #include "link.h"
 #include "object.h"
 #include "signal.h"
 
-class Theme;
 class Client;
-class Settings;
 class Completion;
+class HSTag;
+class Settings;
+class Theme;
 
 // Note: this is basically a singleton
 

--- a/src/keymanager.cpp
+++ b/src/keymanager.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "arglist.h"
+#include "client.h"
 #include "clientmanager.h"
 #include "command.h"
 #include "completion.h"


### PR DESCRIPTION
In clientmanager.h, only a fwd decl of HSTag is required, instead of a
full include of client.h.

Removing the include uncovers a missing include of client.h in
keymanager.cpp, which is added.