### PR TITLE
Disable sanitize flags

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -61,6 +61,7 @@ build_env = os.environ.copy()
 build_env.update({
     'CC': args.cc,
     'CXX': args.cxx,
+    'CXXFLAGS': '-fsanitize=address,leak,undefined',
 })
 
 cmake_args = [

--- a/cmake/debugflags.cmake
+++ b/cmake/debugflags.cmake
@@ -6,7 +6,7 @@ set(FLAGS
     -Werror
 
     # Sanitizers:
-    -fsanitize=address,leak,undefined
+    #-fsanitize=address,leak,undefined
 
     # All kinds of pedantic warnings:
     -pedantic -Wall -Wextra


### PR DESCRIPTION
These flags are make it impossible to use valgrind or gdb, so those who
need the sanitze flags have to activate them explictly.

This we acitvate them manually in the CI.