### PR TITLE
Close window on _NET_CLOSE_WINDOW

### DIFF
--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -38,6 +38,7 @@ const std::array<const char*,NetCOUNT>g_netatom_names =
     { NetSupported                   , "_NET_SUPPORTED"                    },
     { NetClientList                  , "_NET_CLIENT_LIST"                  },
     { NetClientListStacking          , "_NET_CLIENT_LIST_STACKING"         },
+    { NetCloseWindow                 , "_NET_CLOSE_WINDOW"                 },
     { NetNumberOfDesktops            , "_NET_NUMBER_OF_DESKTOPS"           },
     { NetCurrentDesktop              , "_NET_CURRENT_DESKTOP"              },
     { NetDesktopNames                , "_NET_DESKTOP_NAMES"                },
@@ -361,6 +362,11 @@ void Ewmh::handleClientMessage(XEvent* event) {
                 // anything else is a resize
                 root_->mouse->mouse_initiate_resize(client, {});
             }
+            break;
+        }
+
+        case NetCloseWindow: {
+            windowClose(me->window);
             break;
         }
 

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -18,6 +18,7 @@ enum {
     NetSupported = 0,
     NetClientList,
     NetClientListStacking,
+    NetCloseWindow,
     NetNumberOfDesktops,
     NetCurrentDesktop,
     NetDesktopNames,


### PR DESCRIPTION
Pagers wanting to close a window send a _NET_CLOSE_WINDOW client message
to the root window, and this must be handled by the window
manager.

This adapts 0fdac2411db5f81e5d31515505aad00f17e6def7 to the winterbreeze
branch.