### PR TITLE
Use first window type in rules if there are multiple

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1138,7 +1138,8 @@ Valid 'properties' are:
     you can build rules that only live for a certain time.)
 
 +windowtype+::
-    matches the _NET_WM_WINDOW_TYPE property of a window.
+    matches the _NET_WM_WINDOW_TYPE property of a window. If _NET_WM_WINDOW_TYPE
+    has multiple entries, then only the first entry is used here.
 
 +windowrole+::
     matches the WM_WINDOW_ROLE property of a window if it is set by the window.

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -515,6 +515,11 @@ string Ewmh::getWindowTitle(Window win) {
     return "";
 }
 
+/** Return the window type of the given window. If there are mutliple entries, then
+ * only the first window type entry is returned. The return value is an enum value between
+ * NetWmWindowTypeFIRST and NetWmWindowTypeLAST (inclusive). Any other window
+ * type is not recognized and leads to -1 being returned.
+ */
 int Ewmh::getWindowType(Window win) {
     auto atoms = X_.getWindowPropertyAtom(win, g_netatom[NetWmWindowType]);
     if (!atoms.has_value() || atoms.value().size() < 1) {

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -517,7 +517,7 @@ string Ewmh::getWindowTitle(Window win) {
 
 int Ewmh::getWindowType(Window win) {
     auto atoms = X_.getWindowPropertyAtom(win, g_netatom[NetWmWindowType]);
-    if (!atoms.has_value() || atoms.value().size() != 1) {
+    if (!atoms.has_value() || atoms.value().size() < 1) {
         return -1;
     }
     Atom windowtype = atoms.value()[0];


### PR DESCRIPTION
If a window has multiple window types, then use the first window type
entry. This establishes the behaviour of the 'windowtype' rule condition
from the old herbstluftwm codebase.

This should fix issue #554.