### PR TITLE
Let call_xfail_no_output() assert no output

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,7 @@ class HlwmBridge:
     def call_xfail_no_output(self, cmd):
         proc = self.unchecked_call(cmd)
         assert proc.returncode != 0
+        assert proc.stderr == ""
         return proc
 
     def get_attr(self, attribute_path, check=True):

--- a/tests/test_root_commands.py
+++ b/tests/test_root_commands.py
@@ -70,7 +70,7 @@ def test_attr_only_second_argument_if_writable(hlwm):
 
 
 def test_set_attr_can_not_set_writable(hlwm):
-    assert hlwm.call_xfail_no_output('set_attr tags.count 5') \
+    assert hlwm.call_xfail('set_attr tags.count 5') \
         .returncode == 3
 
 


### PR DESCRIPTION
In call_xfail_no_output(), assert that the command has indeed no
output. I think the former reading of the command name was "make
no assertion about the output".