### PR TITLE
Focus dummy window if no client is focused

### DIFF
--- a/src/clientlist.cpp
+++ b/src/clientlist.cpp
@@ -462,8 +462,7 @@ void client_window_unfocus_last() {
         client_window_unfocus(lastfocus);
     }
     hsobject_unlink_by_name(g_client_object, "focus");
-    // give focus to root window
-    XSetInputFocus(g_display, g_root, RevertToPointerRoot, CurrentTime);
+    ewmh_clear_input_focus();
     if (lastfocus) {
         /* only emit the hook if the focus *really* changes */
         hook_emit_list("focus_changed", "0x0", "", NULL);

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -111,11 +111,12 @@ void ewmh_init() {
 
     /* init for the supporting wm check */
     g_wm_window = XCreateSimpleWindow(g_display, g_root,
-                                      42, 42, 42, 42, 0, 0, 0);
+                                      -100, -100, 1, 1, 0, 0, 0);
     XChangeProperty(g_display, g_root, g_netatom[NetSupportingWmCheck],
         XA_WINDOW, 32, PropModeReplace, (unsigned char*)&(g_wm_window), 1);
     XChangeProperty(g_display, g_wm_window, g_netatom[NetSupportingWmCheck],
         XA_WINDOW, 32, PropModeReplace, (unsigned char*)&(g_wm_window), 1);
+    XMapWindow(g_display, g_wm_window);
     ewmh_update_wmname();
 
     /* init atoms that never change */
@@ -561,5 +562,15 @@ void window_update_wm_state(Window win, WmState state) {
     unsigned long wmstate[] = { state, None };
     XChangeProperty(g_display, win,  WM_STATE, WM_STATE,
                     32, PropModeReplace, (unsigned char*)wmstate, LENGTH(wmstate));
+}
+
+// assert that the given window was created by this module and is not a client
+bool ewmh_is_own_window(Window win) {
+    return g_wm_window == win;
+}
+
+// clear input focus by focusing a dummy window
+void ewmh_clear_input_focus() {
+    XSetInputFocus(g_display, g_wm_window, RevertToPointerRoot, CurrentTime);
 }
 

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -96,6 +96,8 @@ void ewmh_update_client_list_stacking();
 void ewmh_update_desktops();
 void ewmh_update_desktop_names();
 void ewmh_update_active_window(Window win);
+bool ewmh_is_own_window(Window win);
+void ewmh_clear_input_focus();
 void ewmh_update_current_desktop();
 void ewmh_update_window_state(struct HSClient* client);
 void ewmh_update_frame_extents(Window win, int left, int right, int top, int bottom);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -639,7 +639,7 @@ void scan(void) {
             // but manage it if it was in the ewmh property _NET_CLIENT_LIST by
             // the previous window manager
             // TODO: what would dwm do?
-            if (ewmh_is_own_window) {
+            if (ewmh_is_own_window(wins[i])) {
                 continue;
             }
             if (is_window_mapped(g_display, wins[i])

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -639,6 +639,9 @@ void scan(void) {
             // but manage it if it was in the ewmh property _NET_CLIENT_LIST by
             // the previous window manager
             // TODO: what would dwm do?
+            if (ewmh_is_own_window) {
+                continue;
+            }
             if (is_window_mapped(g_display, wins[i])
                 || 0 <= array_find(cl, cl_count, sizeof(Window), wins+i)) {
                 manage_client(wins[i]);
@@ -932,7 +935,9 @@ void mapnotify(XEvent* event) {
 void maprequest(XEvent* event) {
     HSDebug("name is: MapRequest\n");
     XMapRequestEvent* mapreq = &event->xmaprequest;
-    if (is_herbstluft_window(g_display, mapreq->window)) {
+    if (ewmh_is_own_window(mapreq->window)
+        || is_herbstluft_window(g_display, mapreq->window))
+    {
         // just map the window if it wants that
         XWindowAttributes wa;
         if (!XGetWindowAttributes(g_display, mapreq->window, &wa)) {


### PR DESCRIPTION
This is an adaption of a commit in the winterbreeze branch with the same
title.

Previously, if no window is focused, the root windows was focused. This
had the effect that the keyboard input was sent to the window under the
mouse cursor (even though this windows was not focused).

We now create a dummy window outside of the screen. This window is used
already for EWMH's _NET_SUPPORTING_WM_CHECK, and now this window is
focused if no real client is focused.

Additionally, this fixes the analogue issue with focus_follows_mouse
which did not work previously when not client window is focused.