### PR TITLE
Remove hook_emit_list

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -172,7 +172,7 @@ void Client::window_unfocus_last() {
     XSetInputFocus(g_display, g_root, RevertToPointerRoot, CurrentTime);
     if (lastfocus) {
         /* only emit the hook if the focus *really* changes */
-        hook_emit_list("focus_changed", "0x0", "", nullptr);
+        hook_emit({"focus_changed", "0x0", ""});
         Ewmh::get().updateActiveWindow(None);
         tag_update_each_focus_layer();
 
@@ -203,7 +203,7 @@ void Client::window_focus() {
         const char* title = this->title_().c_str();
         char winid_str[STRING_BUF_SIZE];
         snprintf(winid_str, STRING_BUF_SIZE, "0x%x", (unsigned int)this->window_);
-        hook_emit_list("focus_changed", winid_str, title, nullptr);
+        hook_emit({"focus_changed", winid_str, title});
     }
 
     // change window-colors
@@ -495,7 +495,7 @@ void Client::set_urgent(bool state) {
 void Client::set_urgent_force(bool state) {
     char winid_str[STRING_BUF_SIZE];
     snprintf(winid_str, STRING_BUF_SIZE, "0x%lx", this->window_);
-    hook_emit_list("urgent", state ? "on" : "off", winid_str, nullptr);
+    hook_emit({"urgent", state ? "on" : "off", winid_str});
 
     this->urgent_ = state;
 
@@ -537,7 +537,7 @@ void Client::update_wm_hints() {
             char winid_str[STRING_BUF_SIZE];
             snprintf(winid_str, STRING_BUF_SIZE, "0x%lx", this->window_);
             this->setup_border(focused_client == this);
-            hook_emit_list("urgent", this->urgent_() ? "on":"off", winid_str, nullptr);
+            hook_emit({"urgent", this->urgent_() ? "on":"off", winid_str});
             tag_set_flags_dirty();
         }
     }
@@ -570,7 +570,7 @@ void Client::update_title() {
     if (changed && get_current_client() == this) {
         char buf[STRING_BUF_SIZE];
         snprintf(buf, STRING_BUF_SIZE, "0x%lx", this->window_);
-        hook_emit_list("window_title_changed", buf, this->title_().c_str(), nullptr);
+        hook_emit({"window_title_changed", buf, this->title_()});
     }
 }
 
@@ -601,7 +601,7 @@ void Client::set_fullscreen(bool state) {
     char buf[STRING_BUF_SIZE];
     snprintf(buf, STRING_BUF_SIZE, "0x%lx", this->window_);
     ewmh.updateWindowState(this);
-    hook_emit_list("fullscreen", state ? "on" : "off", buf, nullptr);
+    hook_emit({"fullscreen", state ? "on" : "off", buf});
 }
 
 void Client::updateEwmhState() {

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -4,7 +4,6 @@
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
-#include <stdarg.h>
 #include <cassert>
 #include <cstdio>
 

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -69,19 +69,3 @@ void emit_tag_changed(HSTag* tag, int monitor) {
     hook_emit({"tag_changed", tag->name->c_str(), monitor_name});
 }
 
-void hook_emit_list(const char* name, ...) {
-    assert(name != nullptr);
-    vector<string> args;
-    va_list ap;
-    va_start(ap, name);
-    while (true) {
-        const char* next = va_arg(ap, const char*);
-        if (!next) {
-            break;
-        }
-        args.push_back(next);
-    }
-    va_end(ap);
-    hook_emit(args);
-}
-

--- a/src/hook.h
+++ b/src/hook.h
@@ -26,7 +26,6 @@ void hook_destroy();
 
 void hook_emit(std::vector<std::string> args);
 void emit_tag_changed(HSTag* tag, int monitor);
-void hook_emit_list(const char* name, ...);
 
 #endif
 

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -135,7 +135,7 @@ void tag_update_flags() {
 
 void tag_set_flags_dirty() {
     g_tag_flags_dirty = true;
-    hook_emit_list("tag_flags", nullptr);
+    hook_emit({"tag_flags"});
 }
 
 HSTag* find_tag_with_toplevel_frame(HSFrame* frame) {

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -74,7 +74,7 @@ int TagManager::tag_add_command(Input input, Output output) {
         return HERBST_INVALID_ARGUMENT;
     }
     HSTag* tag = add_tag(input.front());
-    hook_emit_list("tag_added", tag->name->c_str(), nullptr);
+    hook_emit({"tag_added", tag->name});
     return 0;
 }
 
@@ -137,7 +137,7 @@ int TagManager::removeTag(Input input, Output output) {
     Ewmh::get().updateDesktops();
     Ewmh::get().updateDesktopNames();
     tag_set_flags_dirty();
-    hook_emit_list("tag_removed", removedName.c_str(), targetTag->name->c_str(), nullptr);
+    hook_emit({"tag_removed", removedName, targetTag->name()});
 
     return HERBST_EXIT_SUCCESS;
 }
@@ -162,7 +162,7 @@ int TagManager::tag_rename_command(Input input, Output output) {
     }
     tag->name = new_name;
     Ewmh::get().updateDesktopNames();
-    hook_emit_list("tag_renamed", new_name.c_str(), nullptr);
+    hook_emit({"tag_renamed", new_name});
     return 0;
 }
 


### PR DESCRIPTION
Passing multiple parameters via a vector/initializer list is shorter,
more type safe, and makes it easier to pass std::string.