### PR TITLE
Add mitigations against killing all clients on :0

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -399,8 +399,8 @@ def hlwm_process(tmpdir):
     assert env['DISPLAY'] != ':0', 'Refusing to run tests on display that might be your actual X server (not Xvfb)'
 
     # env['DISPLAY'] = ':13'
-    kill_all_existing_windows(show_warnings=True)
     hlwm_proc = HlwmProcess(tmpdir, env)
+    kill_all_existing_windows(show_warnings=True)
 
     yield hlwm_proc
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,6 +396,8 @@ def hlwm_process(tmpdir):
         'DISPLAY': os.environ['DISPLAY'],
         'XDG_CONFIG_HOME': str(tmpdir),
     }
+    assert env['DISPLAY'] != ':0', 'Refusing to run tests on display that might be your actual X server (not Xvfb)'
+
     # env['DISPLAY'] = ':13'
     kill_all_existing_windows(show_warnings=True)
     hlwm_proc = HlwmProcess(tmpdir, env)


### PR DESCRIPTION
Turns out that just running "pytest" in the repository root happily
starts the tests, which kills all your existing windows.

To mitigate this, this adds a sanity check for $DISPLAY and changes
the startup order so that hlwm *should* refuse to launch due to the
already-running WM.