### PR TITLE
Remove window_set_visible(), inline event masks

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -101,7 +101,9 @@ void Client::make_full_client() {
                             ButtonPressMask | ButtonReleaseMask |
                             ExposureMask |
                             SubstructureRedirectMask | FocusChangeMask));
-    XSelectInput(g_display, window_, CLIENT_EVENT_MASK);
+    XSelectInput(g_display, window_,
+                            StructureNotifyMask|FocusChangeMask
+                            |EnterWindowMask|PropertyChangeMask);
 }
 
 bool Client::ignore_unmapnotify() {
@@ -416,21 +418,6 @@ bool Client::is_client_floated() {
 
 void Client::requestClose() { //! ask the client to close
     ewmh.windowClose(window_);
-}
-
-void window_set_visible(Window win, bool visible) {
-    static int (*action[])(Display*,Window) = {
-        XUnmapWindow,
-        XMapWindow,
-    };
-    unsigned long event_mask = CLIENT_EVENT_MASK;
-    XGrabServer(g_display);
-    XSelectInput(g_display, win, event_mask & ~StructureNotifyMask);
-    XSelectInput(g_display, g_root, ROOT_EVENT_MASK & ~SubstructureNotifyMask);
-    action[visible](g_display, win);
-    XSelectInput(g_display, win, event_mask);
-    XSelectInput(g_display, g_root, ROOT_EVENT_MASK);
-    XUngrabServer(g_display);
 }
 
 void Client::set_visible(bool visible) {

--- a/src/client.h
+++ b/src/client.h
@@ -136,6 +136,4 @@ int client_set_property_command(int argc, char** argv);
 bool is_window_class_ignored(char* window_class);
 bool is_window_ignored(Window win);
 
-void window_set_visible(Window win, bool visible);
-
 #endif

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -36,7 +36,7 @@ ClientManager::~ClientManager()
         XMoveResizeWindow(g_display, window, r.x, r.y, r.width, r.height);
         XReparentWindow(g_display, window, g_root, r.x, r.y);
         ewmh->updateFrameExtents(window, 0,0,0,0);
-        window_set_visible(window, true);
+        XMapWindow(g_display, window);
         delete c.second;
     }
 }

--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -106,14 +106,18 @@ void FrameDecoration::updateVisibility(const FrameDecorationData& data, bool isF
               || isFocused;
     if (show != visible) {
         visible = show;
-        window_set_visible(window, visible);
+        if (visible) {
+            XMapWindow(g_display, window);
+        } else {
+            XUnmapWindow(g_display, window);
+        }
     }
 }
 
 void FrameDecoration::hide() {
     if (visible) {
         visible = false;
-        window_set_visible(window, visible);
+        XUnmapWindow(g_display, window);
     }
 }
 

--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -3,7 +3,6 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 
-#include "client.h"
 #include "ewmh.h"
 #include "globals.h"
 #include "settings.h"

--- a/src/globals.h
+++ b/src/globals.h
@@ -11,10 +11,6 @@
 #define WINDOW_MIN_HEIGHT 32
 #define WINDOW_MIN_WIDTH 32
 
-#define ROOT_EVENT_MASK (SubstructureRedirectMask|SubstructureNotifyMask|ButtonPressMask|EnterWindowMask|LeaveWindowMask|StructureNotifyMask)
-//#define CLIENT_EVENT_MASK (PropertyChangeMask | FocusChangeMask | StructureNotifyMask)
-#define CLIENT_EVENT_MASK (StructureNotifyMask|FocusChangeMask|EnterWindowMask|PropertyChangeMask)
-
 // minimum relative fraction of split frames
 #define FRAME_MIN_FRACTION 0.1
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -620,7 +620,7 @@ int main(int argc, char* argv[]) {
     g_screen_width = X->screenWidth();
     g_screen_height = X->screenHeight();
     g_root = X->root();
-    XSelectInput(g_display, g_root, ROOT_EVENT_MASK);
+    XSelectInput(X->display(), X->root(), SubstructureRedirectMask|SubstructureNotifyMask|ButtonPressMask|EnterWindowMask|LeaveWindowMask|StructureNotifyMask);
 
     // setup ipc server
     IpcServer* ipcServer = new IpcServer(*X);


### PR DESCRIPTION
Remove the expensive and actually unneeded window_set_visible() and do
XMapWindow() and XUnmapWindow() where we actually need it. Note that
window_set_visible() was so complex because it has been used for
clients, formerly.

This allows us to inline the definitions of ROOT_EVENT_MASK and
CLIENT_EVENT_MASK.