### PR TITLE
ci-build.py: Always clear pytest cache

### DIFF
--- a/ci-build.py
+++ b/ci-build.py
@@ -87,7 +87,7 @@ if args.flake8:
     tox('-e flake8', build_dir)
 
 if args.run_tests:
-    tox('-e py37 -- -n auto -v -x', build_dir)
+    tox('-e py37 -- -n auto --cache-clear -v -x', build_dir)
 
     sp.check_call('lcov --capture --directory . --output-file coverage.info', shell=True, cwd=build_dir)
     sp.check_call('lcov --remove coverage.info "/usr/*" --output-file coverage.info', shell=True, cwd=build_dir)


### PR DESCRIPTION
Sometimes (but apparently not always), the pytest cache location happens
to be subdirectory of .tox/. To ensure that the pytest cache is not
persisted across builds (as .tox/ is) we always pass --cache-clear to
pytest.