### PR TITLE
Move monitor_with_cooridnate to MonitorManager

### DIFF
--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -587,18 +587,6 @@ int Monitor::relativeY(int y_root) {
     return y_root - rect.y - pad_up;
 }
 
-Monitor* monitor_with_coordinate(int x, int y) {
-    for (auto m : *g_monitors) {
-        if (m->rect.x + m->pad_left <= x
-            && m->rect.x + m->rect.width - m->pad_right > x
-            && m->rect.y + m->pad_up <= y
-            && m->rect.y + m->rect.height - m->pad_down > y) {
-            return &* m;
-        }
-    }
-    return nullptr;
-}
-
 int detect_monitors_command(int argc, const char **argv, Output output) {
     auto root = Root::get();
     RectangleVec monitor_rects = {};

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -56,7 +56,6 @@ private:
 };
 
 // adds a new monitor to the monitors list and returns a pointer to it
-Monitor* monitor_with_coordinate(int x, int y);
 Monitor* find_monitor_with_tag(HSTag* tag);
 void monitor_focus_by_index(unsigned new_selection);
 int monitor_cycle_command(int argc, char** argv);

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -194,6 +194,24 @@ Monitor* MonitorManager::byTag(HSTag* tag) {
     return nullptr;
 }
 
+/**
+ * @brief Find the monitor having the given coordinate
+ * @param coordinate on a monitor
+ * @return The monitor with the coordinate or nullptr if the coordinate is outside of any monitor
+ */
+Monitor *MonitorManager::byCoordinate(Point2D p)
+{
+    for (Monitor* m : *this) {
+        if (m->rect.x + m->pad_left <= p.x
+            && m->rect.x + m->rect.width - m->pad_right > p.x
+            && m->rect.y + m->pad_up <= p.y
+            && m->rect.y + m->rect.height - m->pad_down > p.y) {
+            return &* m;
+        }
+    }
+    return nullptr;
+}
+
 void MonitorManager::relayoutTag(HSTag* tag)
 {
     Monitor* m = byTag(tag);

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -30,6 +30,7 @@ public:
     void ensure_monitors_are_available();
     Monitor* byString(std::string str);
     Monitor* byTag(HSTag* tag);
+    Monitor* byCoordinate(Point2D coordinate);
     int list_monitors(Output output);
     int list_padding(Input input, Output output);
     int string_to_monitor_index(std::string string);


### PR DESCRIPTION
Move the function that finds a monitor with a given coordinate to the
class MonitorManager. The function is not used at the moment but will be
useful at some point.