### PR TITLE
Detect EWMH panels and update monitor pads

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,17 +4,13 @@ herbstluftwm NEWS -- History of user-visible changes
 Current git version
 -------------------
 
+  * monitor detection via xrandr
+  * detection of external panels
+  * new command: export (convenience wrapper around setenv)
   * The build system is now cmake. See the INSTALL file if you need to
     compile herbstluftwm yourself.
-  * Formerly, double dots in object paths were allowed (similar to double
-    slashes in file paths in unix). Right now, they are only allowed at the end
-    (which is necessary for the tab-completion of attr):
-    - +monitors+ is valid
-    - +monitors.+ is valid
-    - +monitors..+ is valid
-    - +monitors.by-name.+ is valid
-    - +monitors..by-name.+ is *invalid*
-
+  * the 'remove' command now tries to preserve the focus and the client
+    arrangement. Intuitively speaking, 'remove' is undoing a frame split.
   * Many boolean style settings were formerly of type int. Now, these are
     boolean settings.
   * The 'toggle' command only works for boolean settings. For the former
@@ -26,12 +22,16 @@ Current git version
   * 'detect_monitors' has an additional '--list-all' parameter
   * do not change the focus (for focus_follows_mouse=1) when an unmanaged
     dialog (e.g. a rofi menu or a notification) closes.
-  * monitor detection via xrandr
   * list_rules now prints regex-based rule conditions with '~' instead of '='
-  * new command: export (convenience wrapper around setenv)
-  * the 'remove' command now tries to preserve the focus and the client
-    arrangement. Intuitively speaking, 'remove' is undoing a frame split.
   * new attributes on every monitor for pad_up pad_down pad_left pad_right
+  * Formerly, double dots in object paths were allowed (similar to double
+    slashes in file paths in unix). Right now, they are only allowed at the end
+    (which is necessary for the tab-completion of attr):
+    - +monitors+ is valid
+    - +monitors.+ is valid
+    - +monitors..+ is valid
+    - +monitors.by-name.+ is valid
+    - +monitors..by-name.+ is *invalid*
 
 Release 0.7.2 on 2019-05-28
 ---------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(herbstluftwm PRIVATE
     object.cpp object.h
     optional.h
     plainstack.h
+    panelmanager.h panelmanager.cpp
     rectangle.cpp rectangle.h
     rootcommands.cpp rootcommands.h
     root.cpp root.h

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -46,6 +46,7 @@ Monitor::Monitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, 
     , pad_down  (this, "pad_down", 0)
     , pad_left  (this, "pad_left", 0)
     , lock_tag  (this, "lock_tag", false)
+    , pad_automatically_set ({false, false, false, false})
     , dirty(true)
     , mouse { 0, 0 }
     , rect(rect_)
@@ -259,6 +260,7 @@ int Monitor::move_cmd(Input input, Output output) {
     if (!input.empty()) pad_down.change(input.front());
     input.shift();
     if (!input.empty()) pad_left.change(input.front());
+    monitorMoved.emit();
     applyLayout();
     return 0;
 }

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -29,6 +29,9 @@ public:
     Attribute_<int>         pad_down;
     Attribute_<int>         pad_left;
     Attribute_<bool>        lock_tag;
+    // whether the above pads were determined automatically
+    // from autodetected panels
+    std::vector<bool>       pad_automatically_set;
     bool        dirty;
     bool        lock_frames;
     struct {
@@ -38,6 +41,7 @@ public:
     } mouse;
     Rectangle   rect;   // area for this monitor
     Window      stacking_window;   // window used for making stacking easy
+    Signal monitorMoved;
     void setIndexAttribute(unsigned long index) override;
     int lock_tag_cmd(Input argv, Output output);
     int unlock_tag_cmd(Input argv, Output output);

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -14,6 +14,7 @@ extern MonitorManager* g_monitors;
 
 class CommandBinding;
 class Completion;
+class PanelManager;
 class TagManager;
 class HSTag;
 class HSFrame;
@@ -25,7 +26,7 @@ class MonitorManager : public IndexingObject<Monitor> {
 public:
     MonitorManager();
     ~MonitorManager();
-    void injectDependencies(Settings* s, TagManager* t);
+    void injectDependencies(Settings* s, TagManager* t, PanelManager* panels);
 
     Link_<Monitor> focus;
 
@@ -51,6 +52,8 @@ public:
     void removeMonitor(Monitor* monitor);
     // if the name is valid monitor name, return "", otherwise return an error message
     std::string isValidMonitorName(std::string name);
+
+    void autoUpdatePads();
 
     int indexInDirection(Monitor* m, Direction dir);
 
@@ -78,6 +81,7 @@ private:
     PlainStack<Monitor*> monitorStack_;
 
     ByName by_name_;
+    PanelManager* panels_;
     TagManager* tags_;
     Settings* settings_;
 };

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -210,7 +210,6 @@ void Object::removeChild(const string &child)
     children_.erase(child);
 }
 
