### PR TITLE
Move --coverage and -Werror build flags to ci config

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -61,6 +61,8 @@ build_env = os.environ.copy()
 build_env.update({
     'CC': args.cc,
     'CXX': args.cxx,
+    'CFLAGS': '--coverage -Werror',
+    'CXXFLAGS': '--coverage -Werror',
 })
 
 cmake_args = [

--- a/cmake/debugflags.cmake
+++ b/cmake/debugflags.cmake
@@ -2,8 +2,8 @@
 
 set(FLAGS
     # General debug flags:
-    -g -O1 -fno-omit-frame-pointer --coverage
-    -Werror
+    -g -O1 -fno-omit-frame-pointer
+    # --coverage -Werror
 
     # Sanitizers:
     #-fsanitize=address,leak,undefined


### PR DESCRIPTION
It makes no sense for a user to build the project with -Werror. Also,
--coverage causes warnings here (even after recompiling in a fresh build
directory). Since both flags are not needed in normal use, the don't
belong to the default configuration, but only to the ci-config (where
it's good to be picky!).