### PR TITLE
Use right value for error message in set_attr

### DIFF
--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -44,7 +44,7 @@ int RootCommands::set_attr_cmd(Input in, Output output) {
         return 0;
     } else {
         output << in.command() << ": \""
-            << in.front() << "\" is not a valid value for "
+            << new_value << "\" is not a valid value for "
             << a->name() << ": "
             << error_message << endl;
         return HERBST_INVALID_ARGUMENT;

--- a/tests/test_root_commands.py
+++ b/tests/test_root_commands.py
@@ -69,6 +69,11 @@ def test_attr_only_second_argument_if_writable(hlwm):
         .returncode == 7
 
 
+def test_set_attr_can_not_set_writable(hlwm):
+    assert hlwm.call_xfail_no_output('set_attr tags.count 5') \
+        .returncode == 3
+
+
 def test_substitute_missing_attribute__command_treated_as_attribute(hlwm):
     call = hlwm.call_xfail('substitute X echo X')
 


### PR DESCRIPTION
Writing a read-only attribute via set_attr led to a crash because
the wrong variable is used when creating the error message.