### PR TITLE
Drop some unused #include "glib-backports.h"

### DIFF
--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -1,6 +1,7 @@
 #include "floating.h"
 
 #include <algorithm>
+#include <climits>
 #include <cstdlib>
 
 #include "client.h"

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1,6 +1,5 @@
 #include "layout.h"
 
-#include <glib.h>
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
@@ -11,7 +10,6 @@
 #include "client.h"
 #include "floating.h"
 #include "frametree.h" // TODO: remove this dependency!
-#include "glib-backports.h"
 #include "globals.h"
 #include "ipc-protocol.h"
 #include "monitor.h"

--- a/src/layout.h
+++ b/src/layout.h
@@ -6,7 +6,6 @@
 #include <functional>
 #include <memory>
 
-#include "glib-backports.h"
 #include "tilingresult.h"
 #include "types.h"
 #include "x11-types.h"

--- a/src/tag.h
+++ b/src/tag.h
@@ -4,7 +4,6 @@
 #include <memory>
 
 #include "attribute_.h"
-#include "glib-backports.h"
 #include "object.h"
 
 #define TAG_SET_FLAG(tag, flag) \

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -6,7 +6,6 @@
 #include <cassert>
 #include <iomanip>
 
-#include "glib-backports.h"
 #include "globals.h"
 
 using std::string;


### PR DESCRIPTION
Removing these reveals that floating.cpp is missing an include of
<climits>, which is added.