### PR TITLE
Use WindowID wrapper for Window id conversions

### DIFF
--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -76,9 +76,8 @@ Client* ClientManager::client(const string &identifier)
         }
         return {}; // no urgent client found
     }
-    // try to convert from base 16 or base 10 at the same time
     try {
-        Window win = std::stoul(identifier, nullptr, 0);
+        Window win = Converter<WindowID>::parse(identifier);
         return client(win);
     } catch (...) {
         return nullptr;

--- a/src/frameparser.cpp
+++ b/src/frameparser.cpp
@@ -7,6 +7,7 @@
 #include "clientmanager.h"
 #include "globals.h"
 #include "root.h"
+#include "x11-types.h"
 
 using std::dynamic_pointer_cast;
 using std::endl;
@@ -171,11 +172,7 @@ shared_ptr<RawFrameNode> FrameParser::buildTree() {
             Window winid;
             try {
                 // if the window id is syntactically wrong, then throw an error
-                size_t bytesRead = nextToken->second.size();
-                winid = std::stoul(nextToken->second, &bytesRead, 0);
-                if (bytesRead != nextToken->second.size()) {
-                    throw std::invalid_argument("not a valid window id");
-                }
+                winid = Converter<WindowID>::parse(nextToken->second);
             } catch (const std::exception& e) {
                 throw ParsingException(*nextToken, "not a valid window id");
             }

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -45,8 +45,7 @@ void FrameTree::dump(shared_ptr<HSFrame> frame, Output output)
                << l->selection;
         for (auto client : l->clients) {
             output << LAYOUT_DUMP_WHITESPACES[0]
-                   << "0x"
-                   << std::hex << client->x11Window() << std::dec;
+                   << WindowID(client->x11Window()).str();
         }
         output << LAYOUT_DUMP_BRACKETS[1];
     }
@@ -233,8 +232,7 @@ shared_ptr<TreeInterface> FrameTree::treeInterface(
         void appendCaption(Output output) override {
             output << " " << g_layout_names[(int)l_->layout] << ":";
             for (auto client : l_->clients) {
-                output << " 0x"
-                       << std::hex << client->x11Window() << std::dec;
+                output << " " << WindowID(client->x11Window()).str();
             }
             if (l_ == focus_) {
                 output << " [FOCUS]";
@@ -459,7 +457,7 @@ int FrameTree::loadCommand(Input input, Output output) {
     if (!parsingResult.unknownWindowIDs_.empty()) {
         output << "Warning: Unknown window IDs";
         for (const auto& e : parsingResult.unknownWindowIDs_) {
-            output << " 0x" << std::hex << e.second << std::dec
+            output << " " << WindowID(e.second).str()
                    << "(\'" << e.first.second << "\')";
         }
         output << endl;

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -325,10 +325,7 @@ void Consequence::applyEwmhnotify(const Client* client, ClientChanges* changes) 
 }
 
 void Consequence::applyHook(const Client* client, ClientChanges* changes) const {
-    std::stringstream winidSs;
-    winidSs << "0x" << std::hex << client->window_;
-    auto winidStr = winidSs.str();
-    hook_emit({ "rule", value, winidStr });
+    hook_emit({ "rule", value, WindowID(client->window_).str() });
 }
 
 void Consequence::applyKeyMask(const Client* client, ClientChanges* changes) const {

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -81,11 +81,10 @@ string Slice::getLabel() {
     std::stringstream label;
     switch (type) {
         case SLICE_WINDOW:
-            label << "Window 0x" << std::hex << data.window << std::dec;
+            label << "Window " << WindowID(data.window).str();
             break;
         case SLICE_CLIENT:
-            label << "Client 0x"
-                  << std::hex << data.client->x11Window() << std::dec
+            label << "Client " << WindowID(data.client->x11Window()).str()
                   << " \"" << data.client->title_() << "\"";
             break;
         default: ;

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -96,5 +96,41 @@ inline Rectangle Converter<Rectangle>::parse(const std::string &payload) {
 using RectangleVec = std::vector<Rectangle>;
 using RectangleIdxVec = std::vector<std::pair<int, Rectangle>>;
 
+//! utility functions for the Window type
+class WindowID {
+public:
+    WindowID(Window w) : value_(w) { }
+    inline Window operator()() const { return value_; }
+    inline std::string str() const {
+        std::stringstream ss;
+        ss << "0x" << std::hex << value_;
+        return ss.str();
+    }
+    operator Window() const { return value_; }
+private:
+    Window value_;
+};
+
+/** since WindowID is a new type, we can define a Converter instance for it.
+ * (Window clashes with unsigned long)
+ */
+template<>
+inline std::string Converter<WindowID>::str(WindowID payload) {
+    return payload.str();
+}
+
+template<>
+inline WindowID Converter<WindowID>::parse(const std::string &payload) {
+    size_t bytes_read = 0;
+    unsigned long winid = std::stoul(payload, &bytes_read, 0);
+    if (bytes_read != payload.size()) {
+        std::stringstream message;
+        message << "invalid characters at position " << bytes_read
+            << " of \"" << payload << "\"";
+        throw std::invalid_argument(message.str());
+    }
+    return winid;
+}
+
 #endif
 


### PR DESCRIPTION
This gives provides a more precise parser that also checks that the
string is read in its entirety. I.e. "123abc" is rejected.