### PR TITLE
Explicitly manage desktop windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(herbstluftwm PRIVATE
     completion.h
     completion.h completion.cpp
     decoration.cpp decoration.h
+    desktopwindow.h desktopwindow.cpp
     entity.cpp entity.h
     ewmh.cpp ewmh.h
     floating.cpp floating.h

--- a/src/client.h
+++ b/src/client.h
@@ -67,7 +67,7 @@ public:
     HSTag* tag() { return tag_; }
     void setTag(HSTag* tag) { tag_ = tag; }
 
-    Window x11Window() { return window_; }
+    Window x11Window() const { return window_; }
     Window decorationWindow();
     friend void mouse_function_resize(XMotionEvent* me);
 

--- a/src/desktopwindow.cpp
+++ b/src/desktopwindow.cpp
@@ -10,17 +10,18 @@ using std::vector;
 
 vector<shared_ptr<DesktopWindow>> DesktopWindow::windows;
 
-DesktopWindow::DesktopWindow(Window win, bool ifBelow) {
-    m_below = ifBelow;
-    this->win = win;
+DesktopWindow::DesktopWindow(Window win, bool ifBelow)
+    : win_(win)
+    , below_(ifBelow)
+{
 }
 
 Window DesktopWindow::window() const {
-    return win;
+    return win_;
 }
 
 bool DesktopWindow::below() const {
-    return m_below;
+    return below_;
 }
 
 void DesktopWindow::registerDesktop(Window win) {
@@ -30,7 +31,7 @@ void DesktopWindow::registerDesktop(Window win) {
 
 void DesktopWindow::lowerDesktopWindows() {
     for (auto dw : windows) {
-        XLowerWindow(g_display, dw->win);
+        XLowerWindow(g_display, dw->win_);
     }
 }
 

--- a/src/desktopwindow.h
+++ b/src/desktopwindow.h
@@ -28,8 +28,8 @@ public:
 private:
 
     // members:
-    Window win;
-    bool m_below;
+    Window win_;
+    bool below_;
     static std::vector<std::shared_ptr<DesktopWindow>> windows;
 
 };

--- a/src/desktopwindow.h
+++ b/src/desktopwindow.h
@@ -6,9 +6,7 @@
 #ifndef __HERBSTLUFT_DESKTOPWINDOW_H_
 #define __HERBSTLUFT_DESKTOPWINDOW_H_
 
-#include <X11/Xatom.h>
-#include <X11/Xlib.h>
-#include <X11/Xproto.h>
+#include <X11/X.h>
 #include <memory>
 #include <vector>
 

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -496,3 +496,18 @@ void Ewmh::windowClose(Window window) {
 Atom Ewmh::wmatom(WM proto) {
     return wmatom_[(int)proto];
 }
+
+int Ewmh::getWindowType(Window win) {
+    auto atoms = X_.getWindowPropertyAtom(win, g_netatom[NetWmWindowType]);
+    if (!atoms.has_value() || atoms.value().size() != 1) {
+        return -1;
+    }
+    Atom windowtype = atoms.value()[0];
+    for (int i = NetWmWindowTypeFIRST; i <= NetWmWindowTypeLAST; i++) {
+        // try to find the window type
+        if (windowtype == g_netatom[i]) {
+            return i;
+        }
+    }
+    return -1;
+}

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -113,6 +113,8 @@ public:
     bool isFullscreenSet(Window win);
     void clearClientProperties(Window win);
 
+    int getWindowType(Window win);
+
     bool isOwnWindow(Window win);
     void clearInputFocus();
 

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -1,13 +1,10 @@
 #include "rules.h"
 
-#include <X11/X.h>
-#include <X11/Xlib.h>
 #include <algorithm>
 #include <cstdio>
 
 #include "client.h"
 #include "ewmh.h"
-#include "globals.h"
 #include "hook.h"
 #include "root.h"
 #include "utils.h"
@@ -233,8 +230,8 @@ bool Condition::matchesWindowtype(const Client* client) const {
 }
 
 bool Condition::matchesWindowrole(const Client* client) const {
-    auto role = Root::get()->X.getWindowProperty(client->window_,
-        ATOM("WM_WINDOW_ROLE"));
+    auto& X = Root::get()->X;
+    auto role = X.getWindowProperty(client->window_, X.atom("WM_WINDOW_ROLE"));
 
     if (!role.has_value()) {
         return false;

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -225,55 +225,11 @@ bool Condition::matchesMaxage(const Client* client) const {
 }
 
 bool Condition::matchesWindowtype(const Client* client) const {
-    // that only works for atom-type utf8-string, _NET_WM_WINDOW_TYPE is int
-    //  GString* wintype=
-    //      window_property_to_g_string(g_display, client->window, wintype_atom);
-    // =>
-    // kinda duplicate from src/utils.c:window_properties_to_g_string()
-    // using different xatom type, and only calling XGetWindowProperty
-    // once, because we are sure we only need four bytes
-    long bufsize = 10;
-    char *buf;
-    Atom type_ret, wintype;
-    int format;
-    unsigned long items, bytes_left;
-    long offset = 0;
-
-    int status = XGetWindowProperty(
-            g_display,
-            client->window_,
-            g_netatom[NetWmWindowType],
-            offset,
-            bufsize,
-            False,
-            ATOM("ATOM"),
-            &type_ret,
-            &format,
-            &items,
-            &bytes_left,
-            (unsigned char**)&buf
-            );
-    // we only need precisely four bytes (one Atom)
-    // if there are bytes left, something went wrong
-    if(status != Success || bytes_left > 0 || items < 1 || buf == nullptr) {
+    int wintype = Ewmh::get().getWindowType(client->x11Window());
+    if (wintype < 0) {
         return false;
-    } else {
-        wintype= *(Atom *)buf;
-        XFree(buf);
     }
-
-    for (int i = NetWmWindowTypeFIRST; i <= NetWmWindowTypeLAST; i++) {
-        // try to find the window type
-        if (wintype == g_netatom[i]) {
-            // if found, then treat the window type as a string value,
-            // which is registered in g_netatom_names[]
-            return matches(g_netatom_names[i]);
-        }
-    }
-
-    // if no valid window type has been found,
-    // it can not match
-    return false;
+    return matches(g_netatom_names[wintype]);
 }
 
 bool Condition::matchesWindowrole(const Client* client) const {


### PR DESCRIPTION
Remember which desktop windows (xfdesktop) we have and force them to
stay below the other windows.

This is an adaption of 184f4b03a8f27563acadd07e0d5421018fe4da08 to the
new code base.