### PR TITLE
Avoid get_client_from_window()

### DIFF
--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 
 #include "client.h"
+#include "clientmanager.h"
 #include "layout.h"
 #include "monitor.h"
 #include "monitormanager.h"
@@ -260,7 +261,7 @@ void Ewmh::handleClientMessage(XEvent* event) {
             // only steal focus it allowed to the current source
             // (i.e.  me->data.l[0] in this case as specified by EWMH)
             if (focusStealingAllowed(me->data.l[0])) {
-                auto client = get_client_from_window(me->window);
+                auto client = root_->clients->client(me->window);
                 if (client) {
                     focus_client(client, true, true);
                 }
@@ -286,7 +287,7 @@ void Ewmh::handleClientMessage(XEvent* event) {
                 break;
             }
             HSTag* target = get_tag_by_index(desktop_index);
-            auto client = get_client_from_window(me->window);
+            auto client = root_->clients->client(me->window);
             if (client && target) {
                 global_tags->moveClient(client, target);
             }
@@ -294,7 +295,7 @@ void Ewmh::handleClientMessage(XEvent* event) {
         }
 
         case NetWmState: {
-            auto client = get_client_from_window(me->window);
+            auto client = root_->clients->client(me->window);
             /* ignore requests for unmanaged windows */
             if (!client || !client->ewmhrequests_) break;
 
@@ -344,7 +345,7 @@ void Ewmh::handleClientMessage(XEvent* event) {
         }
 
         case NetWmMoveresize: {
-            auto client = get_client_from_window(me->window);
+            auto client = root_->clients->client(me->window);
             if (!client) {
                 break;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -486,9 +486,9 @@ int unsetenv_command(int argc, char** argv, Output output) {
 
 // handle x-events:
 
-void event_on_configure(Root*, XEvent event) {
+void event_on_configure(Root* root, XEvent event) {
     XConfigureRequestEvent* cre = &event.xconfigurerequest;
-    Client* client = get_client_from_window(cre->window);
+    Client* client = root->clients->client(cre->window);
     if (client) {
         bool changes = false;
         auto newRect = client->float_size_;
@@ -706,7 +706,7 @@ void buttonpress(Root* root, XEvent* event) {
     if (mouse_binding_find(be->state, be->button)) {
         mouse_handle_event(event);
     } else {
-        Client* client = get_client_from_window(be->window);
+        Client* client = root->clients->client(be->window);
         if (client) {
             focus_client(client, false, true);
             if (root->settings->raise_on_click()) {
@@ -759,7 +759,7 @@ void enternotify(Root* root, XEvent* event) {
     if (!mouse_is_dragging()
         && root->settings()->focus_follows_mouse()
         && ce->focus == false) {
-        Client* c = get_client_from_window(ce->window);
+        Client* c = root->clients->client(ce->window);
         shared_ptr<HSFrameLeaf> target;
         if (c && c->tag()->floating == false
               && (target = c->tag()->frame->root_->frameWithClient(c))
@@ -806,7 +806,7 @@ void motionnotify(Root*, XEvent* event) {
 
 void mapnotify(Root* root, XEvent* event) {
     //HSDebug("name is: MapNotify\n");
-    Client* c = get_client_from_window(event->xmap.window);
+    Client* c = root->clients()->client(event->xmap.window);
     if (c != nullptr) {
         // reset focus. so a new window gets the focus if it shall have the
         // input focus
@@ -821,6 +821,7 @@ void mapnotify(Root* root, XEvent* event) {
 void maprequest(Root* root, XEvent* event) {
     HSDebug("name is: MapRequest\n");
     XMapRequestEvent* mapreq = &event->xmaprequest;
+    Client* c = root->clients()->client(event->xmap.window);
     if (root->ewmh->isOwnWindow(mapreq->window)
         || is_herbstluft_window(g_display, mapreq->window))
     {
@@ -830,7 +831,7 @@ void maprequest(Root* root, XEvent* event) {
             return;
         }
         XMapWindow(g_display, mapreq->window);
-    } else if (!get_client_from_window(mapreq->window)) {
+    } else if (c == nullptr) {
         // client should be managed (is not ignored)
         // but is not managed yet
         auto clientmanager = root->clients();
@@ -846,11 +847,11 @@ void maprequest(Root* root, XEvent* event) {
 void propertynotify(Root* root, XEvent* event) {
     // printf("name is: PropertyNotify\n");
     XPropertyEvent *ev = &event->xproperty;
-    Client* client;
+    Client* client = root->clients->client(ev->window);
     if (ev->state == PropertyNewValue) {
         if (root->ipcServer_.isConnectable(event->xproperty.window)) {
             root->ipcServer_.handleConnection(event->xproperty.window, callCommand);
-        } else if((client = get_client_from_window(ev->window))) {
+        } else if (client != nullptr) {
             if (ev->atom == XA_WM_HINTS) {
                 client->update_wm_hints();
             } else if (ev->atom == XA_WM_NORMAL_HINTS) {


### PR DESCRIPTION
Whenever we have a Root-pointer present, we can use the ClientManager to
resolve X Window IDs to Client-pointers.