### PR TITLE
Move stack command to MonitorManager

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -112,7 +112,6 @@ struct {
     { "remove_monitor", 2,  no_completion },
     { "move_monitor",   7,  no_completion },
     { "raise_monitor",  2,  no_completion },
-    { "stack",          2,  no_completion },
     { "monitor_rect",   3,  no_completion },
     { "pad",            6,  no_completion },
     { "list_padding",   2,  no_completion },

--- a/src/command.h
+++ b/src/command.h
@@ -70,6 +70,16 @@ public:
                                 std::placeholders::_1))
     {
     }
+    /** Binding to a command in a given object, but with no input
+     * parameters and thus without completion.
+     */
+    template <typename ClassName>
+    CommandBinding(ClassName* object,
+                   int(ClassName::*member_cmd)(Output))
+        : CommandBinding(std::bind(member_cmd, object,
+                            std::placeholders::_1))
+    {
+    }
 
     // FIXME: Remove after C++ transition
     // The following constructors are only there to ease the transition from

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,6 @@
 #include "rootcommands.h"
 #include "rulemanager.h"
 #include "settings.h"
-#include "stack.h"
 #include "tagmanager.h"
 #include "tmp.h"
 #include "utils.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,7 +194,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                    &RuleManager::unruleCompletion}},
         {"list_rules",     {[rules] (Output o) { return rules->listRulesCommand(o); }}},
         {"layout",         print_layout_command},
-        {"stack",          { monitors, &MonitorManager::printStack }},
+        {"stack",          { monitors, &MonitorManager::printStackCommand }},
         {"dump",           print_layout_command},
         {"load",           { tags->frameCommand(&FrameTree::loadCommand) }},
         {"complete",       complete_command},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,7 +194,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                    &RuleManager::unruleCompletion}},
         {"list_rules",     {[rules] (Output o) { return rules->listRulesCommand(o); }}},
         {"layout",         print_layout_command},
-        {"stack",          { monitors, &MonitorManager::printStackCommand }},
+        {"stack",          { monitors, &MonitorManager::stackCommand }},
         {"dump",           print_layout_command},
         {"load",           { tags->frameCommand(&FrameTree::loadCommand) }},
         {"complete",       complete_command},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -195,7 +195,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                    &RuleManager::unruleCompletion}},
         {"list_rules",     {[rules] (Output o) { return rules->listRulesCommand(o); }}},
         {"layout",         print_layout_command},
-        {"stack",          print_stack_command},
+        {"stack",          { monitors, &MonitorManager::printStack }},
         {"dump",           print_layout_command},
         {"load",           { tags->frameCommand(&FrameTree::loadCommand) }},
         {"complete",       complete_command},

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -372,7 +372,7 @@ private:
     string label_;
 };
 
-int MonitorManager::printStack(Output output) {
+int MonitorManager::printStackCommand(Output output) {
     vector<shared_ptr<StringTree>> monitors;
     for (Monitor* monitor : monitorStack_) {
         vector<shared_ptr<StringTree>> layers;

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -372,7 +372,7 @@ private:
     string label_;
 };
 
-int MonitorManager::printStackCommand(Output output) {
+int MonitorManager::stackCommand(Output output) {
     vector<shared_ptr<StringTree>> monitors;
     for (Monitor* monitor : monitorStack_) {
         vector<shared_ptr<StringTree>> layers;

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -49,6 +49,7 @@ public:
     void unlock();
     std::string lock_number_changed();
 
+    int printStack(Output output);
     void extractWindowStack(bool real_clients, std::function<void(Window)> addToStack);
     void restack();
 

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -49,7 +49,7 @@ public:
     void unlock();
     std::string lock_number_changed();
 
-    int printStackCommand(Output output);
+    int stackCommand(Output output);
     void extractWindowStack(bool real_clients, std::function<void(Window)> addToStack);
     void restack();
 

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -49,7 +49,7 @@ public:
     void unlock();
     std::string lock_number_changed();
 
-    int printStack(Output output);
+    int printStackCommand(Output output);
     void extractWindowStack(bool real_clients, std::function<void(Window)> addToStack);
     void restack();
 

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -3,7 +3,6 @@
 #include <X11/Xlib.h>
 #include <algorithm>
 #include <cassert>
-#include <cstdio>
 
 #include "client.h"
 #include "ewmh.h"

--- a/src/stack.h
+++ b/src/stack.h
@@ -7,8 +7,6 @@
 #include <set>
 #include <vector>
 
-#include "types.h"
-
 enum HSLayer {
     /* layers on each tag, from top to bottom */
     LAYER_FOCUS,
@@ -35,6 +33,8 @@ public:
     static Slice* makeWindowSlice(Window window);
     static Slice* makeFrameSlice(Window window);
     static Slice* makeClientSlice(Client* client);
+
+    std::string getLabel();
 
     SliceType type;
     std::set<HSLayer> layers; //!< layers this slice is contained in
@@ -69,8 +69,6 @@ private:
 };
 
 HSLayer slice_highest_layer(Slice* slice);
-
-int print_stack_command(int argc, char** argv, Output output);
 
 #endif
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -17,6 +17,7 @@ commands_without_input = shlex.split(
     reload
     remove
     rotate
+    stack
     true
     unlock
     use_previous


### PR DESCRIPTION
Also provide another constructor to CommandBinding for commands
that sit in objects and that don't need an Input parameter.