### PR TITLE
x11-types.cpp: Drop unused <cstdio> and <iostream>

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
 #include <sstream>
 
 #include "client.h"

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -4,9 +4,7 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <cassert>
-#include <cstdio>
 #include <iomanip>
-#include <iostream>
 
 #include "glib-backports.h"
 #include "globals.h"

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -2,7 +2,6 @@
 #define __HERBST_X11_TYPES_H_
 
 #include <X11/Xlib.h>
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Removing these reveals that main.cpp is missing an include of
<iostream>, which is added.