### PR TITLE
Make man page date reproducible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,10 +298,11 @@ if(WITH_DOCUMENTATION)
             COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/doc/"
             # asciidoc doesn't support destination directory for manpages
             COMMAND ${CMAKE_COMMAND} -E copy ${src_orig} ${src}
+            STRING(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)
             COMMAND ${ASCIIDOC_A2X}
                     -f manpage
                     -a \"herbstluftwmversion=herbstluftwm ${VERSION}\"
-                    -a \"date=`date +%Y-%m-%d`\"
+                    -a \"date=${BUILD_DATE}\"
                     ${src}
             DEPENDS ${src_orig}
         )

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ tar: doc
 
 doc/%.1 doc/%.7: doc/%.txt version.mk
 	$(call colorecho,DOC,$@)
-	$(VERBOSE) $(A2X) -f manpage -a "herbstluftwmversion=herbstluftwm $(VERSION)" -a "date=`date +%Y-%m-%d`" $<
+	$(VERBOSE) $(A2X) -f manpage -a "herbstluftwmversion=herbstluftwm $(VERSION)" -a "date=`date -u -r NEWS %Y-%m-%d`" $<
 
 doc/%.html: doc/%.txt version.mk
 	$(call colorecho,DOC,$@)


### PR DESCRIPTION
cmake already uses `SOURCE_DATE_EPOCH` for its `TIMESTAMP` function.

Makefile could use it as well as documented in
https://reproducible-builds.org/docs/source-date-epoch/

Note: cmake codepath needs testing. I only tested the Makefile part.