### PR TITLE
Fix clamping in HSFrameLeaf::removeClient()

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -91,7 +91,7 @@ bool HSFrameLeaf::removeClient(Client* client) {
         // else shift it by 1
         selection -= (selection < idx) ? 0 : 1;
         // ensure valid index
-        selection = std::max(std::min(selection, (int)clients.size()), 0);
+        selection = std::max(std::min(selection, ((int)clients.size()) - 1), 0);
         return true;
     } else {
         return false;


### PR DESCRIPTION
The selection can be at most clients.size() - 1, so enforce it to be at most this bound. Technically, the overflow can not happen, because if the n'th window in a frame with n windows is removed then the line before already decreases 'selection' by 1.