### PR TITLE
Avoid iwyu fix_include output for unchanged files

### DIFF
--- a/ci-build.py
+++ b/ci-build.py
@@ -80,11 +80,14 @@ if args.ccache:
 
 if args.iwyu:
     # Check lexicographical order of #include directives (cheap pre-check)
-    fix_include = sp.run('fix_include --dry_run --sort_only --reorder /hlwm/*/*.{h,cpp,c}', shell=True, executable='bash', stdout=sp.PIPE, check=True)
+    fix_include = sp.run('fix_include --dry_run --sort_only --reorder /hlwm/*/*.{h,cpp,c}', shell=True, executable='bash', stdout=sp.PIPE)
     print(re.sub(
         r">>> Fixing #includes in '[^']*'[\n\r]*No changes in file [^\n\r]*[\n\r]*",
         '',
         fix_include.stdout.decode()))
+    if fix_include.returncode != 0:
+        print('IWYU/fix_include made suggestions, please fix them')
+        sys.exit(1)
 
     # Run include-what-you-use
     iwyu_out = sp.check_output(f'iwyu_tool -p . -j "$(nproc)" -- --transitive_includes_only --mapping_file=/hlwm/.hlwm.imp', shell=True, cwd=build_dir)

--- a/ci-build.py
+++ b/ci-build.py
@@ -84,7 +84,7 @@ if args.iwyu:
     print(re.sub(
         r">>> Fixing #includes in '[^']*'[\n\r]*No changes in file [^\n\r]*[\n\r]*",
         '',
-        fix_include.stdout))
+        fix_include.stdout.decode()))
 
     # Run include-what-you-use
     iwyu_out = sp.check_output(f'iwyu_tool -p . -j "$(nproc)" -- --transitive_includes_only --mapping_file=/hlwm/.hlwm.imp', shell=True, cwd=build_dir)

--- a/ci-build.py
+++ b/ci-build.py
@@ -80,7 +80,11 @@ if args.ccache:
 
 if args.iwyu:
     # Check lexicographical order of #include directives (cheap pre-check)
-    sp.check_call('fix_include --dry_run --sort_only --reorder /hlwm/*/*.{h,cpp,c}', shell=True, executable='bash')
+    fix_include = sp.run('fix_include --dry_run --sort_only --reorder /hlwm/*/*.{h,cpp,c}', shell=True, executable='bash', stdout=sp.PIPE, check=True)
+    print(re.sub(
+        r">>> Fixing #includes in '[^']*'[\n\r]*No changes in file [^\n\r]*[\n\r]*",
+        '',
+        fix_include.stdout))
 
     # Run include-what-you-use
     iwyu_out = sp.check_output(f'iwyu_tool -p . -j "$(nproc)" -- --transitive_includes_only --mapping_file=/hlwm/.hlwm.imp', shell=True, cwd=build_dir)


### PR DESCRIPTION
Filter the output of fix_include by removing messages
of the pattern:

    >>> Fixing #includes in 'somefilename.cpp'
    No changes in file somefilename.cpp

This uses subprocess.run because the documentation of subprocess.check_call
says that it should not be combined with piped stdout (stdout=subprocess.PIPE).
