### PR TITLE
Run herbstluftwm with valgrind in test suite

### DIFF
--- a/ci/Dockerfile.ci-disco
+++ b/ci/Dockerfile.ci-disco
@@ -18,6 +18,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     pkg-config \
     python3.7 \
     tox \
+    valgrind \
     xdotool \
     xterm \
     xvfb \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,7 +269,7 @@ class HlwmProcess:
         autostart.chmod(0o755)
         bin_path = os.path.join(BINDIR, 'herbstluftwm')
         self.proc = subprocess.Popen(
-            [bin_path, '--verbose'], env=env,
+            ['valgrind', '--tool=memcheck', '--error-exitcode=3', bin_path, '--verbose'], env=env,
             bufsize=0,  # essential for reading output with selectors!
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,9 +235,12 @@ class HlwmBridge:
     def shutdown(self):
         for client_proc in self.client_procs:
             client_proc.terminate()
-            client_proc.wait(2)
 
         self.hc_idle.terminate()
+
+        for client_proc in self.client_procs:
+            client_proc.wait(3)
+
         self.hc_idle.wait(2)
 
     def bool(self, python_bool_var):
@@ -383,7 +386,7 @@ class HlwmProcess:
             # only wait the process if it hasn't been cleaned up
             # this also avoids the second exception if hlwm crashed
             try:
-                assert self.proc.wait(2) == 0
+                assert self.proc.wait(5) == 0
             except subprocess.TimeoutExpired:
                 self.proc.kill()
                 self.proc.wait(2)
@@ -429,7 +432,7 @@ class HcIdle:
     def shutdown(self):
         self.proc.terminate()
         try:
-            self.proc.wait(2)
+            self.proc.wait(3)
         except subprocess.TimeoutExpired:
             self.proc.kill()
             self.proc.wait(2)

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -88,7 +88,7 @@ def test_keymask(hlwm, keyboard, maskmethod, whenbind, refocus):
     if maskmethod == 'rule':
         hlwm.call('rule once keymask=^x$')
 
-    _, client_proc = hlwm.create_client(term_command='read -n 1')
+    winid, client_proc = hlwm.create_client(term_command='read -n 1')
 
     if maskmethod == 'set_attr':
         hlwm.call('set_attr clients.focus.keymask ^x$')
@@ -99,6 +99,7 @@ def test_keymask(hlwm, keyboard, maskmethod, whenbind, refocus):
         hlwm.create_client()
         hlwm.call('cycle +1')
         hlwm.call('cycle -1')
+    assert hlwm.get_attr('clients.focus.winid') == winid
 
     keyboard.press('x')
 
@@ -124,6 +125,8 @@ def test_invalid_keymask_has_no_effect(hlwm, keyboard, maskmethod):
         # Note: In future work, we could make this fail right away. But
         # currently, that is not the case.
         hlwm.call('set_attr clients.focus.keymask [b-a]')
+
+    hlwm.call('true')
 
     keyboard.press('x')
 


### PR DESCRIPTION
Run the test suite with valgrind and let the test suite fail if there
are any errors reported by valgrind.