### PR TITLE
Fix includes in stack.h (drop memory, add set)

### DIFF
--- a/src/stack.h
+++ b/src/stack.h
@@ -3,7 +3,7 @@
 
 #include <X11/X.h>
 #include <array>
-#include <memory>
+#include <set>
 #include <vector>
 
 #include "types.h"


### PR DESCRIPTION
<memory> (things like shared_ptr) is not used, but <set> is.