### PR TITLE
Avoid wireAttributes() in Client

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -36,24 +36,22 @@ static Client* lastfocus = nullptr;
 
 
 Client::Client(Window window, bool visible_already, ClientManager& cm)
-    : window_(window),
-      dec(this, *cm.settings),
-      visible_(visible_already),
-      manager(cm),
-      theme(*cm.theme),
-      settings(*cm.settings)
+    : window_(window)
+    , dec(this, *cm.settings)
+    , visible_(visible_already)
+    , urgent_(this, "urgent", false)
+    , fullscreen_(this,  "fullscreen", false)
+    , title_(this,  "title", "")
+    , window_id_str(this,  "winid", "")
+    , keyMask_(this,  "keymask", "")
+    , pseudotile_(this,  "pseudotile", false)
+    , manager(cm)
+    , theme(*cm.theme)
+    , settings(*cm.settings)
 {
     std::stringstream tmp;
     tmp << "0x" << std::hex << window;
     window_id_str = tmp.str();
-    wireAttributes({
-        &title_,
-        &fullscreen_,
-        &urgent_,
-        &window_id_str,
-        &keyMask_,
-        &pseudotile_,
-    });
     keyMask_.setWriteable();
     for (auto i : {&fullscreen_, &pseudotile_}) {
         i->setWriteable();

--- a/src/client.h
+++ b/src/client.h
@@ -22,24 +22,12 @@ public:
 
     Window      window_;
     Decoration  dec;
-    Rectangle   float_size_ = {0, 0, 100, 100};     // floating size without the window border
-    Attribute_<bool> urgent_ = {"urgent", false};
-    Attribute_<bool> fullscreen_ = {"fullscreen", false};
-    Attribute_<std::string> title_ = {"title", {}};  // or also called window title; this is never NULL
-    Slice* slice = {};
     Rectangle   last_size_;      // last size excluding the window border
-    Attribute_<std::string> window_id_str = {"winid", {}};
-
+    Rectangle   float_size_ = {0, 0, 100, 100};     // floating size without the window border
     HSTag*      tag_ = {};
-    Attribute_<
-    std::string> keyMask_ = {"keymask", {}}; // keymask applied to mask out keybindins
+    Slice* slice = {};
     bool        ewmhfullscreen_ = false; // ewmh fullscreen state
-    Attribute_<bool> pseudotile_ = {"pseudotile", false}; // only move client but don't resize (if possible)
     bool        neverfocus_ = false; // do not give the focus via XSetInputFocus
-    bool        ewmhrequests_ = true; // accept ewmh-requests for this client
-    bool        ewmhnotify_ = true; // send ewmh-notifications for this client
-    bool        sizehints_floating_ = true;  // respect size hints regarding this client in floating mode
-    bool        sizehints_tiling_ = false;  // respect size hints regarding this client in tiling mode
     bool        visible_;
     bool        dragged_ = false;  // if this client is dragged currently
     int         pid_;
@@ -51,6 +39,21 @@ public:
     int basew_, baseh_, incw_, inch_, maxw_, maxh_, minw_, minh_;
     // for other modules
     Signal_<HSTag*> needsRelayout;
+
+    // attributes:
+    Attribute_<bool> urgent_;
+    Attribute_<bool> fullscreen_;
+    Attribute_<std::string> title_;  // or also called window title; this is never NULL
+    Attribute_<std::string> window_id_str;
+
+    Attribute_<std::string> keyMask_; // keymask applied to mask out keybindins
+    Attribute_<bool> pseudotile_; // only move client but don't resize (if possible)
+    bool        ewmhrequests_ = true; // accept ewmh-requests for this client
+    bool        ewmhnotify_ = true; // send ewmh-notifications for this client
+    bool        sizehints_floating_ = true;  // respect size hints regarding this client in floating mode
+    bool        sizehints_tiling_ = false;  // respect size hints regarding this client in tiling mode
+
+public:
     void init_from_X();
 
     void make_full_client();


### PR DESCRIPTION
Also, group attributes together (even though some of them are not
attributes in winterbreeze yet, but only in master)