### PR TITLE
rulemanager.cpp: Use <string> instead of <cstring>

### DIFF
--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -1,6 +1,6 @@
 #include "rulemanager.h"
 
-#include <cstring>
+#include <string>
 
 #include "completion.h"
 #include "ipc-protocol.h"


### PR DESCRIPTION
There is no C-style string handling in this file anymore, but
std::string is used.