### PR TITLE
Move clients to closest frame in nested split

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -488,7 +488,7 @@ shift_to_monitor 'MONITOR'::
     See the <<MONITORS,MONITORS section>>, how to address a monitor.
 
 remove::
-    Removes focused frame and merges its windows to its neighbour frame.
+    Removes focused frame and merges its windows to its closest neighbour frame.
 
 rotate::
     Rotates the layout on the focused tag counterclockwise by 90 degrees. This


### PR DESCRIPTION
When removing a frame whose direct sibling is a frame-split itself, then
move the clients of the removed frame to the closest child frame of the
sibling, and not the focused one.

This also adds a test case and consequently solves #593.