### PR TITLE
Make MouseDragHandler an abstract class

### DIFF
--- a/src/mousedraghandler.h
+++ b/src/mousedraghandler.h
@@ -1,16 +1,24 @@
 #pragma once
 
 #include <exception>
+#include <functional>
+#include <memory>
 
 #include "x11-types.h"
 
 class Client;
 class Monitor;
 class MonitorManager;
-class MouseDragHandler;
+class MouseDragHandlerFloating;
 
-typedef void (MouseDragHandler::*MouseDragFunction)(Point2D);
+typedef void (MouseDragHandlerFloating::*MouseDragFunction)(Point2D);
 
+/**
+ * @brief The abstract class MouseDragHandler encapsulates what drag handling
+ should do: after starting, it is fed with new coordinates whenever the mouse
+ cursor moves. This is done until mouse dragging stops or until the dragged
+ resources disappear.
+ */
 class MouseDragHandler {
 public:
     class DragNotPossible : virtual public std::exception {
@@ -22,10 +30,28 @@ public:
         virtual ~DragNotPossible() throw () {}
     };
     //! possibly throws a DragNotPossible exception
-    MouseDragHandler(MonitorManager* monitors_, Client* dragClient, MouseDragFunction function);
-    void finalize();
-    void handle_motion_event(Point2D newCursorPos);
+    virtual ~MouseDragHandler() {};
+    virtual void finalize() = 0;
+    virtual void handle_motion_event(Point2D newCursorPos) = 0;
 
+    //! a MouseDragHandler::Constructor creates a MouseDragHandler object, given the
+    //! MonitorManager (as a dependency) and the actual client to drag.
+    typedef std::function<std::shared_ptr<MouseDragHandler>(MonitorManager*, Client*)> Constructor;
+protected:
+    MouseDragHandler() {};
+};
+
+/**
+ * @brief The MouseDragHandlerFloating class manages the dragging (i.e. mouse
+ * moving and resizing) of clients in floating mode
+ */
+class MouseDragHandlerFloating : public MouseDragHandler {
+public:
+    MouseDragHandlerFloating(MonitorManager* monitors_, Client* dragClient, MouseDragFunction function);
+    virtual ~MouseDragHandlerFloating() {};
+    virtual void finalize();
+    virtual void handle_motion_event(Point2D newCursorPos);
+    static Constructor construct(MouseDragFunction dragFunction);
     /* some mouse drag functions */
     void mouse_function_move(Point2D newCursorPos);
     void mouse_function_resize(Point2D newCursorPos);

--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -112,15 +112,24 @@ void MouseManager::mouse_handle_event(unsigned int modifiers, unsigned int butto
     (this ->* (b->action))(client, b->cmd); }
 
 void MouseManager::mouse_initiate_move(Client* client, const vector<string> &cmd) {
-    mouse_initiate_drag(client, &MouseDragHandler::mouse_function_move);
+    mouse_initiate_drag(
+                client,
+                MouseDragHandlerFloating::construct(
+                    &MouseDragHandlerFloating::mouse_function_move));
 }
 
 void MouseManager::mouse_initiate_zoom(Client* client, const vector<string> &cmd) {
-    mouse_initiate_drag(client, &MouseDragHandler::mouse_function_zoom);
+    mouse_initiate_drag(
+                client,
+                MouseDragHandlerFloating::construct(
+                    &MouseDragHandlerFloating::mouse_function_zoom));
 }
 
 void MouseManager::mouse_initiate_resize(Client* client, const vector<string> &cmd) {
-    mouse_initiate_drag(client, &MouseDragHandler::mouse_function_resize);
+    mouse_initiate_drag(
+                client,
+                MouseDragHandlerFloating::construct(
+                    &MouseDragHandlerFloating::mouse_function_resize));
 }
 
 void MouseManager::mouse_call_command(Client* client, const vector<string> &cmd) {
@@ -135,10 +144,10 @@ void MouseManager::mouse_call_command(Client* client, const vector<string> &cmd)
     clients_->setDragged(nullptr);
 }
 
-void MouseManager::mouse_initiate_drag(Client *client, void (MouseDragHandler::*function)(Point2D))
+void MouseManager::mouse_initiate_drag(Client *client, const MouseDragHandler::Constructor& createHandler)
 {
     try {
-        dragHandler_ = std::make_shared<MouseDragHandler>(monitors_, client, function);
+        dragHandler_ = createHandler(monitors_, client);
         // only grab pointer if dragHandler_ could be started
         clients_->setDragged(client);
         XGrabPointer(g_display, client->x11Window(), True,

--- a/src/mousemanager.h
+++ b/src/mousemanager.h
@@ -47,7 +47,9 @@ public:
     void mouse_call_command(Client* client, const std::vector<std::string> &cmd);
 
 private:
-    void mouse_initiate_drag(Client* client, void (MouseDragHandler::*function)(Point2D));
+    //! manually (forward-)declare MouseDragHandler::Constructor as MDC here:
+    typedef std::function<std::shared_ptr<MouseDragHandler>(MonitorManager*, Client*)> MDC;
+    void mouse_initiate_drag(Client* client, const MDC& createHandler);
 
     std::shared_ptr<MouseDragHandler> dragHandler_;
     Cursor cursor;


### PR DESCRIPTION
The abstract class MouseDragHandler encapsulates what drag handling
should do: after starting, it is fed with new coordinates whenever the
mouse cursor moves. This is done until mouse dragging stops or until the
dragged resources disappear.

Currently, it's only subclass is MouseDragHandlerFloating that handles
the dragging of clients in floating mode.

The present commit is a step towards mouse resizing in tiling mode
(issue #520).