### PR TITLE
Add an interface for monitor detection methods

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include "ipc-server.h"
 #include "keymanager.h"
 #include "layout.h"
+#include "monitordetection.h"
 #include "monitormanager.h"
 #include "mousemanager.h"
 #include "rectangle.h"
@@ -256,6 +257,8 @@ int version(Output output) {
     output << WINDOW_MANAGER_NAME << " " << HERBSTLUFT_VERSION << endl;
     output << "Copyright (c) 2011-2014 Thorsten Wißmann" << endl;
     output << "Released under the Simplified BSD License" << endl;
+    bool xinerama = MonitorDetection::xinerama().detect_ != nullptr;
+    output << "Xinerama support: " << (xinerama ? "on" : "off") << endl;
     return 0;
 }
 

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -566,7 +566,11 @@ Monitor* monitor_with_coordinate(int x, int y) {
 
 int detect_monitors_command(int argc, const char **argv, Output output) {
     auto root = Root::get();
-    RectangleVec monitor_rects = detectMonitorsXinerama(root->X);
+    auto xinerama = MonitorDetection::xinerama();
+    RectangleVec monitor_rects = {};
+    if (xinerama.detect_) {
+        monitor_rects = xinerama.detect_(root->X);
+    }
     if (monitor_rects.empty()) {
         monitor_rects = { root->X.windowSize(root->X.root()) };
     }

--- a/src/monitordetection.cpp
+++ b/src/monitordetection.cpp
@@ -6,7 +6,7 @@
 #include <X11/extensions/Xinerama.h>
 #endif /* XINERAMA */
 
-MonitorDetection::MonitorDetection(std::string name)
+MonitorDetection::MonitorDetection(string name)
     : name_(name)
     , checkDisplay_(nullptr)
     , detect_(nullptr)

--- a/src/monitordetection.cpp
+++ b/src/monitordetection.cpp
@@ -6,6 +6,8 @@
 #include <X11/extensions/Xinerama.h>
 #endif /* XINERAMA */
 
+using std::string;
+
 MonitorDetection::MonitorDetection(string name)
     : name_(name)
     , checkDisplay_(nullptr)

--- a/src/monitordetection.cpp
+++ b/src/monitordetection.cpp
@@ -6,6 +6,13 @@
 #include <X11/extensions/Xinerama.h>
 #endif /* XINERAMA */
 
+MonitorDetection::MonitorDetection(std::string name)
+    : name_(name)
+    , checkDisplay_(nullptr)
+    , detect_(nullptr)
+{
+}
+
 #ifdef XINERAMA
 // inspired by dwm's isuniquegeom()
 static bool geom_unique(const RectangleVec& unique, XineramaScreenInfo *info) {
@@ -15,6 +22,11 @@ static bool geom_unique(const RectangleVec& unique, XineramaScreenInfo *info) {
             return false;
     }
     return true;
+}
+
+
+static bool checkDisplayXinerama(XConnection& X) {
+    return XineramaIsActive(X.display());
 }
 
 // inspired by dwm's updategeom()
@@ -38,11 +50,14 @@ RectangleVec detectMonitorsXinerama(XConnection& X) {
     XFree(info);
     return monitor_rects;
 }
-#else  /* XINERAMA */
-
-RectangleVec detectMonitorsXinerama(XConnection& X) {
-    return {};
-}
 
 #endif /* XINERAMA */
 
+MonitorDetection MonitorDetection::xinerama() {
+    MonitorDetection md("xinerama");
+    #ifdef XINERAMA
+    md.checkDisplay_ = checkDisplayXinerama;
+    md.detect_ = detectMonitorsXinerama;
+    #endif
+    return md;
+}

--- a/src/monitordetection.h
+++ b/src/monitordetection.h
@@ -1,9 +1,23 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "x11-types.h"
 
 class XConnection;
 
-//! returns a list of monitors or an empty list if no xinerama is present
-RectangleVec detectMonitorsXinerama(XConnection& X);
+class MonitorDetection {
+public:
+    MonitorDetection(std::string name);
+    std::string name_;
+    /** whether this is supported by the X display.
+     * This pointer is null if the monitor detection is deactivated at compile time
+     */
+    bool (*checkDisplay_)(XConnection& X);
+    //! run the detection
+    RectangleVec (*detect_)(XConnection& X);
+
+    static MonitorDetection xinerama();
+};
 

--- a/src/monitordetection.h
+++ b/src/monitordetection.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 #include "x11-types.h"
 


### PR DESCRIPTION
The interface for the monitor detection can be used in the version
command in order to print information about the features compiled into
herbstluftwm.