### PR TITLE
CodeCov: Disable PR status checks for now

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,12 @@
 coverage:
     precision: 1
 
+    # Status reporting is disabled until we have fixed the flaky coverage
+    # (seems to be related to our completion tests):
+    status:
+        project: off
+        patch: off
+
 comment:
     layout: "diff"
     require_changes: yes


### PR DESCRIPTION
This is a rather new feature, but not yet very helpful because of our
known issues with flaky coverage.