-
 void Object::addHook(Hook* hook)
 {
     hooks_.push_back(hook);

--- a/src/panelmanager.cpp
+++ b/src/panelmanager.cpp
@@ -1,8 +1,5 @@
 #include "panelmanager.h"
 
-#include <X11/Xlib.h>
-
-#include "globals.h"
 #include "x11-types.h"
 #include "xconnection.h"
 

--- a/src/panelmanager.cpp
+++ b/src/panelmanager.cpp
@@ -1,0 +1,138 @@
+#include "panelmanager.h"
+
+#include <X11/Xlib.h>
+
+#include "globals.h"
+#include "x11-types.h"
+#include "xconnection.h"
+
+using std::make_pair;
+using std::string;
+using std::vector;
+
+class Panel {
+public:
+    Panel(Window winid, PanelManager& pm) : winid_(winid), pm_(pm) {}
+    Window winid_;
+    PanelManager& pm_;
+    Rectangle size_;
+    vector<long> wmStrut_ = {0, 0, 0, 0};
+    int operator[](PanelManager::WmStrut idx) const {
+        size_t i = static_cast<size_t>(idx);
+        if (i < wmStrut_.size()) {
+            return static_cast<int>(wmStrut_[i]);
+        } else if (idx == PanelManager::WmStrut::left_end_y
+               || idx == PanelManager::WmStrut::right_end_y)
+        {
+            return pm_.rootWindowGeometry_.height;
+        } else if (idx == PanelManager::WmStrut::top_end_x
+               || idx == PanelManager::WmStrut::bottom_end_x)
+        {
+            return pm_.rootWindowGeometry_.width;
+        } else {
+            return 0;
+        }
+    }
+};
+
+PanelManager::PanelManager(XConnection& xcon)
+    : xcon_(xcon)
+{
+    atomWmStrut_ = xcon_.atom("_NET_WM_STRUT");
+    atomWmStrutPartial_ = xcon_.atom("_NET_WM_STRUT_PARTIAL");
+    rootWindowGeometry_ = xcon_.windowSize(xcon_.root());
+}
+
+PanelManager::~PanelManager()
+{
+    for (auto it : panels_) {
+        delete it.second;
+    }
+}
+
+void PanelManager::registerPanel(Window win)
+{
+    Panel* p = new Panel(win, *this);
+    panels_.insert(make_pair(win, p));
+    updateReservedSpace(p);
+    panels_changed_.emit();
+}
+
+void PanelManager::unregisterPanel(Window win)
+{
+    auto it = panels_.find(win);
+    if (it == panels_.end()) {
+        return;
+    }
+    Panel* p = it->second;
+    panels_.erase(win);
+    delete p;
+    panels_changed_.emit();
+}
+
+void PanelManager::propertyChanged(Window win, Atom property)
+{
+    if (property != atomWmStrut_ && property != atomWmStrutPartial_) {
+        return;
+    }
+    auto it = panels_.find(win);
+    if (it != panels_.end()) {
+        Panel* p = it->second;
+        if (updateReservedSpace(p)) {
+            panels_changed_.emit();
+        }
+    }
+}
+
+//! read the reserved space from the panel window and return if there are changes
+bool PanelManager::updateReservedSpace(Panel* p)
+{
+    Rectangle size = xcon_.windowSize(p->winid_);
+    auto optionalWmStrut = xcon_.getWindowPropertyCardinal(p->winid_, atomWmStrut_);
+    if (!optionalWmStrut) {
+        optionalWmStrut= xcon_.getWindowPropertyCardinal(p->winid_, atomWmStrutPartial_);
+    }
+    vector<long> wmStrut = optionalWmStrut.value_or(vector<long>());
+    if (p->wmStrut_ != wmStrut || p->size_ != size) {
+        p->wmStrut_ = wmStrut;
+        p->size_ = size;
+        return true;
+    }
+    return false;
+}
+
+
+//! given the dimension of a monitor, return the space reserved for panels
+PanelManager::ReservedSpace PanelManager::computeReservedSpace(Rectangle mon)
+{
+    ReservedSpace rsTotal;
+    for (auto it : panels_) {
+        Panel& p = *(it.second);
+        ReservedSpace rs;
+        Rectangle intersection = mon.intersectionWith(p.size_);
+        if (!intersection) {
+            // monitor does not intersect with panel at all
+            continue;
+        }
+        rs.left_ = (p[WmStrut::left] > 0) ? intersection.width : 0;
+        rs.right_ = (p[WmStrut::right] > 0) ? intersection.width : 0;
+        rs.top_ = (p[WmStrut::top] > 0) ? intersection.height : 0;
+        rs.bottom_ = (p[WmStrut::bottom] > 0) ? intersection.height : 0;
+        for (size_t i = 0; i < 4; i++) {
+            rsTotal[i] = std::max(rsTotal[i], rs[i]);
+        }
+    }
+    return rsTotal;
+}
+
+void PanelManager::rootWindowChanged(int width, int height)
+{
+    rootWindowGeometry_.width = width;
+    rootWindowGeometry_.height = height;
+}
+
+int& PanelManager::ReservedSpace::operator[](size_t idx)
+{
+    vector<int*> v = {  &left_, &right_, &top_, &bottom_ };
+    return *(v[idx]);
+}

--- a/src/panelmanager.h
+++ b/src/panelmanager.h
@@ -1,12 +1,10 @@
 #pragma once
 
 #include <X11/X.h>
-
 #include <unordered_map>
 
-#include "object.h"
-#include "attribute_.h"
 #include "signal.h"
+#include "x11-types.h"
 
 class Panel;
 class XConnection;

--- a/src/panelmanager.h
+++ b/src/panelmanager.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <X11/X.h>
+
+#include <unordered_map>
+
+#include "object.h"
+#include "attribute_.h"
+#include "signal.h"
+
+class Panel;
+class XConnection;
+
+class PanelManager {
+public:
+    class ReservedSpace {
+    public:
+        int left_ = 0;
+        int right_ = 0;
+        int top_ = 0;
+        int bottom_ = 0;
+        int& operator[](size_t idx);
+    };
+    //! the entries of  _NET_WM_STRUT_PARTIAL
+    enum class WmStrut {
+        left = 0,
+        right,
+        top,
+        bottom,
+        left_start_y, left_end_y,
+        right_start_y, right_end_y,
+        top_start_x, top_end_x,
+        bottom_start_x, bottom_end_x,
+    };
+
+    PanelManager(XConnection& xcon);
+    virtual ~PanelManager();
+    void registerPanel(Window win);
+    void unregisterPanel(Window win);
+    void propertyChanged(Window win, Atom property);
+    ReservedSpace computeReservedSpace(Rectangle monitorDimension);
+    Signal panels_changed_;
+    void rootWindowChanged(int width, int height);
+private:
+    friend Panel;
+    bool updateReservedSpace(Panel* p);
+
+    std::unordered_map<Window, Panel*> panels_;
+    Atom atomWmStrut_;
+    Atom atomWmStrutPartial_;
+    XConnection& xcon_;
+    Rectangle rootWindowGeometry_;
+};

--- a/src/root.h
+++ b/src/root.h
@@ -16,6 +16,7 @@ class IpcServer;
 class KeyManager;
 class MonitorManager;
 class MouseManager;
+class PanelManager;
 class RootCommands;
 class RuleManager;
 class Settings;
@@ -60,6 +61,7 @@ public:
     IpcServer& ipcServer_;
     //! Temporary member. In the long run, ewmh should get its information
     // automatically from the signals emitted by ClientManager, etc
+    std::unique_ptr<PanelManager> panels; // Using "pimpl" to avoid include
     std::unique_ptr<Ewmh> ewmh; // Using "pimpl" to avoid include
 
 private:


### PR DESCRIPTION
Keep track of running EWMH panels (such as xfce4-panel) and their
position and automatically update the pad-settings for all monitors.