### PR TITLE
Update all clients' ewmh desktop after tag removal

### DIFF
--- a/src/root.cpp
+++ b/src/root.cpp
@@ -52,7 +52,7 @@ Root::Root(Globals g, XConnection& xconnection, IpcServer& ipcServer)
     // inject dependencies where needed
     ewmh->injectDependencies(this);
     settings->injectDependencies(this);
-    tags->injectDependencies(monitors(), settings());
+    tags->injectDependencies(monitors(), clients(), settings());
     clients->injectDependencies(settings(), theme(), ewmh.get());
     monitors->injectDependencies(settings(), tags());
 

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "client.h"
+#include "clientmanager.h"
 #include "ewmh.h"
 #include "frametree.h"
 #include "globals.h"
@@ -27,7 +28,8 @@ TagManager::TagManager()
 {
 }
 
-void TagManager::injectDependencies(MonitorManager* m, Settings *s) {
+void TagManager::injectDependencies(MonitorManager* m, ClientManager* c, Settings *s) {
+    clients_ = c;
     monitors_ = m;
     settings_ = s;
 }
@@ -120,7 +122,6 @@ int TagManager::removeTag(Input input, Output output) {
         client->tag()->stack->removeSlice(client->slice);
         client->setTag(targetTag);
         client->tag()->stack->insertSlice(client->slice);
-        Ewmh::get().windowUpdateTag(client->window_, client->tag());
         targetTag->frame->focusedFrame()->insertClient(client);
     }
 
@@ -139,6 +140,9 @@ int TagManager::removeTag(Input input, Output output) {
     Ewmh::get().updateCurrentDesktop();
     Ewmh::get().updateDesktops();
     Ewmh::get().updateDesktopNames();
+    for (auto client : clients_->clients()) {
+        Ewmh::get().windowUpdateTag(client.first, client.second->tag());
+    }
     tag_set_flags_dirty();
     hook_emit({"tag_removed", removedName, targetTag->name()});
 

--- a/src/tagmanager.h
+++ b/src/tagmanager.h
@@ -7,6 +7,7 @@
 #include "tag.h"
 
 class Client;
+class ClientManager;
 class FrameTree;
 class Monitor;
 class MonitorManager;
@@ -17,7 +18,7 @@ typedef void (FrameTree::*FrameCompleter)(Completion&);
 class TagManager : public IndexingObject<HSTag> {
 public:
     TagManager();
-    void injectDependencies(MonitorManager* m, Settings *s);
+    void injectDependencies(MonitorManager* m, ClientManager* c, Settings *s);
 
     int removeTag(Input input, Output output);
     int tag_add_command(Input input, Output output);
@@ -39,6 +40,7 @@ public:
 private:
     void onTagRename(HSTag* tag);
     ByName by_name_;
+    ClientManager* clients_;
     MonitorManager* monitors_ = {}; // circular dependency
     Settings* settings_;
     Link_<HSTag> focus_;


### PR DESCRIPTION
When removing a tag, update the ewmh desktop field for each client
because the indices have changed.