### PR TITLE
Check in herbstclient if herbstluftwm is running

### DIFF
--- a/ipc-client/ipc-client.h
+++ b/ipc-client/ipc-client.h
@@ -11,9 +11,15 @@
 
 typedef struct HCConnection HCConnection;
 
+/** Connect to hlwm via an X11 display. This does not check whether
+ * herbstluftwm is (still) running. Use hc_check_running() for this
+ */
 HCConnection* hc_connect();
 HCConnection* hc_connect_to_display(Display* display);
+/** check whether herbstluftwm is running */
+bool hc_check_running(HCConnection* con);
 void hc_disconnect(HCConnection* con);
+
 /* ensure there is a client window for sending commands */
 bool hc_create_client_window(HCConnection* con);
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -464,6 +464,8 @@ def kill_all_existing_windows(show_warnings=True):
 @pytest.fixture()
 def hlwm_spawner(tmpdir):
     """yield a function to spawn hlwm"""
+    assert os.environ['DISPLAY'] != ':0', 'Refusing to run tests on display that might be your actual X server (not Xvfb)'
+
     def spawn():
         env = {
             'DISPLAY': os.environ['DISPLAY'],
@@ -475,7 +477,7 @@ def hlwm_spawner(tmpdir):
 
 @pytest.fixture()
 def hlwm_process(hlwm_spawner):
-    assert os.environ['DISPLAY'] != ':0', 'Refusing to run tests on display that might be your actual X server (not Xvfb)'
+    """Set up hlwm and also check that it shuts down gently afterwards"""
     hlwm_proc = hlwm_spawner()
     kill_all_existing_windows(show_warnings=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -474,15 +474,9 @@ def hlwm_spawner(tmpdir):
 
 
 @pytest.fixture()
-def hlwm_process(tmpdir):
-    env = {
-        'DISPLAY': os.environ['DISPLAY'],
-        'XDG_CONFIG_HOME': str(tmpdir),
-    }
-    assert env['DISPLAY'] != ':0', 'Refusing to run tests on display that might be your actual X server (not Xvfb)'
-
-    # env['DISPLAY'] = ':13'
-    hlwm_proc = HlwmProcess(tmpdir, env)
+def hlwm_process(hlwm_spawner):
+    assert os.environ['DISPLAY'] != ':0', 'Refusing to run tests on display that might be your actual X server (not Xvfb)'
+    hlwm_proc = hlwm_spawner()
     kill_all_existing_windows(show_warnings=True)
 
     yield hlwm_proc

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -37,7 +37,7 @@ def test_herbstclient_recognizes_hlwm_not_running(hlwm_spawner, x11, hlwm_mode, 
 
     # run herbstclient while no hlwm is running
     hc_command = [HC_PATH, hc_parameter]
-    result = subprocess.run(hc_command, stderr=subprocess.PIPE, text=True)
+    result = subprocess.run(hc_command, stderr=subprocess.PIPE, universal_newlines=True)
 
     assert result.returncode != 0
     assert re.search(r'Error: herbstluftwm is not running', result.stderr)

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -17,7 +17,7 @@ def test_herbstclient_recognizes_hlwm_not_running(hlwm_spawner, x11, hlwm_mode, 
         # ping that herbstclient still works here
         hc = subprocess.run([HC_PATH, 'echo', 'ping'],
                             stdout=subprocess.PIPE,
-                            text=True,
+                            universal_newlines=True,
                             check=True)
         assert hc.stdout == 'ping\n'
         if hlwm_mode == 'sigterm':

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -1,0 +1,43 @@
+import subprocess
+import os
+import re
+import pytest
+
+HC_PATH = os.path.join(os.path.abspath(os.environ['PWD']), 'herbstclient')
+
+
+@pytest.mark.parametrize('hlwm_mode', ['never started', 'sigterm', 'sigkill'])
+@pytest.mark.parametrize('hc_parameter', ['true', '--wait'])
+def test_herbstclient_recognizes_hlwm_not_running(hlwm_spawner, x11, hlwm_mode, hc_parameter):
+    if hlwm_mode == 'never started':
+        pass
+    else:
+        # start hlwm and kill it in order to leave X in some inconsistent state
+        hlwm_proc = hlwm_spawner()
+        # ping that herbstclient still works here
+        hc = subprocess.run([HC_PATH, 'echo', 'ping'],
+                            stdout=subprocess.PIPE,
+                            text=True,
+                            check=True)
+        assert hc.stdout == 'ping\n'
+        if hlwm_mode == 'sigterm':
+            hlwm_proc.proc.terminate()
+            hlwm_proc.proc.wait(1)
+            # if we terminate it gently, then the property is cleaned up
+            assert x11.get_property('__HERBST_HOOK_WIN_ID') is None
+        elif hlwm_mode == 'sigkill':
+            hlwm_proc.proc.kill()
+            hlwm_proc.proc.wait(1)
+            # if we kill it forcefully, then the property is not cleaned up
+            # so check that we really test hc_command with an inconsistent
+            # state
+            assert x11.get_property('__HERBST_HOOK_WIN_ID') is not None
+        else:
+            assert False, 'assert that we have no typos above'
+
+    # run herbstclient while no hlwm is running
+    hc_command = [HC_PATH, hc_parameter]
+    result = subprocess.run(hc_command, stderr=subprocess.PIPE, text=True)
+
+    assert result.returncode != 0
+    assert re.search(r'Error: herbstluftwm is not running', result.stderr)


### PR DESCRIPTION
Before sending commands or listening for hooks, check that herbstluftwm
is running. This is done by reading the window id of herbstluftwm's hook
window and then checking that this window still exists.

In the test suite, it is checked that herbstclient recognizes an absent
herbstluftwm. Previously, sending commands without herbstluftwm made
herbstclient hang.

In this new test case, we either don't start hlwm or we make it quit
abnormally, so we don't want the hlwm_process fixture to start and check
that hlwm shuts down gently. Hence, this removes the autouse-flag from
the hlwm_process fixture. This does not affect the other taste cases,
because they actively rely on hlwm which depends on hlwm_process.