### PR TITLE
Make IpcServer the counterpart of ipc-client.h

### DIFF
--- a/src/ipc-server.cpp
+++ b/src/ipc-server.cpp
@@ -4,7 +4,6 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <cstdio>
-#include <sstream>
 
 #include "ipc-protocol.h"
 #include "xconnection.h"

--- a/src/ipc-server.cpp
+++ b/src/ipc-server.cpp
@@ -68,7 +68,7 @@ bool IpcServer::handleConnection(Window win, CallHandler callback) {
     const string& output = result.second;
     // Mark this command as executed
     XDeleteProperty(X.display(), win, X.atom(HERBST_IPC_ARGS_ATOM));
-    X.setPropertyString(win, X.atom(HERBST_IPC_OUTPUT_ATOM), output.str());
+    X.setPropertyString(win, X.atom(HERBST_IPC_OUTPUT_ATOM), output);
     // and also set the exit status
     XChangeProperty(X.display(), win, X.atom(HERBST_IPC_STATUS_ATOM),
         XA_ATOM, 32, PropModeReplace, (unsigned char*)&(status), 1);

--- a/src/ipc-server.h
+++ b/src/ipc-server.h
@@ -17,22 +17,20 @@ public:
     using CallHandler = std::function<std::pair<int,std::string>(const std::vector<std::string>&)>;
     IpcServer(XConnection& xconnection);
     ~IpcServer();
-    //! set a function that handle incoming calls. This callback
-    //must be set before addConnection() or handleConnection() is called!
-    void setCallHandler(CallHandler callback);
 
     //! check wether window is a ipc client window
     bool isConnectable(Window window);
-    //! listen for ipc requests on the given window
+    //! listen for ipc requests on the given window, but don't read them
+    //if there are requests already.
     void addConnection(Window win);
-    //! try to run an ipc request in the given window, return if there was one
-    bool handleConnection(Window window);
+    //! try to run an ipc request in the given window via the given callback,
+    //return if there was one
+    bool handleConnection(Window window, CallHandler callback);
     //! send a hook to all listening clients
     void emitHook(std::vector<std::string> args);
 
 private:
     XConnection& X;
-    CallHandler callHandler_;
 
     Window hookEventWindow_; //! window on which the hooks are announced
     int nextHookNumber_; //! index for the next hook

--- a/src/ipc-server.h
+++ b/src/ipc-server.h
@@ -4,8 +4,8 @@
 #include <X11/X.h>
 #include <functional>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 class XConnection;
 

--- a/src/ipc-server.h
+++ b/src/ipc-server.h
@@ -2,15 +2,24 @@
 #define __HERBSTLUFT_IPC_SERVER_H_
 
 #include <X11/X.h>
+#include <functional>
 #include <string>
 #include <vector>
+#include <utility>
 
 class XConnection;
 
 class IpcServer {
 public:
+    //! a callback that handles a call, represented by a vector of strings. The
+    // callback can produce some output and return a status code.
+    // This is the counterpart of hc_send_command() in ipc-client/ipc-client.h
+    using CallHandler = std::function<std::pair<int,std::string>(const std::vector<std::string>&)>;
     IpcServer(XConnection& xconnection);
     ~IpcServer();
+    //! set a function that handle incoming calls. This callback
+    //must be set before addConnection() or handleConnection() is called!
+    void setCallHandler(CallHandler callback);
 
     //! check wether window is a ipc client window
     bool isConnectable(Window window);
@@ -23,6 +32,7 @@ public:
 
 private:
     XConnection& X;
+    CallHandler callHandler_;
 
     Window hookEventWindow_; //! window on which the hooks are announced
     int nextHookNumber_; //! index for the next hook

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,6 @@
 #include <sys/select.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <vector>
 #include <cassert>
 #include <cerrno>
 #include <csignal>
@@ -13,6 +12,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <vector>
 
 #include "client.h"
 #include "clientmanager.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,7 +233,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
 }
 
 //! wrapper around Commands::call()
-static std::pair<int,std::string> callCommand(const vector<string>& call) {
+static pair<int,string> callCommand(const vector<string>& call) {
     // the call consists of the command and its arguments
     std::ostringstream output;
     auto input =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <sys/select.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <vector>
 #include <cassert>
 #include <cerrno>
 #include <csignal>
@@ -43,6 +44,7 @@ using std::pair;
 using std::shared_ptr;
 using std::string;
 using std::unique_ptr;
+using std::vector;
 
 // globals:
 int g_verbose = 0;
@@ -890,6 +892,17 @@ int main(int argc, char* argv[]) {
 
     init_handler_table();
     Commands::initialize(commands(root));
+    // now that we have initialized
+    ipcServer->setCallHandler([](const vector<string>& call) {
+        // the call consists of the command and its arguments
+        std::ostringstream output;
+        auto input =
+            (call.size() == 0)
+            ? Input("", call)
+            : Input(call[0], vector<string>(call.begin() + 1, call.end()));
+        int status = Commands::call(input, output);
+        return make_pair(status, output.str());
+    });
 
 
     // initialize subsystems


### PR DESCRIPTION
Make the interface of the IpcServer the precise counterpart of
ipc-client.h. This is also removes IpcServer's dependency on command.h.
Now, the IpcServer calls a callback for each request received from a
(herbst-)client. The result of the callback is then sent back to the
(herbst-)client.

Formerly, the IpcServer called a function from command.h directly. Now, the
only in-project dependencies of IpcServer are ipc-protocol.h and xconnection.h.
