### PR TITLE
Make 'verbose' setting modifiable at run-time

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1082,7 +1082,7 @@ update_dragged_clients (Int)::
     it with the mouse. If unset, the client's content is resized after the mouse
     button are released.
 
-verbose (Int)::
+verbose (Bool)::
     If set, verbose output is logged to herbstluftwm's stderr. The default value
     is controlled by the *--verbose* command line flag.
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -38,7 +38,10 @@ Settings::Settings()
                                  getColorAttr("theme.tiling.urgent.color"),
                                  setColorAttr("theme.urgent.color"))
 {
+    verbose = g_verbose > 0;
+    verbose.changed().connect([](bool newVal) { g_verbose = newVal; });
     wireAttributes({
+        &verbose,
         &frame_gap,
         &frame_padding,
         &window_gap,

--- a/src/settings.h
+++ b/src/settings.h
@@ -28,6 +28,7 @@ public:
     void cycle_value_complete(Completion& complete);
 
     // all the settings:
+    Attribute_<bool>          verbose = {"verbose", false};
     Attribute_<int>           frame_gap = {"frame_gap", 5};
     Attribute_<int>           frame_padding = {"frame_padding", 0};
     Attribute_<int>           window_gap = {"window_gap", 0};


### PR DESCRIPTION
This adapts 40e2a2ce85e7 to winterbreeze.