### PR TITLE
Wrapper for XChangeProperty for type = XA_CARDINAL

### DIFF
--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -210,8 +210,8 @@ void Ewmh::removeClient(Window win) {
 }
 
 void Ewmh::updateDesktops() {
-    int cnt = tag_get_count();
-    X_.setPropertyCardinal(X_.root(), g_netatom[NetNumberOfDesktops], { cnt });
+    X_.setPropertyCardinal(X_.root(), g_netatom[NetNumberOfDesktops],
+                           { (long) root_->tags->size() });
 }
 
 void Ewmh::updateDesktopNames() {
@@ -456,8 +456,8 @@ void Ewmh::setWindowOpacity(Window win, double opacity) {
 }
 
 void Ewmh::updateFrameExtents(Window win, int left, int right, int top, int bottom) {
-    vector<long> extents = { left, right, top, bottom };
-    X_.setPropertyCardinal(win, g_netatom[NetFrameExtents], extents);
+    X_.setPropertyCardinal(win, g_netatom[NetFrameExtents],
+                           { left, right, top, bottom });
 }
 
 void Ewmh::windowUpdateWmState(Window win, WmState state) {

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -110,9 +110,7 @@ Ewmh::Ewmh(XConnection& xconnection)
         XA_WINDOW, 32, PropModeReplace, (unsigned char*)&(g_wm_window), 1);
 
     /* init atoms that never change */
-    vector<long> buf{ 0, 0 };
-    XChangeProperty(X_.display(), X_.root(), g_netatom[NetDesktopViewport],
-        XA_CARDINAL, 32, PropModeReplace, (unsigned char*)&buf.front(), buf.size());
+    X_.setPropertyCardinal(X_.root(), g_netatom[NetDesktopViewport], {0, 0});
 }
 
 void Ewmh::injectDependencies(Root* root) {
@@ -213,8 +211,7 @@ void Ewmh::removeClient(Window win) {
 
 void Ewmh::updateDesktops() {
     int cnt = tag_get_count();
-    XChangeProperty(X_.display(), X_.root(), g_netatom[NetNumberOfDesktops],
-        XA_CARDINAL, 32, PropModeReplace, (unsigned char*)&cnt, 1);
+    X_.setPropertyCardinal(X_.root(), g_netatom[NetNumberOfDesktops], { cnt });
 }
 
 void Ewmh::updateDesktopNames() {
@@ -237,8 +234,7 @@ void Ewmh::updateCurrentDesktop() {
         HSWarning("tag %s not found in internal list\n", tag->name->c_str());
         return;
     }
-    XChangeProperty(X_.display(), X_.root(), g_netatom[NetCurrentDesktop],
-        XA_CARDINAL, 32, PropModeReplace, (unsigned char*)&(index), 1);
+    X_.setPropertyCardinal(X_.root(), g_netatom[NetCurrentDesktop], { index });
 }
 
 void Ewmh::windowUpdateTag(Window win, HSTag* tag) {
@@ -247,8 +243,7 @@ void Ewmh::windowUpdateTag(Window win, HSTag* tag) {
         HSWarning("tag %s not found in internal list\n", tag->name->c_str());
         return;
     }
-    XChangeProperty(X_.display(), win, g_netatom[NetWmDesktop],
-        XA_CARDINAL, 32, PropModeReplace, (unsigned char*)&(index), 1);
+    X_.setPropertyCardinal(win, g_netatom[NetWmDesktop], { index });
 }
 
 void Ewmh::updateActiveWindow(Window win) {
@@ -457,19 +452,16 @@ void Ewmh::setWindowOpacity(Window win, double opacity) {
     uint32_t int_opacity = std::numeric_limits<uint32_t>::max()
                             * CLAMP(opacity, 0, 1);
 
-    XChangeProperty(X_.display(), win, g_netatom[NetWmWindowOpacity], XA_CARDINAL,
-                    32, PropModeReplace, (unsigned char*)&int_opacity, 1);
+    X_.setPropertyCardinal(win, g_netatom[NetWmWindowOpacity], { int_opacity });
 }
+
 void Ewmh::updateFrameExtents(Window win, int left, int right, int top, int bottom) {
     vector<long> extents = { left, right, top, bottom };
-    XChangeProperty(X_.display(), win, g_netatom[NetFrameExtents], XA_CARDINAL,
-                    32, PropModeReplace, (unsigned char*)&extents.front(), extents.size());
+    X_.setPropertyCardinal(win, g_netatom[NetFrameExtents], extents);
 }
 
 void Ewmh::windowUpdateWmState(Window win, WmState state) {
-    uint32_t int_state = state;
-    XChangeProperty(X_.display(), win,  WM_STATE, XA_CARDINAL,
-                    32, PropModeReplace, (unsigned char*)&int_state, 1);
+    X_.setPropertyCardinal(win, WM_STATE, { state });
 }
 
 Ewmh& Ewmh::get() {

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -11,6 +11,7 @@
 using std::endl;
 using std::pair;
 using std::string;
+using std::vector;
 
 XConnection::XConnection(Display* disp)
     : m_display(disp) {
@@ -165,7 +166,7 @@ std::experimental::optional<string> XConnection::getWindowProperty(Window window
 
 
 //! implement XChangeProperty for type=XA_CARDINAL
-void XConnection::setPropertyCardinal(Window w, Atom property, std::vector<long> value) {
+void XConnection::setPropertyCardinal(Window w, Atom property, vector<long> value) {
     // according to the XChangeProperty-specification:
     // if format = 32, then the data must be a long array.
     XChangeProperty(m_display, w, property,

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -164,3 +164,11 @@ std::experimental::optional<string> XConnection::getWindowProperty(Window window
 }
 
 
+//! implement XChangeProperty for type=XA_CARDINAL
+void XConnection::setPropertyCardinal(Window w, Atom property, std::vector<long> value) {
+    // according to the XChangeProperty-specification:
+    // if format = 32, then the data must be a long array.
+    XChangeProperty(m_display, w, property,
+        XA_CARDINAL, 32, PropModeReplace,
+        (unsigned char*)(value.data()), value.size());
+}

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -166,7 +166,7 @@ std::experimental::optional<string> XConnection::getWindowProperty(Window window
 
 
 //! implement XChangeProperty for type=XA_CARDINAL
-void XConnection::setPropertyCardinal(Window w, Atom property, vector<long> value) {
+void XConnection::setPropertyCardinal(Window w, Atom property, const vector<long>& value) {
     // according to the XChangeProperty-specification:
     // if format = 32, then the data must be a long array.
     XChangeProperty(m_display, w, property,

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -29,6 +29,7 @@ public:
     std::string getInstance(Window win) { return getClassHint(win).first; };
     std::string getClass(Window win) { return getClassHint(win).second; };
     std::experimental::optional<std::string> getWindowProperty(Window window, Atom atom);
+    void setPropertyCardinal(Window w, Atom property, std::vector<long> value);
 private:
     Display* m_display;
     int      m_screen;

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -29,7 +29,7 @@ public:
     std::string getInstance(Window win) { return getClassHint(win).first; };
     std::string getClass(Window win) { return getClassHint(win).second; };
     std::experimental::optional<std::string> getWindowProperty(Window window, Atom atom);
-    void setPropertyCardinal(Window w, Atom property, std::vector<long> value);
+    void setPropertyCardinal(Window w, Atom property, const std::vector<long>& value);
 private:
     Display* m_display;
     int      m_screen;


### PR DESCRIPTION
Add a convenience wrapper XConnection::setPropertyCardinal() that takes
a vector of longs.