### PR TITLE
Fix key combo tokenizing with trailing delemiter

### DIFF
--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -172,15 +172,7 @@ vector<string> ModifierCombo::tokensFromString(string keySpec)
     for (auto &sep : string(separators)) {
         std::replace(keySpec.begin(), keySpec.end(), sep, baseSep);
     }
-
-    // Split spec into tokens:
-    vector<string> tokens;
-    string token;
-    std::istringstream tokenStream(keySpec);
-    while (std::getline(tokenStream, token, baseSep)) {
-        tokens.push_back(token);
-    }
-    return tokens;
+    return ArgList::split(keySpec, baseSep);
 }
 
 /*!

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -130,12 +130,16 @@ def test_invalid_keymask_has_no_effect(hlwm, keyboard, maskmethod):
     assert hlwm.get_attr('tags.0.client_count') == '0'
 
 
-def test_complete_keybind_offers_all_mods_and_syms(hlwm):
-    complete = hlwm.complete('keybind', partial=True, position=1)
+@pytest.mark.parametrize('prefix', ['', 'Mod1+'])
+def test_complete_keybind_offers_all_mods_and_syms(hlwm, prefix):
+    complete = hlwm.complete(['keybind', prefix], partial=True, position=1)
 
     assert len(complete) > 200  # plausibility check
+    all_mods = ['Alt', 'Control', 'Ctrl', 'Mod1', 'Mod2', 'Mod3', 'Mod4', 'Mod5', 'Shift', 'Super']
+    if prefix == 'Mod1+':
+        all_mods = [m for m in all_mods if m not in ['Mod1', 'Alt']]
     assert sorted([c[:-1] for c in complete if c.endswith('+')]) == \
-        ['Alt', 'Control', 'Ctrl', 'Mod1', 'Mod2', 'Mod3', 'Mod4', 'Mod5', 'Shift', 'Super']
+        sorted([prefix + m for m in all_mods])
 
 
 def test_complete_keybind_after_combo_offers_all_commands(hlwm):

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -70,12 +70,13 @@ def test_overlapping_bindings_most_recent_one_counts(hlwm, mouse):
     assert hlwm.get_attr('my_press') == 'secondbind'
 
 
-def test_complete_mousebind_offers_all_mods_and_buttons(hlwm):
-    complete = hlwm.complete('mousebind', partial=True, position=1)
+@pytest.mark.parametrize('prefix', ['', 'Mod1+'])
+def test_complete_mousebind_offers_all_mods_and_buttons(hlwm, prefix):
+    complete = hlwm.complete(['mousebind', prefix], partial=True, position=1)
 
     buttons = sum(([f'Button{i}', f'B{i}'] for i in MOUSE_BUTTONS_THAT_EXIST), [])
     mods = ['Alt', 'Control', 'Ctrl', 'Mod1', 'Mod2', 'Mod3', 'Mod4', 'Mod5', 'Shift', 'Super']
-    assert sorted(c[:-1] for c in complete) == sorted(mods + buttons)
+    assert sorted(c[:-1] for c in complete) == sorted(prefix + i for i in mods + buttons)
 
 
 def test_complete_mousebind_after_button_offers_action(hlwm):

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -70,13 +70,12 @@ def test_overlapping_bindings_most_recent_one_counts(hlwm, mouse):
     assert hlwm.get_attr('my_press') == 'secondbind'
 
 
-@pytest.mark.parametrize('prefix', ['', 'Mod1+'])
-def test_complete_mousebind_offers_all_mods_and_buttons(hlwm, prefix):
-    complete = hlwm.complete(['mousebind', prefix], partial=True, position=1)
+def test_complete_mousebind_offers_all_mods_and_buttons(hlwm):
+    complete = hlwm.complete('mousebind', partial=True, position=1)
 
     buttons = sum(([f'Button{i}', f'B{i}'] for i in MOUSE_BUTTONS_THAT_EXIST), [])
     mods = ['Alt', 'Control', 'Ctrl', 'Mod1', 'Mod2', 'Mod3', 'Mod4', 'Mod5', 'Shift', 'Super']
-    assert sorted(c[:-1] for c in complete) == sorted(prefix + i for i in mods + buttons)
+    assert sorted(c[:-1] for c in complete) == sorted(mods + buttons)
 
 
 def test_complete_mousebind_after_button_offers_action(hlwm):


### PR DESCRIPTION
Use ArgList::split() to split a key combo into tokens, since this
handles a trailing delemiter correctly. E.g. "Mod1+Mod4+" splits
correctly to ["Mod1", "Mod4", ""]. This fixes the keybind and mousebind
completion for e.g. "Mod1+" and "Mod1+Mod4+".