### PR TITLE
Use XGetProperty instead of XFetchName

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -518,23 +518,9 @@ void Client::update_wm_hints() {
 }
 
 void Client::update_title() {
-    std::experimental::optional<string> newName =
-        Root::get()->X.getWindowProperty(this->window_, g_netatom[NetWmName]);
-
-    if (!newName.has_value()) {
-        char* ch_new_name = nullptr;
-        /* if EWMH name isn't set, then fall back to WM_NAME */
-        if (0 != XFetchName(g_display, this->window_, &ch_new_name)) {
-            newName = string(ch_new_name);
-            XFree(ch_new_name);
-        } else {
-            newName = string("");
-            HSDebug("no title for window %lx found, using \"\"\n",
-                    this->window_);
-        }
-    }
-    bool changed = this->title_() != newName;
-    title_ = newName.value();
+    string newName = ewmh.getWindowTitle(window_);
+    bool changed = title_() != newName;
+    title_ = newName;
     if (changed && get_current_client() == this) {
         hook_emit({"window_title_changed", WindowID(window_).str(), title_()});
     }

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -85,6 +85,7 @@ Ewmh::Ewmh(XConnection& xconnection)
         }
         g_netatom[i] = XInternAtom(X_.display(), g_netatom_names[i], False);
     }
+    wmatom_[(int)WM::Name] = XInternAtom(g_display, "WM_NAME", False);
     wmatom_[(int)WM::Protocols] = XInternAtom(g_display, "WM_PROTOCOLS", False);
     wmatom_[(int)WM::Delete] = XInternAtom(g_display, "WM_DELETE_WINDOW", False);
     wmatom_[(int)WM::State] = XInternAtom(g_display, "WM_STATE", False);
@@ -499,3 +500,16 @@ void Ewmh::windowClose(Window window) {
 Atom Ewmh::wmatom(WM proto) {
     return wmatom_[(int)proto];
 }
+
+string Ewmh::getWindowTitle(Window win) {
+    auto newName = X_.getWindowProperty(win, g_netatom[NetWmName]);
+    if (newName.has_value()) {
+        return newName.value();
+    }
+    newName = X_.getWindowProperty(win, wmatom(WM::Name));
+    if (newName.has_value()) {
+        return newName.value();
+    }
+    return "";
+}
+

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -91,7 +91,7 @@ public:
     Ewmh(XConnection& xconnection);
     ~Ewmh();
 
-    enum class WM { Protocols, Delete, State, TakeFocus, Last };
+    enum class WM { Name, Protocols, Delete, State, TakeFocus, Last };
 
     void injectDependencies(Root* root);
     void updateAll();
@@ -112,6 +112,7 @@ public:
     bool isWindowStateSet(Window win, Atom hint);
     bool isFullscreenSet(Window win);
     void clearClientProperties(Window win);
+    std::string getWindowTitle(Window win);
 
     bool isOwnWindow(Window win);
     void clearInputFocus();


### PR DESCRIPTION
This makes the window title getting work for utf8- and non-utf8-strings.
In XConnection::getWindowProperty(), convert an iso-encoded XA_STRING to
utf8.

This fixes #522.