### PR TITLE
Update child indices after removal

### DIFF
--- a/src/indexingobject.h
+++ b/src/indexingobject.h
@@ -18,12 +18,12 @@ public:
     : count("count", [this]() { return this->size(); })
     { wireAttributes({ &count }); }
     void addIndexed(T* newChild) {
-        unsigned long index_int = data.size();
-        std::string index = std::to_string(index_int);
+        // the current array size is the index for the new child
+        unsigned long index = data.size();
         data.push_back(newChild);
         // add a child object
-        addChild(newChild, index);
-        newChild->setIndexAttribute(index_int);
+        addChild(newChild, std::to_string(index));
+        newChild->setIndexAttribute(index);
     }
     ~IndexingObject() override {
         clearChildren();
@@ -45,6 +45,7 @@ public:
             std::string old_idx_str = std::to_string(new_idx + 1);
             removeChild(old_idx_str);
             addChild(data[new_idx], std::to_string(new_idx));
+            data[new_idx]->setIndexAttribute(new_idx);
         }
 
         delete child;

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -77,6 +77,7 @@ def test_remove_monitor(hlwm):
 
     hlwm.call('remove_monitor 0')
 
+    assert hlwm.get_attr('monitors.0.index') == '0'
     assert hlwm.get_attr('monitors.count') == '1'
     assert hlwm.get_attr('monitors.focus.name') == 'monitor2'
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -77,6 +77,7 @@ def test_merge_tag_into_another_tag(hlwm):
     hlwm.call('merge_tag default foobar')
 
     assert hlwm.get_attr('tags.count') == '1'
+    assert hlwm.get_attr('tags.0.index') == '0'
     assert hlwm.get_attr('tags.0.name') == 'foobar'
 
 


### PR DESCRIPTION
After removing indexed objects like monitors or tags, update the index
of the remaining objects.

This fixes #482.

This also makes some cosmetic changes in addIndexed().