### PR TITLE
Fix keyboard focus

### DIFF
--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -162,7 +162,6 @@ int FrameTree::removeFrameCommand() {
         // if parent was root frame
         root_ = newparent;
     }
-    frame_focus_recursive(parent);
     get_current_monitor()->applyLayout();
     return 0;
 }
@@ -472,9 +471,6 @@ int FrameTree::loadCommand(Input input, Output output) {
     Monitor* m = find_monitor_with_tag(tag);
     if (m) {
         tag->frame->root_->setVisibleRecursive(true);
-        if (get_current_monitor() == m) {
-            frame_focus_recursive(tag->frame->root_);
-        }
         m->applyLayout();
         monitor_update_focus_objects();
     } else {

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -806,7 +806,6 @@ int frame_focus_command(int argc, char** argv, Output output) {
     } else if (!external_only &&
         (index = frame_inner_neighbour_index(frame, direction)) != -1) {
         frame->setSelection(index);
-        frame_focus_recursive(frame);
         get_current_monitor()->applyLayout();
     } else {
         shared_ptr<HSFrame> neighbour = frame->neighbour(direction);
@@ -815,7 +814,6 @@ int frame_focus_command(int argc, char** argv, Output output) {
             // alter focus (from 0 to 1, from 1 to 0)
             parent->swapSelection();
             // change focus if possible
-            frame_focus_recursive(parent);
             get_current_monitor()->applyLayout();
         } else {
             neighbour_found = false;
@@ -873,7 +871,6 @@ int frame_move_window_command(int argc, char** argv, Output output) {
     if (!external_only &&
         (index = frame_inner_neighbour_index(frame, direction)) != -1) {
         frame->moveClient(index);
-        frame_focus_recursive(frame);
         get_current_monitor()->applyLayout();
     } else {
         shared_ptr<HSFrame> neighbour = frame->neighbour(direction);
@@ -888,7 +885,6 @@ int frame_move_window_command(int argc, char** argv, Output output) {
             shared_ptr<HSFrameSplit> parent = neighbour->getParent();
             assert(parent);
             parent->swapSelection();
-            frame_focus_recursive(parent);
 
             // layout was changed, so update it
             get_current_monitor()->applyLayout();
@@ -1011,15 +1007,5 @@ bool smart_window_surroundings_active(HSFrameLeaf* frame) {
     return g_settings->smart_window_surroundings()
             && (frame->clientCount() == 1
                 || frame->getLayout() == LayoutAlgorithm::max);
-}
-
-void frame_focus_recursive(shared_ptr<HSFrame> frame) {
-    shared_ptr<HSFrameLeaf> leaf = FrameTree::focusedFrame(frame);
-    Client* client = leaf->focusedClient();
-    if (client) {
-        client->window_focus();
-    } else {
-        Client::window_unfocus_last();
-    }
 }
 

--- a/src/layout.h
+++ b/src/layout.h
@@ -209,7 +209,6 @@ int frame_inner_neighbour_index(std::shared_ptr<HSFrameLeaf> frame, Direction di
 int frame_focus_command(int argc, char** argv, Output output);
 
 // follow selection to leaf and focus this frame
-void frame_focus_recursive(std::shared_ptr<HSFrame> frame);
 int frame_current_cycle_client_layout(int argc, char** argv, Output output);
 int frame_current_set_client_layout(int argc, char** argv, Output output);
 int frame_split_count_to_root(HSFrame* frame, int align);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -804,14 +804,15 @@ void motionnotify(Root*, XEvent* event) {
     handle_motion_event(event);
 }
 
-void mapnotify(Root*, XEvent* event) {
+void mapnotify(Root* root, XEvent* event) {
     //HSDebug("name is: MapNotify\n");
-    Client* c;
-    if ((c = get_client_from_window(event->xmap.window))) {
+    Client* c = get_client_from_window(event->xmap.window);
+    if (c != nullptr) {
         // reset focus. so a new window gets the focus if it shall have the
         // input focus
-        // TODO: reset input focus
-        //frame_focus_recursive(get_current_monitor()->tag->frame->getFocusedFrame());
+        if (c == root->clients->focus()) {
+            XSetInputFocus(g_display, c->window_, RevertToPointerRoot, CurrentTime);
+        }
         // also update the window title - just to be sure
         c->update_title();
     }

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -245,12 +245,6 @@ void TagManager::moveClient(Client* client, HSTag* target) {
     if (!monitor_source && monitor_target) {
         client->set_visible(true);
     }
-    if (monitor_target == get_current_monitor()) {
-        frame_focus_recursive(monitor_target->tag->frame->root_);
-    }
-    else if (monitor_source == get_current_monitor()) {
-        frame_focus_recursive(monitor_source->tag->frame->root_);
-    }
     tag_set_flags_dirty();
 }
 

--- a/tests/test_x11.py
+++ b/tests/test_x11.py
@@ -1,0 +1,27 @@
+import pytest
+import subprocess
+
+
+@pytest.mark.parametrize("running_clients_num", [0, 1, 2])
+def test_window_focus(hlwm, x11,  hc_idle, running_clients_num):
+    # before creating the clients, assert that new clients are focused
+    hlwm.call('rule focus=on')
+
+    # create some clients:
+    last_client = None
+    for k in range(running_clients_num):
+        last_client, _ = x11.create_client()
+
+    hlwm.call('true') # sync with hlwm
+    x11.display.sync()
+
+    assert x11.ewmh.getActiveWindow() == last_client
+    if last_client is None:
+        assert x11.display.get_input_focus().focus == x11.root
+        assert 'focus' not in hlwm.list_children('clients')
+    else:
+        hlwm.call('attr clients')
+        print(hc_idle.hooks())
+        print(x11.display.get_input_focus().focus)
+        assert x11.display.get_input_focus().focus == last_client
+        assert x11.winid_str(last_client) == hlwm.get_attr('clients.focus.winid')

--- a/tests/test_x11.py
+++ b/tests/test_x11.py
@@ -1,9 +1,8 @@
 import pytest
-import subprocess
 
 
 @pytest.mark.parametrize("running_clients_num", [0, 1, 2])
-def test_window_focus(hlwm, x11,  hc_idle, running_clients_num):
+def test_window_focus(hlwm, x11, hc_idle, running_clients_num):
     # before creating the clients, assert that new clients are focused
     hlwm.call('rule focus=on')
 
@@ -12,7 +11,7 @@ def test_window_focus(hlwm, x11,  hc_idle, running_clients_num):
     for k in range(running_clients_num):
         last_client, _ = x11.create_client()
 
-    hlwm.call('true') # sync with hlwm
+    hlwm.call('true')  # sync with hlwm
     x11.display.sync()
 
     assert x11.ewmh.getActiveWindow() == last_client


### PR DESCRIPTION
The focus setting helper frame_focus_recursive() was called in many
places (and the focus was still broken when the first client showed up).
However, every such call is followed by a call to Monitor::applyLayout()
which sets the object link clients.focus. If the window is not visible
yet, XSetInputFocus() has no effect. So we need to reset the focus on
MapNotify events.

Hence, we now directly set the keyboard focus at this single place in
Monitor::applyLayout().