### PR TITLE
Clearing a monitor name is always allowed

### DIFF
--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -365,6 +365,10 @@ string MonitorManager::isValidMonitorName(string name) {
     if (isdigit(name[0])) {
         return "Invalid name \"" + name + "\": The monitor name may not start with a number";
     }
+    if (name.empty()) {
+        // clearing a name is always OK.
+        return "";
+    }
     if (find_monitor_by_name(name.c_str())) {
         return "A monitor with the name \"" + name + "\" already exists";
     }


### PR DESCRIPTION
Do not perform the uniqueness check for a new monitor name if the
monitor name is cleared.