### PR TITLE
[WIP][winterbreeze] Make position monitor-relative on configure request

### DIFF
--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -186,8 +186,19 @@ void XMainLoop::configurerequest(XConfigureRequestEvent* cre) {
             bool height_requested = 0 != (cre->value_mask & CWHeight);
             bool x_requested = 0 != (cre->value_mask & CWX);
             bool y_requested = 0 != (cre->value_mask & CWY);
-            cre->width += 2*cre->border_width;
-            cre->height += 2*cre->border_width;
+            // find monitor appropriate for client
+            Monitor* m = find_monitor_with_tag(client->tag());
+            if (!m) {
+                m = monitor_with_coordinate(client->float_size_.x,
+                                            client->float_size_.y);
+                if (!m) {
+                    m = get_current_monitor();
+                }
+            }
+            // requested coordinates are relative to the root window.
+            // convert them to coordinates relative to the monitor.
+            cre->x -= m->rect.x + m->pad_left;
+            cre->y -= m->rect.y + m->pad_up;
             if (width_requested && newRect.width  != cre->width) changes = true;
             if (height_requested && newRect.height != cre->height) changes = true;
             if (x_requested || y_requested) changes = true;


### PR DESCRIPTION
A client's floating window position is relative to the monitor the
client is on. However, the coordinates of a configure request is
relative to the root window. So convert the coordinates. If the client
is not visible, we fuzzily find the most appropriate monitor based on
the coordinates of the client.

Ported from ebed05c.

The code compiles but it does not yet show the expected behaviour -> WIP