### PR TITLE
Apply rules to Override Redirect windows as well

### DIFF
--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -109,7 +109,7 @@ void ClientManager::remove(Window window)
     clients_.erase(window);
 }
 
-Client* ClientManager::manage_client(Window win, bool visible_already) {
+Client* ClientManager::manage_client(Window win, bool visible_already, bool force_unmanage) {
     if (is_herbstluft_window(g_display, win)) {
         // ignore our own window
         return nullptr;
@@ -125,7 +125,7 @@ Client* ClientManager::manage_client(Window win, bool visible_already) {
 
     // apply rules
     ClientChanges changes = Root::get()->rules()->evaluateRules(client);
-    if (!changes.manage) {
+    if (!changes.manage || force_unmanage) {
         // map it... just to be sure
         XMapWindow(g_display, win);
         delete client;

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -48,7 +48,7 @@ public:
     void fullscreen_complete(Completion& complete);
 
     // adds a new client to list of managed client windows
-    Client* manage_client(Window win, bool visible_already);
+    Client* manage_client(Window win, bool visible_already, bool force_unmanage);
 
 protected:
     int clientSetAttribute(std::string attribute, Input input, Output output);

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -91,7 +91,7 @@ void XMainLoop::scanExistingClients() {
         }
         if (wa.map_state == IsViewable
             || isInOriginalClients(win)) {
-            clientmanager->manage_client(win, true);
+            clientmanager->manage_client(win, true, false);
             XMapWindow(X_.display(), win);
         }
     }
@@ -105,7 +105,7 @@ void XMainLoop::scanExistingClients() {
             continue;
         }
         XReparentWindow(X_.display(), win, X_.root(), 0,0);
-        clientmanager->manage_client(win, true);
+        clientmanager->manage_client(win, true, false);
     }
 }
 
@@ -329,6 +329,10 @@ void XMainLoop::mapnotify(XMapEvent* event) {
         }
         // also update the window title - just to be sure
         c->update_title();
+    } else {
+        // the window is not managed.
+        HSDebug("MapNotify: briefly managing %lx to apply rules\n", event->window);
+        root_->clients()->manage_client(event->window, true, true);
     }
 }
 
@@ -355,7 +359,7 @@ void XMainLoop::maprequest(XMapRequestEvent* mapreq) {
             // client should be managed (is not ignored)
             // but is not managed yet
             auto clientmanager = root_->clients();
-            auto client = clientmanager->manage_client(window, false);
+            auto client = clientmanager->manage_client(window, false, false);
             if (client && find_monitor_with_tag(client->tag())) {
                 XMapWindow(X_.display(), window);
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -551,7 +551,9 @@ def x11(x11_connection):
             return resp.value if resp is not None else None
 
         def create_client(self, urgent=False, pid=None,
-                          geometry=(50, 50, 300, 200)):
+                          geometry=(50, 50, 300, 200),
+                          force_unmanage=False,
+                          ):
             w = self.root.create_window(
                 geometry[0],
                 geometry[1],
@@ -562,6 +564,7 @@ def x11(x11_connection):
                 X.InputOutput,
                 X.CopyFromParent,
                 background_pixel=self.screen.white_pixel,
+                override_redirect=force_unmanage,
             )
 
             # Keep track of window for later removal:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -323,3 +323,15 @@ def test_unmanage(hlwm, x11, manage):
 
     expected_children = [] if manage == 'off' else [winid, 'focus']
     assert hlwm.list_children('clients') == expected_children
+
+
+@pytest.mark.parametrize('force_unmanage', [False, True])
+def test_rule_hook_unmanaged(hlwm, x11, hc_idle, force_unmanage):
+    # here, we test that a new window fires a rule with a hook, regardless
+    # of whether the window is managable or not (e.g. menus). The crucial case
+    # is of course for force_unmanage=True.
+    hlwm.call('rule hook=somewindow')
+
+    _, winid = x11.create_client(force_unmanage=force_unmanage)
+
+    assert ['rule', 'somewindow', str(winid)] in hc_idle.hooks()


### PR DESCRIPTION
This adapts the commits 738a0ce and a11e88fc from master to
winterbreeze, and herewith solves #521.

This commit moreover adds a testcase to ensure that the rules are indeed
applied for unmanaged windows ('Override Redirect' in the X11
vocabulary).