### PR TITLE
Always use focus layer in tiling mode

### DIFF
--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -155,14 +155,25 @@ void Monitor::applyLayout() {
             c->raise();
         }
     }
+    HSDebug("setting up focus layer\n");
     tag->stack->clearLayer(LAYER_FOCUS);
     if (isFocused && res.focus) {
+        HSDebug("we have the focus\n");
         // activate the focus layer if requested by the setting
         // or if there is a fullscreen client potentially covering
-        // the focused client
+        // the focused client.
+        // Also activate raise on focus in tiling mode to make the decoration
+        // of the focused window look better. If we don't raise it
+        // (temporarily), then the shadow of another window can
+        // cover the decoration of the focused client. To avoid that
+        // the decoration of the focused window is covered by the shadow
+        // of an unfocused window,
+        // we raise the focused window. Without shadows, this has no effect.
         if (g_settings->raise_on_focus_temporarily()
-            || tag->stack->isLayerEmpty(LAYER_FULLSCREEN) == false)
+            || tag->stack->isLayerEmpty(LAYER_FULLSCREEN) == false
+            || tag->floating() == false)
         {
+            HSDebug("filling focus layer\n");
             tag->stack->sliceAddLayer(res.focus->slice, LAYER_FOCUS);
         }
     }

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -108,6 +108,7 @@ def test_stack_tree(hlwm):
   -
     - Monitor 1 ("monitor2") with tag "tag2"
       - Focus-Layer
+        - Client <windowid> "bash"
       - Fullscreen-Layer
       - Normal Layer
         - Client <windowid> "bash"


### PR DESCRIPTION
This avoids that the decoration of a focused window is covered by the
shadow of an unfocused window.