### PR TITLE
Maintain clients.dragged link and explicit drag state

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -594,11 +594,6 @@ Window get_window(const string& str) {
     }
 }
 
-void Client::set_dragged(bool drag_state) {
-    if (drag_state == dragged_) return;
-    dragged_ = drag_state;
-}
-
 void Client::fuzzy_fix_initial_position() {
     // find out the top-left-most position of the decoration,
     // considering the current settings of possible floating decorations

--- a/src/client.h
+++ b/src/client.h
@@ -91,8 +91,6 @@ public:
     void update_title();
     void raise();
 
-    void set_dragged(bool drag_state);
-
     void send_configure();
     bool applysizehints(int *w, int *h);
     bool applysizehints_xy(int *x, int *y, int *w, int *h);

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -24,6 +24,7 @@ using std::string;
 
 ClientManager::ClientManager()
     : focus(*this, "focus")
+    , dragged(*this, "dragged")
 {
 }
 
@@ -90,6 +91,16 @@ void ClientManager::add(Client* client)
     clients_[client->window_] = client;
     client->needsRelayout.connect(needsRelayout);
     addChild(client, client->window_id_str);
+}
+
+void ClientManager::setDragged(Client* client) {
+    if (dragged()) {
+        dragged()->dragged_ = false;
+    }
+    dragged = client;
+    if (dragged()) {
+        dragged()->dragged_ = true;
+    }
 }
 
 void ClientManager::remove(Window window)
@@ -218,7 +229,8 @@ void ClientManager::unmap_notify(Window win) {
 }
 
 void ClientManager::force_unmanage(Client* client) {
-    if (client->dragged_) {
+    if (dragged() == client) {
+        dragged = nullptr;
         Root::get()->mouse->mouse_stop_drag();
     }
     if (client->tag() && client->slice) {

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -36,8 +36,11 @@ public:
     void force_unmanage(Window win);
     void force_unmanage(Client* client);
 
+    void setDragged(Client* client);
+
     Signal_<HSTag*> needsRelayout;
     Link_<Client> focus;
+    Link_<Client> dragged;
 
     int pseudotile_cmd(Input input, Output output);
     int fullscreen_cmd(Input input, Output output);

--- a/src/indexingobject.h
+++ b/src/indexingobject.h
@@ -65,7 +65,7 @@ public:
     }
 
     T* byIdx(size_t idx) {
-        return data[idx];
+        return idx < data.size() ? data[idx] : nullptr;
     }
 
     size_t size() {

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -184,13 +184,21 @@ function<int(Input, Output)> MonitorManager::byFirstArg(MonitorCommand cmd)
     };
 }
 
-void MonitorManager::relayoutTag(HSTag *tag)
-{
+
+Monitor* MonitorManager::byTag(HSTag* tag) {
     for (Monitor* m : *this) {
         if (m->tag == tag) {
-            m->applyLayout();
-            break;
+            return m;
         }
+    }
+    return nullptr;
+}
+
+void MonitorManager::relayoutTag(HSTag* tag)
+{
+    Monitor* m = byTag(tag);
+    if (m) {
+        m->applyLayout();
     }
 }
 

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -29,6 +29,7 @@ public:
     void clearChildren();
     void ensure_monitors_are_available();
     Monitor* byString(std::string str);
+    Monitor* byTag(HSTag* tag);
     int list_monitors(Output output);
     int list_padding(Input input, Output output);
     int string_to_monitor_index(std::string string);

--- a/src/mousemanager.h
+++ b/src/mousemanager.h
@@ -8,14 +8,22 @@
 #include "optional.h"
 #include "x11-types.h"
 
+class ClientManager;
 class Completion;
+class MonitorManager;
 
 typedef void (MouseManager::*MouseDragFunction)(Point2D);
 
 class MouseManager : public Object {
 public:
+    enum class Mode {
+        NoDrag,
+        DraggingClient,
+    };
     MouseManager();
     ~MouseManager();
+
+    void injectDependencies(ClientManager* clients, MonitorManager* monitors);
 
     int addMouseBindCommand(Input input, Output output);
 
@@ -48,10 +56,16 @@ public:
     void mouse_function_zoom(Point2D newCursorPos);
 
 private:
+    //! check whether we can continue dragging
+    bool draggingIsStillSafe();
+    Mode mode_;
     Cursor cursor;
+    ClientManager*  clients_;
+    MonitorManager*  monitors_;
     Point2D          buttonDragStart_;
     Rectangle        winDragStart_;
     Client*        winDragClient_ = nullptr;
     Monitor*       dragMonitor_ = nullptr;
+    unsigned int dragMonitorIndex_ = 0;
     MouseDragFunction dragFunction_ = nullptr;
 };

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -43,12 +43,12 @@ Root::Root(Globals g, XConnection& xconnection, IpcServer& ipcServer)
     hooks.init();
     keys.init();
     monitors.init();
+    mouse.init();
     rules.init();
     settings.init();
     tags.init();
     theme.init();
     tmp.init();
-    mouse.init(); // needs MonitorManager (implicitly)
 
     // inject dependencies where needed
     ewmh->injectDependencies(this);
@@ -56,6 +56,7 @@ Root::Root(Globals g, XConnection& xconnection, IpcServer& ipcServer)
     tags->injectDependencies(monitors(), settings());
     clients->injectDependencies(settings(), theme(), ewmh.get());
     monitors->injectDependencies(settings(), tags());
+    mouse->injectDependencies(clients(), monitors());
 
     // set temporary globals
     ::global_tags = tags();


### PR DESCRIPTION
Explicitly maintain a drag mode in the MouseManager and maintain a
clients.dragged state (as in master) that points to the currently
dragged client window.