### PR TITLE
Allow the monitor name to be empty

### DIFF
--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -256,9 +256,14 @@ int MonitorManager::addMonitor(Input input, Output output)
     // TODO: error message on invalid rectString
     auto rect = Rectangle::fromStr(rectString);
     if (input >> monitorName) {
-        auto error = isValidMonitorName(monitorName);
+        string error;
+        if (monitorName.empty()) {
+            error = "An empty monitor name is not permitted";
+        } else {
+            error = isValidMonitorName(monitorName);
+        }
         if (error != "") {
-            output << input.command() << ": " << error;
+            output << input.command() << ": " << error << "\n";
             return HERBST_INVALID_ARGUMENT;
         }
     }
@@ -277,13 +282,10 @@ int MonitorManager::addMonitor(Input input, Output output)
 
 string MonitorManager::isValidMonitorName(string name) {
     if (isdigit(name[0])) {
-        return "Invalid name \"" + name + "\": The monitor name may not start with a number\n";
-    }
-    if (name.empty()) {
-        return "An empty monitor name is not permitted\n";
+        return "Invalid name \"" + name + "\": The monitor name may not start with a number";
     }
     if (find_monitor_by_name(name.c_str())) {
-        return "A monitor with the name \"" + name + "\" already exists\n";
+        return "A monitor with the name \"" + name + "\" already exists";
     }
     return "";
 }

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -106,3 +106,19 @@ def test_detect_monitors_does_not_crash(hlwm):
     # I don't know how to test detect_monitors properly, so just check that
     # it does not crash at least
     hlwm.call('detect_monitors')
+
+
+def test_rename_monitor(hlwm):
+    hlwm.call('rename_monitor 0 foo')
+
+    assert hlwm.get_attr('monitors.focus.name') == 'foo'
+    assert hlwm.list_children('monitors.by-name') == ['foo']
+
+
+def test_rename_monitor_no_name(hlwm):
+    hlwm.call('rename_monitor 0 foo')
+
+    hlwm.call('rename_monitor foo ""')
+
+    assert hlwm.get_attr('monitors.focus.name') == ''
+    assert hlwm.list_children('monitors.by-name') == []


### PR DESCRIPTION
Monitor names are optional and a monitor with no name has the name
attribute empty. Only for add_monitor, it is not permitted to pass an
empty monitor name.

This is the current behaviour in master.