### PR TITLE
Wrapper for XChangeProperty/XSetTextProperty

### DIFF
--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -21,6 +21,7 @@
 
 using std::function;
 using std::make_shared;
+using std::string;
 using std::vector;
 
 Atom g_netatom[NetCOUNT];
@@ -137,17 +138,10 @@ Ewmh::~Ewmh() {
     XDestroyWindow(X_.display(), g_wm_window);
 }
 
-void Ewmh::setWmName(const char* name) {
-    XChangeProperty(X_.display(), g_wm_window, g_netatom[NetWmName],
-        ATOM("UTF8_STRING"), 8, PropModeReplace,
-        (unsigned char*)name, strlen(name));
-    XChangeProperty(X_.display(), X_.root(), g_netatom[NetWmName],
-        ATOM("UTF8_STRING"), 8, PropModeReplace,
-        (unsigned char*)name, strlen(name));
-}
-
 void Ewmh::updateWmName() {
-    setWmName(root_->settings->wmname().c_str());
+    string name = root_->settings->wmname();
+    X_.setPropertyString(g_wm_window, g_netatom[NetWmName], name);
+    X_.setPropertyString(X_.root(), g_netatom[NetWmName], name);
 }
 
 void Ewmh::updateClientList() {
@@ -218,16 +212,11 @@ void Ewmh::updateDesktops() {
 }
 
 void Ewmh::updateDesktopNames() {
-    // we know that the tags don't change during the following lines
-    vector<const char*> names;
+    vector<string> names;
     for (auto tag : *global_tags) {
-        names.push_back(tag->name->c_str());
+        names.push_back(tag->name);
     }
-    XTextProperty text_prop;
-    Xutf8TextListToTextProperty(X_.display(), (char**)names.data(), names.size(),
-                                XUTF8StringStyle, &text_prop);
-    XSetTextProperty(X_.display(), X_.root(), &text_prop, g_netatom[NetDesktopNames]);
-    XFree(text_prop.value);
+    X_.setPropertyString(X_.root(), g_netatom[NetDesktopNames], names);
 }
 
 void Ewmh::updateCurrentDesktop() {

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -2,7 +2,6 @@
 
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
-#include <X11/Xutil.h>
 #include <algorithm>
 #include <cstring>
 #include <limits>

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -94,7 +94,6 @@ public:
 
     void addClient(Window win);
     void removeClient(Window win);
-    void setWmName(const char* name);
     void updateWmName();
 
     void updateClientList();

--- a/src/ipc-server.cpp
+++ b/src/ipc-server.cpp
@@ -66,9 +66,7 @@ bool IpcServer::handleConnection(Window win) {
     // send output back
     // Mark this command as executed
     XDeleteProperty(X.display(), win, X.atom(HERBST_IPC_ARGS_ATOM));
-    XChangeProperty(X.display(), win, X.atom(HERBST_IPC_OUTPUT_ATOM),
-        X.atom("UTF8_STRING"), 8, PropModeReplace,
-        (unsigned char*)output.str().c_str(), 1 + output.str().size());
+    X.setPropertyString(win, X.atom(HERBST_IPC_OUTPUT_ATOM), output.str());
     // and also set the exit status
     XChangeProperty(X.display(), win, X.atom(HERBST_IPC_STATUS_ATOM),
         XA_ATOM, 32, PropModeReplace, (unsigned char*)&(status), 1);
@@ -87,18 +85,9 @@ void IpcServer::emitHook(vector<string> args) {
         // nothing to do
         return;
     }
-    vector<const char*> args_c_str;
-    args_c_str.reserve(args.size());
-    for (const auto& s : args) {
-        args_c_str.push_back(s.c_str());
-    }
-    XTextProperty text_prop;
     static char atom_name[1000];
     snprintf(atom_name, 1000, HERBST_HOOK_PROPERTY_FORMAT, nextHookNumber_);
-    Atom atom = X.atom(atom_name);
-    Xutf8TextListToTextProperty(X.display(), (char**) args_c_str.data(), args.size(), XUTF8StringStyle, &text_prop);
-    XSetTextProperty(X.display(), hookEventWindow_, &text_prop, atom);
-    XFree(text_prop.value);
+    X.setPropertyString(hookEventWindow_, X.atom(atom_name), args);
     // set counter for next property
     nextHookNumber_ += 1;
     nextHookNumber_ %= HERBST_HOOK_PROPERTY_COUNT;

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -29,12 +29,15 @@ public:
     std::string getInstance(Window win) { return getClassHint(win).first; };
     std::string getClass(Window win) { return getClassHint(win).second; };
     std::experimental::optional<std::string> getWindowProperty(Window window, Atom atom);
+    void setPropertyString(Window w, Atom property, std::string value);
+    void setPropertyString(Window w, Atom property, const std::vector<std::string>& value);
 private:
     Display* m_display;
     int      m_screen;
     Window   m_root;
     int      m_screen_width;
     int      m_screen_height;
+    Atom     utf8StringAtom_;
 };
 
 #endif


### PR DESCRIPTION
Add a convenience wrapper XConnection::setPropertyString() that takes
a string or a vector of strings and sets the given property accordingly.