### PR TITLE
Wrapper for XChangeProperty for type = XA_WINDOW

### DIFF
--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -104,10 +104,8 @@ Ewmh::Ewmh(XConnection& xconnection)
     /* init for the supporting wm check */
     g_wm_window = XCreateSimpleWindow(X_.display(), X_.root(),
                                       42, 42, 42, 42, 0, 0, 0);
-    XChangeProperty(X_.display(), X_.root(), g_netatom[NetSupportingWmCheck],
-        XA_WINDOW, 32, PropModeReplace, (unsigned char*)&(g_wm_window), 1);
-    XChangeProperty(X_.display(), g_wm_window, g_netatom[NetSupportingWmCheck],
-        XA_WINDOW, 32, PropModeReplace, (unsigned char*)&(g_wm_window), 1);
+    X_.setPropertyWindow(X_.root(), g_netatom[NetSupportingWmCheck], { g_wm_window });
+    X_.setPropertyWindow(g_wm_window, g_netatom[NetSupportingWmCheck], { g_wm_window });
 
     /* init atoms that never change */
     vector<long> buf{ 0, 0 };
@@ -151,9 +149,7 @@ void Ewmh::updateWmName() {
 }
 
 void Ewmh::updateClientList() {
-    XChangeProperty(X_.display(), X_.root(), g_netatom[NetClientList],
-        XA_WINDOW, 32, PropModeReplace,
-        (unsigned char *) g_windows.data(), g_windows.size());
+    X_.setPropertyWindow(X_.root(), g_netatom[NetClientList], g_windows);
 }
 
 bool Ewmh::readClientList(Window** buf, unsigned long *count) {
@@ -194,9 +190,7 @@ void Ewmh::updateClientListStacking() {
     // reverse stacking order, because ewmh requires bottom to top order
     std::reverse(buf.begin(), buf.end());
 
-    XChangeProperty(X_.display(), X_.root(), g_netatom[NetClientListStacking],
-        XA_WINDOW, 32, PropModeReplace,
-        (unsigned char *) buf.data(), buf.size());
+    X_.setPropertyWindow(X_.root(), g_netatom[NetClientListStacking], buf);
 }
 
 void Ewmh::addClient(Window win) {
@@ -252,8 +246,7 @@ void Ewmh::windowUpdateTag(Window win, HSTag* tag) {
 }
 
 void Ewmh::updateActiveWindow(Window win) {
-    XChangeProperty(X_.display(), X_.root(), g_netatom[NetActiveWindow],
-        XA_WINDOW, 32, PropModeReplace, (unsigned char*)&(win), 1);
+    X_.setPropertyWindow(X_.root(), g_netatom[NetActiveWindow], { win });
 }
 
 bool Ewmh::focusStealingAllowed(long source) {

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -166,7 +166,7 @@ std::experimental::optional<string> XConnection::getWindowProperty(Window window
 
 
 //! implement XChangeProperty for type=XA_WINDOW
-void XConnection::setPropertyWindow(Window w, Atom property, vector<Window> value) {
+void XConnection::setPropertyWindow(Window w, Atom property, const vector<Window>& value) {
     // according to the XChangeProperty-specification:
     // if format = 32, then the data must be a long array.
     XChangeProperty(m_display, w, property,

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -11,6 +11,7 @@
 using std::endl;
 using std::pair;
 using std::string;
+using std::vector;
 
 XConnection::XConnection(Display* disp)
     : m_display(disp) {
@@ -165,7 +166,7 @@ std::experimental::optional<string> XConnection::getWindowProperty(Window window
 
 
 //! implement XChangeProperty for type=XA_WINDOW
-void XConnection::setPropertyWindow(Window w, Atom property, std::vector<Window> value) {
+void XConnection::setPropertyWindow(Window w, Atom property, vector<Window> value) {
     // according to the XChangeProperty-specification:
     // if format = 32, then the data must be a long array.
     XChangeProperty(m_display, w, property,

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -164,3 +164,11 @@ std::experimental::optional<string> XConnection::getWindowProperty(Window window
 }
 
 
+//! implement XChangeProperty for type=XA_WINDOW
+void XConnection::setPropertyWindow(Window w, Atom property, std::vector<Window> value) {
+    // according to the XChangeProperty-specification:
+    // if format = 32, then the data must be a long array.
+    XChangeProperty(m_display, w, property,
+        XA_WINDOW, 32, PropModeReplace,
+        (unsigned char*)(value.data()), value.size());
+}

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -29,6 +29,7 @@ public:
     std::string getInstance(Window win) { return getClassHint(win).first; };
     std::string getClass(Window win) { return getClassHint(win).second; };
     std::experimental::optional<std::string> getWindowProperty(Window window, Atom atom);
+    void setPropertyWindow(Window w, Atom property, std::vector<Window> value);
 private:
     Display* m_display;
     int      m_screen;

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -29,7 +29,7 @@ public:
     std::string getInstance(Window win) { return getClassHint(win).first; };
     std::string getClass(Window win) { return getClassHint(win).second; };
     std::experimental::optional<std::string> getWindowProperty(Window window, Atom atom);
-    void setPropertyWindow(Window w, Atom property, std::vector<Window> value);
+    void setPropertyWindow(Window w, Atom property, const std::vector<Window>& value);
 private:
     Display* m_display;
     int      m_screen;


### PR DESCRIPTION
Add a convenience wrapper XConnection::setPropertyWindow() that takes
a vector of Windows.