### PR TITLE
Replace plain enum with SplitAlign enum class

### DIFF
--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -52,7 +52,7 @@ void FrameTree::dump(shared_ptr<HSFrame> frame, Output output)
             << LAYOUT_DUMP_BRACKETS[0]
             << "split"
             << LAYOUT_DUMP_WHITESPACES[0]
-            << g_align_names[s->align_]
+            << g_align_names[(int)s->align_]
             << LAYOUT_DUMP_SEPARATOR
             << ((double)s->fraction_) / (double)FRACTION_UNIT
             << LAYOUT_DUMP_SEPARATOR
@@ -194,11 +194,11 @@ int FrameTree::rotateCommand() {
     void (*onSplit)(HSFrameSplit*) =
         [] (HSFrameSplit* s) {
             switch (s->align_) {
-                case ALIGN_VERTICAL:
-                    s->align_ = ALIGN_HORIZONTAL;
+                case SplitAlign::vertical:
+                    s->align_ = SplitAlign::horizontal;
                     break;
-                case ALIGN_HORIZONTAL:
-                    s->align_ = ALIGN_VERTICAL;
+                case SplitAlign::horizontal:
+                    s->align_ = SplitAlign::vertical;
                     s->selection_ = s->selection_ ? 0 : 1;
                     swap(s->a_, s->b_);
                     s->fraction_ = FRACTION_UNIT - s->fraction_;
@@ -252,7 +252,7 @@ shared_ptr<TreeInterface> FrameTree::treeInterface(
         }
         size_t childCount() override { return 2; };
         void appendCaption(Output output) override {
-            output << " " << g_align_names[s_->align_]
+            output << " " << g_align_names[(int)s_->align_]
                    << " " << (s_->fraction_ * 100 / FRACTION_UNIT) << "%"
                    << " selection=" << s_->selection_;
         }

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -63,7 +63,7 @@ HSFrameLeaf::HSFrameLeaf(HSTag* tag, Settings* settings, weak_ptr<HSFrameSplit> 
     decoration = new FrameDecoration(tag, settings);
 }
 
-HSFrameSplit::HSFrameSplit(HSTag* tag, Settings* settings, weak_ptr<HSFrameSplit> parent, int fraction, int align,
+HSFrameSplit::HSFrameSplit(HSTag* tag, Settings* settings, weak_ptr<HSFrameSplit> parent, int fraction, SplitAlign align,
                  shared_ptr<HSFrame> a, shared_ptr<HSFrame> b)
              : HSFrame(tag, settings, parent) {
     this->align_ = align;
@@ -391,11 +391,11 @@ TilingResult HSFrameLeaf::computeLayout(Rectangle rect) {
 TilingResult HSFrameSplit::computeLayout(Rectangle rect) {
     auto first = rect;
     auto second = rect;
-    if (align_ == ALIGN_VERTICAL) {
+    if (align_ == SplitAlign::vertical) {
         first.height = (rect.height * fraction_) / FRACTION_UNIT;
         second.y += first.height;
         second.height -= first.height;
-    } else { // (align == ALIGN_HORIZONTAL)
+    } else { // (align == SplitAlign::horizontal)
         first.width = (rect.width * fraction_) / FRACTION_UNIT;
         second.x += first.width;
         second.width -= first.width;
@@ -469,11 +469,11 @@ void HSFrameLeaf::setSelection(int index) {
     get_current_monitor()->applyLayout();
 }
 
-int HSFrame::splitsToRoot(int align) {
+int HSFrame::splitsToRoot(SplitAlign align) {
     if (!parent_.lock()) return 0;
     return parent_.lock()->splitsToRoot(align);
 }
-int HSFrameSplit::splitsToRoot(int align) {
+int HSFrameSplit::splitsToRoot(SplitAlign align) {
     if (!parent_.lock()) return 0;
     int delta = 0;
     if (this->align_ == align) delta = 1;
@@ -495,7 +495,7 @@ void HSFrameLeaf::addClients(const vector<Client*>& vec) {
     for (auto c : vec) clients.push_back(c);
 }
 
-bool HSFrameLeaf::split(int alignment, int fraction, size_t childrenLeaving) {
+bool HSFrameLeaf::split(SplitAlign alignment, int fraction, size_t childrenLeaving) {
     if (splitsToRoot(alignment) > HERBST_MAX_TREE_HEIGHT) {
         return false;
     }
@@ -533,7 +533,7 @@ int frame_split_command(Input input, Output output) {
         return HERBST_NEED_MORE_ARGS;
     }
     bool userDefinedFraction = input >> strFraction;
-    int align = -1;
+    SplitAlign align = SplitAlign::vertical;
     bool frameToFirst = true;
     double fractionFloat = userDefinedFraction ? atof(strFraction.c_str()) : 0.5;
     fractionFloat = CLAMP(fractionFloat, 0.0 + FRAME_MIN_FRACTION,
@@ -543,36 +543,42 @@ int frame_split_command(Input input, Output output) {
     auto cur_frame = HSFrame::getGloballyFocusedFrame();
     int lh = cur_frame->lastRect().height;
     int lw = cur_frame->lastRect().width;
-    int align_auto = (lw > lh) ? ALIGN_HORIZONTAL : ALIGN_VERTICAL;
+    SplitAlign align_auto = (lw > lh) ? SplitAlign::horizontal : SplitAlign::vertical;
+    SplitAlign align_explode = SplitAlign::vertical;
+    bool exploding = false;
     struct {
         const char* name;
-        int align;
+        SplitAlign align;
         bool frameToFirst;  // if former frame moves to first child
         int selection;      // which child to select after the split
     } splitModes[] = {
-        { "top",        ALIGN_VERTICAL,     false,  1   },
-        { "bottom",     ALIGN_VERTICAL,     true,   0   },
-        { "vertical",   ALIGN_VERTICAL,     true,   0   },
-        { "right",      ALIGN_HORIZONTAL,   true,   0   },
-        { "horizontal", ALIGN_HORIZONTAL,   true,   0   },
-        { "left",       ALIGN_HORIZONTAL,   false,  1   },
-        { "explode",    ALIGN_EXPLODE,      true,   0   },
-        { "auto",       align_auto,         true,   0   },
+        { "top",        SplitAlign::vertical,     false,  1   },
+        { "bottom",     SplitAlign::vertical,     true,   0   },
+        { "vertical",   SplitAlign::vertical,     true,   0   },
+        { "right",      SplitAlign::horizontal,   true,   0   },
+        { "horizontal", SplitAlign::horizontal,   true,   0   },
+        { "left",       SplitAlign::horizontal,   false,  1   },
+        { "explode",    align_explode,            true,   0   },
+        { "auto",       align_auto,               true,   0   },
     };
+    bool found = false;
     for (auto &m : splitModes) {
         if (m.name[0] == splitType[0]) {
             align           = m.align;
             frameToFirst    = m.frameToFirst;
             selection       = m.selection;
+            found = true;
+            if (string(m.name) == "explode") {
+                exploding = true;
+            }
             break;
         }
     }
-    if (align < 0) {
+    if (!found) {
         output << input.command() << ": Invalid alignment \"" << splitType << "\"\n";
         return HERBST_INVALID_ARGUMENT;
     }
     auto frame = HSFrame::getGloballyFocusedFrame();
-    bool exploding = align == ALIGN_EXPLODE;
     int layout = frame->getLayout();
     auto windowcount = frame->clientCount();
     if (exploding) {
@@ -581,11 +587,11 @@ int frame_split_command(Input input, Output output) {
         } else if (layout == LAYOUT_MAX) {
             align = align_auto;
         } else if (layout == LAYOUT_GRID && windowcount == 2) {
-            align = ALIGN_HORIZONTAL;
+            align = SplitAlign::horizontal;
         } else if (layout == LAYOUT_HORIZONTAL) {
-            align = ALIGN_HORIZONTAL;
+            align = SplitAlign::horizontal;
         } else {
-            align = ALIGN_VERTICAL;
+            align = SplitAlign::vertical;
         }
         size_t count1 = frame->clientCount();
         size_t nc1 = (count1 + 1) / 2;      // new count for the first frame
@@ -676,28 +682,28 @@ shared_ptr<HSFrame> HSFrameLeaf::neighbour(Direction direction) {
         // selection in the desired direction
         switch(direction) {
             case Direction::Right:
-                if (frame->getAlign() == ALIGN_HORIZONTAL
+                if (frame->getAlign() == SplitAlign::horizontal
                     && frame->firstChild() == child) {
                     found = true;
                     other = frame->secondChild();
                 }
                 break;
             case Direction::Left:
-                if (frame->getAlign() == ALIGN_HORIZONTAL
+                if (frame->getAlign() == SplitAlign::horizontal
                     && frame->secondChild() == child) {
                     found = true;
                     other = frame->firstChild();
                 }
                 break;
             case Direction::Down:
-                if (frame->getAlign() == ALIGN_VERTICAL
+                if (frame->getAlign() == SplitAlign::vertical
                     && frame->firstChild() == child) {
                     found = true;
                     other = frame->secondChild();
                 }
                 break;
             case Direction::Up:
-                if (frame->getAlign() == ALIGN_VERTICAL
+                if (frame->getAlign() == SplitAlign::vertical
                     && frame->secondChild() == child) {
                     found = true;
                     other = frame->firstChild();

--- a/src/layout.h
+++ b/src/layout.h
@@ -15,11 +15,9 @@
 #define LAYOUT_DUMP_SEPARATOR_STR ":" /* must be a string with one char */
 #define LAYOUT_DUMP_SEPARATOR LAYOUT_DUMP_SEPARATOR_STR[0]
 
-enum {
-    ALIGN_VERTICAL = 0,
-    ALIGN_HORIZONTAL,
-    // temporary values in split_command
-    ALIGN_EXPLODE,
+enum class SplitAlign {
+    vertical = 0,
+    horizontal,
 };
 
 enum {
@@ -77,7 +75,7 @@ public:
     std::shared_ptr<HSFrameSplit> getParent() { return parent_.lock(); };
     std::shared_ptr<HSFrame> root();
     // count the number of splits to the root with alignment "align"
-    virtual int splitsToRoot(int align);
+    virtual int splitsToRoot(SplitAlign align);
 
     HSTag* getTag() { return tag_; };
 
@@ -138,7 +136,7 @@ public:
 
     Client* focusedClient() override;
 
-    bool split(int alignment, int fraction, size_t childrenLeaving = 0);
+    bool split(SplitAlign alignment, int fraction, size_t childrenLeaving = 0);
     int getLayout() { return layout; }
     void setLayout(int l) { layout = l; }
     int getSelection() { return selection; }
@@ -173,7 +171,7 @@ private:
 
 class HSFrameSplit : public HSFrame {
 public:
-    HSFrameSplit(HSTag* tag, Settings* settings, std::weak_ptr<HSFrameSplit> parent, int fraction_, int align_,
+    HSFrameSplit(HSTag* tag, Settings* settings, std::weak_ptr<HSFrameSplit> parent, int fraction_, SplitAlign align_,
                  std::shared_ptr<HSFrame> a_, std::shared_ptr<HSFrame> b_);
     ~HSFrameSplit() override;
     // inherited:
@@ -188,7 +186,7 @@ public:
     Client* focusedClient() override;
 
     // own members
-    int splitsToRoot(int align_) override;
+    int splitsToRoot(SplitAlign align_) override;
     void replaceChild(std::shared_ptr<HSFrame> old, std::shared_ptr<HSFrame> newchild);
     std::shared_ptr<HSFrame> firstChild() { return a_; }
     std::shared_ptr<HSFrame> secondChild() { return b_; }
@@ -197,12 +195,12 @@ public:
     void adjustFraction(int delta);
     std::shared_ptr<HSFrameSplit> thisSplit();
     std::shared_ptr<HSFrameSplit> isSplit() override { return thisSplit(); }
-    int getAlign() { return align_; }
+    SplitAlign getAlign() { return align_; }
     void swapSelection() { selection_ = 1 - selection_; }
     void setSelection(int s) { selection_ = s; }
 private:
     friend class FrameTree;
-    int align_;         // ALIGN_VERTICAL or ALIGN_HORIZONTAL
+    SplitAlign align_;
     std::shared_ptr<HSFrame> a_; // first child
     std::shared_ptr<HSFrame> b_; // second child
 


### PR DESCRIPTION
This also drops ALIGN_EXPLODE in favor of a temporary variable in the
split command handler.