### PR TITLE
Cast to current xevent type during event handler call

### DIFF
--- a/src/keymanager.cpp
+++ b/src/keymanager.cpp
@@ -117,7 +117,7 @@ void KeyManager::removeKeybindCompletion(Completion &complete) {
     }
 }
 
-void KeyManager::handleKeyPress(XEvent* ev) const {
+void KeyManager::handleKeyPress(XKeyEvent* ev) const {
     KeyCombo pressed = xKeyGrabber_.xEventToKeyCombo(ev);
 
     auto found = std::find_if(binds.begin(), binds.end(),

--- a/src/keymanager.h
+++ b/src/keymanager.h
@@ -72,7 +72,7 @@ public:
     void addKeybindCompletion(Completion &complete);
     void removeKeybindCompletion(Completion &complete);
 
-    void handleKeyPress(XEvent* ev) const;
+    void handleKeyPress(XKeyEvent* ev) const;
 
     void regrabAll();
     void ensureKeyMask(const Client* client = nullptr);

--- a/src/xkeygrabber.cpp
+++ b/src/xkeygrabber.cpp
@@ -38,10 +38,10 @@ void XKeyGrabber::updateNumlockMask() {
  * Normalization means stripping any ignored modifiers from the modifier mask
  * (including the runtime-defined Numlock mask).
  */
-KeyCombo XKeyGrabber::xEventToKeyCombo(XEvent *ev) const {
+KeyCombo XKeyGrabber::xEventToKeyCombo(XKeyEvent* ev) const {
     KeyCombo combo;
-    combo.keysym = XkbKeycodeToKeysym(g_display, ev->xkey.keycode, 0, 0);
-    combo.modifiers_ = ev->xkey.state;
+    combo.keysym = XkbKeycodeToKeysym(g_display, ev->keycode, 0, 0);
+    combo.modifiers_ = ev->state;
 
     // Normalize
     combo.modifiers_ &= ~(numlockMask_ | LockMask);

--- a/src/xkeygrabber.h
+++ b/src/xkeygrabber.h
@@ -19,7 +19,7 @@ public:
 
     void updateNumlockMask();
 
-    KeyCombo xEventToKeyCombo(XEvent *ev) const;
+    KeyCombo xEventToKeyCombo(XKeyEvent *ev) const;
 
     void grabKeyCombo(const KeyCombo& keyCombo);
     void ungrabKeyCombo(const KeyCombo& keyCombo);

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -12,29 +12,29 @@ public:
     void run();
     //! quit the main loop as soon as possible
     void quit();
-private:
     using EventHandler = void (XMainLoop::*)(XEvent*);
+private:
     // members
     XConnection& X_;
     Root* root_;
     bool aboutToQuit_;
     EventHandler handlerTable_[LASTEvent];
     // event handlers
-    void buttonpress(XEvent* event);
-    void buttonrelease(XEvent* event);
-    void clientmessage(XEvent* event);
-    void createnotify(XEvent* event);
-    void configurerequest(XEvent* event);
-    void configurenotify(XEvent* event);
-    void destroynotify(XEvent* event);
-    void enternotify(XEvent* event);
+    void buttonpress(XButtonEvent* event);
+    void buttonrelease(XButtonEvent* event);
+    void clientmessage(XClientMessageEvent* event);
+    void createnotify(XCreateWindowEvent* event);
+    void configurerequest(XConfigureRequestEvent* cre);
+    void configurenotify(XConfigureEvent* event);
+    void destroynotify(XUnmapEvent* event);
+    void enternotify(XCrossingEvent* event);
     void expose(XEvent* event);
     void focusin(XEvent* event);
-    void keypress(XEvent* event);
-    void mappingnotify(XEvent* event);
-    void motionnotify(XEvent* event);
-    void mapnotify(XEvent* event);
-    void maprequest(XEvent* event);
-    void propertynotify(XEvent* event);
-    void unmapnotify(XEvent* event);
+    void keypress(XKeyEvent* event);
+    void mappingnotify(XMappingEvent* event);
+    void motionnotify(XMotionEvent* event);
+    void mapnotify(XMapEvent* event);
+    void maprequest(XMapRequestEvent* event);
+    void propertynotify(XPropertyEvent* event);
+    void unmapnotify(XUnmapEvent* event);
 };


### PR DESCRIPTION
Formerly, every event handler blindly casted the event to the expected
to the "right" event type by accessing the corresponding union member.
The current approach is as (un)safe, but it is less work in the event
handler.