### PR TITLE
Preserve focus and client order after frame removal

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,8 @@ Current git version
   * monitor detection via xrandr
   * list_rules now prints regex-based rule conditions with '~' instead of '='
   * new command: export (convenience wrapper around setenv)
+  * the 'remove' command now tries to preserve the focus and the client
+    arrangement. Intutively speaking, 'remove' is undoing a frame split.
 
 Release 0.7.2 on 2019-05-28
 ---------------------------

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -145,18 +145,31 @@ int FrameTree::removeFrameCommand() {
         // do nothing if is toplevel frame
         return 0;
     }
+    auto clientFocusIndex = frame->getSelection();
     auto parent = frame->getParent();
     auto pp = parent->getParent();
     auto newparent = (frame == parent->firstChild())
                      ? parent->secondChild()
                      : parent->firstChild();
-    focusedFrame(newparent)->addClients(frame->removeAllClients());
+    bool insertAtFront = (frame == parent->firstChild());
+    auto removedFrameClients = frame->removeAllClients();
+    auto targetFrame = focusedFrame(newparent);
+    int oldClientCount = (int)targetFrame->clientCount();
+    targetFrame->addClients(removedFrameClients, insertAtFront);
     // now, frame is empty
     if (pp) {
         pp->replaceChild(parent, newparent);
     } else {
         // if parent was root frame
         root_ = newparent;
+    }
+    // focus the same client again
+    if (removedFrameClients.size() > 0) {
+        if (insertAtFront) {
+            targetFrame->setSelection(clientFocusIndex);
+        } else {
+            targetFrame->setSelection(clientFocusIndex + oldClientCount);
+        }
     }
     get_current_monitor()->applyLayout();
     return 0;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -423,8 +423,9 @@ void HSFrameSplit::replaceChild(shared_ptr<HSFrame> old, shared_ptr<HSFrame> new
     }
 }
 
-void HSFrameLeaf::addClients(const vector<Client*>& vec) {
-    for (auto c : vec) clients.push_back(c);
+void HSFrameLeaf::addClients(const vector<Client*>& vec, bool atFront) {
+    auto targetPosition = atFront ? clients.begin() : clients.end();
+    clients.insert(targetPosition, vec.begin(), vec.end());
 }
 
 bool HSFrameLeaf::split(SplitAlign alignment, int fraction, size_t childrenLeaving) {

--- a/src/layout.h
+++ b/src/layout.h
@@ -104,7 +104,7 @@ public:
     // own members
     void setSelection(int idx);
     void select(Client* client);
-    void addClients(const std::vector<Client*>& vec);
+    void addClients(const std::vector<Client*>& vec, bool atFront = false);
 
 
     Client* focusedClient() override;

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -34,8 +34,30 @@ def test_remove(hlwm, running_clients, running_clients_num):
     assert int(hlwm.get_attr('tags.0.curframe_wcount')) == running_clients_num
     assert int(hlwm.get_attr('tags.0.client_count')) == running_clients_num
     assert hlwm.get_attr('tags.0.frame_count') == '1'
-    # TODO: reasonably handle focus, e.g. to have
-    # assert hlwm.get_attr('tags.0.curframe_windex') == '2'
+
+
+@pytest.mark.parametrize("running_clients_num", [4])
+@pytest.mark.parametrize("focus_idx", [0, 1, 2, 3])
+def test_remove_client_focus(hlwm, running_clients, running_clients_num, focus_idx):
+    layout = """
+        (split horizontal:0.5:{x}
+          (clients vertical:{y} {} {})
+          (clients vertical:{z} {} {}))
+    """.format(*running_clients,
+               x=(focus_idx // 2),
+               y=(focus_idx % 2),
+               z=(focus_idx % 2)).strip()
+    hlwm.call(['load', layout])
+    focus = hlwm.get_attr('clients.focus.winid')
+    assert running_clients[focus_idx] == focus
+
+    hlwm.call('remove')
+
+    # then the focus is preserved
+    assert focus == hlwm.get_attr('clients.focus.winid')
+    # and the clients appear in the original order
+    assert ' '.join(running_clients) in hlwm.call('dump').stdout
+    assert hlwm.get_attr('tags.0.frame_count') == '1'
 
 
 @pytest.mark.parametrize("running_clients_num", [3, 4])


### PR DESCRIPTION
When removing a frame, insert the clients of the removed frame in the
target frame at the beginning or the end, depending on how the clients
were aligned visually before the split. Moreover, preserve the client
focus.

In total, the new semantics of the 'remove' command is less 'removing
the frame' but more 'undoing the split'.