### PR TITLE
Update Mergify config to work with travis-ci.com

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
     - name: automatic merge on CI success and review
       conditions:
           - base=winterbreeze
-          - status-success=continuous-integration/travis-ci/pr
+          - status-success="Travis CI - Pull Request"
           - "#approved-reviews-by>=1"
       actions:
           merge:


### PR DESCRIPTION
On travis-ci.com, the PR status check appears to have a different "name"
than on travis-ci.org. Changing it like this might help.