### PR TITLE
Make initial client positions monitor relative

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -15,6 +15,7 @@
 #include "keymanager.h"
 #include "layout.h"
 #include "monitor.h"
+#include "monitormanager.h"
 #include "mousemanager.h"
 #include "root.h"
 #include "settings.h"
@@ -74,7 +75,9 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
 
 void Client::init_from_X() {
     // treat wanted coordinates as floating coords
-    float_size_ = Root::get()->X.windowSize(window_);
+    auto root = Root::get();
+    auto globalGeometry = root->X.windowSize(window_);
+    float_size_ = root->monitors->interpretGlobalGeometry(globalGeometry);
     last_size_ = float_size_;
 
     pid_ = Root::get()->X.windowPid(window_);

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -505,6 +505,35 @@ void MonitorManager::setMonitorsCompletion(Completion&) {
     // we don't have completion for rectangles
 }
 
+/**
+ * @brief Transform a rectangle on the screen into a rectangle relative to one of the monitor.
+ * Currently, we pick the monitor that has the biggest intersection with the given rectangle.
+ *
+ * @param globalGeometry A rectangle whose coordinates are interpreted relative to (0,0) on the screen
+ * @return The given rectangle with coordinates relative to a monitor
+ */
+Rectangle MonitorManager::interpretGlobalGeometry(Rectangle globalGeometry)
+{
+    int bestArea = 0;
+    Monitor* best = nullptr;
+    for (Monitor* m : *this) {
+        auto intersection = m->rect.intersectionWith(globalGeometry);
+        if (!intersection) {
+            continue;
+        }
+        auto area = intersection.width * intersection.height;
+        if (area > bestArea) {
+            bestArea = area;
+            best = m;
+        }
+    }
+    if (best) {
+        globalGeometry.x -= best->rect.x + *best->pad_left;
+        globalGeometry.y -= best->rect.y + *best->pad_up;
+    }
+    return globalGeometry;
+}
+
 int MonitorManager::raiseMonitorCommand(Input input, Output output) {
     string monitorName = "";
     input >> monitorName;

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -63,6 +63,8 @@ public:
     int setMonitorsCommand(Input input, Output output);
     void setMonitorsCompletion(Completion& complete);
 
+    Rectangle interpretGlobalGeometry(Rectangle globalGeometry);
+
     int cur_monitor;
 
 private:

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -3,6 +3,7 @@
 #include <X11/X.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <algorithm>
 #include <cassert>
 #include <iomanip>
 
@@ -113,6 +114,28 @@ bool Rectangle::operator==(const Rectangle& other) const
         && y == other.y
         && width == other.width
         && height == other.height;
+}
+
+/**
+ * @brief Check whether a rectangle has non-negative width and height
+ */
+Rectangle::operator bool() const
+{
+    return (width >= 0) && (height >= 0);
+}
+
+/**
+ * @brief Return the intersection with another rectangel
+ * @param the other rectangle
+ * @return the intersection
+ */
+Rectangle Rectangle::intersectionWith(const Rectangle &other) const
+{
+    return Rectangle::fromCorners(
+                std::max(x, other.x),
+                std::max(y, other.y),
+                std::min(br().x, other.br().x),
+                std::min(br().y, other.br().y));
 }
 
 std::ostream& operator<< (std::ostream& stream, const Rectangle& rect) {

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -76,6 +76,10 @@ struct Rectangle {
     bool operator<(const Rectangle& other) const;
     bool operator==(const Rectangle& other) const;
 
+    operator bool() const;
+
+    Rectangle intersectionWith(const Rectangle& other) const;
+
     int x;
     int y;
     int width;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -550,9 +550,14 @@ def x11(x11_connection):
             resp = window.get_full_property(prop, X.AnyPropertyType)
             return resp.value if resp is not None else None
 
-        def create_client(self, urgent=False, pid=None):
+        def create_client(self, urgent=False, pid=None,
+                          geometry=(50, 50, 300, 200)):
             w = self.root.create_window(
-                50, 50, 300, 200, 2,
+                geometry[0],
+                geometry[1],
+                geometry[2],
+                geometry[3],
+                2,
                 self.screen.root_depth,
                 X.InputOutput,
                 X.CopyFromParent,
@@ -575,6 +580,25 @@ def x11(x11_connection):
             w.map()
             self.display.sync()
             return w, self.winid_str(w)
+
+        def get_absolute_top_left(self, window):
+            """return the absolute (x,y) coordinate of the given window,
+            i.e. relative to the root window"""
+            x = 0
+            y = 0
+            while True:
+                # the following coordinates are only relative
+                # to the parent of window
+                geom = window.get_geometry()
+                x += geom.x
+                y += geom.y
+                # check if the window's parent is already the root window
+                tree = window.query_tree()
+                if tree.root == tree.parent:
+                    break
+                # if it's not, continue at its parent
+                window = tree.parent
+            return (x, y)
 
         def shutdown(self):
             # Destroy all created windows:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -219,3 +219,27 @@ def test_use_previous_on_stolen_monitor(hlwm):
     hlwm.call('use_previous')
 
     assert hlwm.get_attr('tags.focus.name') == 'tag3'
+
+
+@pytest.mark.parametrize("two_monitors", [True, False])
+def test_initial_client_position(hlwm, x11, two_monitors):
+    # create two monitors side by side (with a little y-offset)
+    if two_monitors:
+        hlwm.call('add other')
+        hlwm.call('set_monitors 173x174+4+5 199x198+200+100')
+        hlwm.call('focus_monitor 1')
+    hlwm.call('set_attr theme.border_width 0')  # disable border
+    # add pad to the focused monitor and set its tag to floating
+    hlwm.call('pad +0 12 13 14 15')
+    hlwm.call('floating on')
+
+    # create a new window in the area of the second monitor.
+    g = (250, 160, 81, 82)  # x, y, width, height
+    w, winid = x11.create_client(geometry=g)
+    assert int(hlwm.get_attr('tags.focus.client_count')) == 1
+
+    # check that the new client has the desired geometry
+    win_geo = w.get_geometry()
+    assert (win_geo.width, win_geo.height) == (g[2], g[3])
+    x, y = x11.get_absolute_top_left(w)
+    assert (x, y) == (g[0], g[1])


### PR DESCRIPTION
When a new client window suggests its window size, it does so by
proposing (x,y)-coordinates relative to (0,0) of the root window. We
now detect within which monitor the new window lies and transform the
coordinates to be relative to that monitor.

If the user puts the clinet window on the monitor within the window's
requested coordinates are, then the client window is precisely at its
requested coordinates. The new test case checks this (both for one and
two monitors).