### PR TITLE
Drop EnterNotify events after unmap

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,8 @@ Current git version
   * The 'keybind' command now accepts all valid key symbols, even if they are
     not present on the current keyboard layout at the time of setup.
   * 'detect_monitors' has an additional '--list-all' parameter
+  * do not change the focus (for focus_follows_mouse=1) when an unmanaged
+    dialog (e.g. a rofi menu or a notification) closes.
 
 Release 0.7.2 on 2019-05-28
 ---------------------------

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -382,5 +382,9 @@ void XMainLoop::unmapnotify(XUnmapEvent* event) {
         // to forcefully make the window dissappear.
         XUnmapWindow(X_.display(), event->window);
     }
+    // drop all enternotify events
+    XSync(X_.display(), False);
+    XEvent ev;
+    while (XCheckMaskEvent(X_.display(), EnterWindowMask, &ev));
 }
 


### PR DESCRIPTION
If a (unmanaged) dialog has the mouse cursor inside and closes, then an
EnterNotify event is triggered for the next window under the cursor.
With focus_follows_mouse=1 this causes a usually undesired focus change.