### PR TITLE
Use -O1 in CXXFLAGS in Debug build type

### DIFF
--- a/cmake/debugflags.cmake
+++ b/cmake/debugflags.cmake
@@ -2,7 +2,7 @@
 
 set(FLAGS
     # General debug flags:
-    -g -Og -fno-omit-frame-pointer --coverage
+    -g -O1 -fno-omit-frame-pointer --coverage
     -Werror
 
     # Sanitizers:


### PR DESCRIPTION
When running cmake mit -DCMAKE_BUILD_TYPE=Debug the option -Og sometimes
optimizes parameters away. For better debugging, let us switch to -O1
which should keep the variables intact.