### PR TITLE
Catch exceptions by stoi() and stoul() calls

### DIFF
--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -77,8 +77,12 @@ Client* ClientManager::client(const string &identifier)
         return {}; // no urgent client found
     }
     // try to convert from base 16 or base 10 at the same time
-    Window win = std::stoul(identifier, nullptr, 0);
-    return client(win);
+    try {
+        Window win = std::stoul(identifier, nullptr, 0);
+        return client(win);
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 void ClientManager::add(Client* client)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -420,8 +420,9 @@ int raise_command(int argc, char** argv, Output) {
         client->raise();
     } else {
         auto window = get_window((argc > 1) ? argv[1] : "");
-        if (window)
-            XRaiseWindow(g_display, std::stoul(argv[1], nullptr, 0));
+        if (window) {
+            XRaiseWindow(g_display, window);
+        }
         else return HERBST_INVALID_ARGUMENT;
     }
     return 0;

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -263,13 +263,13 @@ int Monitor::move_cmd(Input input, Output output) {
     // else: just move it:
     this->rect = new_rect;
     input.shift();
-    if (!input.empty()) pad_up       = stoi(input.front());
+    if (!input.empty()) pad_up.change(input.front());
     input.shift();
-    if (!input.empty()) pad_right    = stoi(input.front());
+    if (!input.empty()) pad_right.change(input.front());
     input.shift();
-    if (!input.empty()) pad_down     = stoi(input.front());
+    if (!input.empty()) pad_down.change(input.front());
     input.shift();
-    if (!input.empty()) pad_left     = stoi(input.front());
+    if (!input.empty()) pad_left.change(input.front());
     applyLayout();
     return 0;
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -145,7 +145,11 @@ function<int()> Settings::getIntAttr(string name) {
     return [this, name]() {
         Attribute* a = this->root_->deepAttribute(name);
         if (a) {
-            return std::stoi(a->str());
+            try {
+                return std::stoi(a->str());
+            } catch (...) {
+                return 0;
+            }
         } else {
             HSDebug("Internal Error: No such attribute %s\n", name.c_str());
             return 0;

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -176,7 +176,12 @@ HSTag* TagManager::ensure_tags_are_available() {
 }
 
 HSTag* TagManager::byIndexStr(const string& index_str, bool skip_visible_tags) {
-    int index = stoi(index_str);
+    int index
+    try {
+        index = stoi(index_str);
+    } catch (...) {
+        return nullptr;
+    }
     // index must be treated relative, if it's first char is + or -
     bool is_relative = index_str[0] == '+' || index_str[0] == '-';
     Monitor* monitor = get_current_monitor();

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -176,7 +176,7 @@ HSTag* TagManager::ensure_tags_are_available() {
 }
 
 HSTag* TagManager::byIndexStr(const string& index_str, bool skip_visible_tags) {
-    int index
+    int index;
     try {
         index = stoi(index_str);
     } catch (...) {


### PR DESCRIPTION
This fixes the crash when non-integer values are passed as the
respective arguments.