### PR TITLE
Update _NET_WM_DESKTOP in Client::setTag()

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -110,6 +110,11 @@ void Client::make_full_client() {
                             |EnterWindowMask|PropertyChangeMask);
 }
 
+void Client::setTag(HSTag *tag) {
+    tag_ = tag;
+    ewmh.windowUpdateTag(window_, tag);
+}
+
 bool Client::ignore_unmapnotify() {
     if (ignore_unmaps_ > 0) {
         ignore_unmaps_--;

--- a/src/client.h
+++ b/src/client.h
@@ -65,7 +65,7 @@ public:
 
     // setter and getter for attributes
     HSTag* tag() { return tag_; }
-    void setTag(HSTag* tag) { tag_ = tag; }
+    void setTag(HSTag* tag);
 
     Window x11Window() const { return window_; }
     Window decorationWindow();

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -185,7 +185,6 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
         client->tag()->frame->focusClient(client);
     }
 
-    ewmh->windowUpdateTag(client->window_, client->tag());
     tag_set_flags_dirty();
     client->fullscreen_ = changes.fullscreen;
     ewmh->updateWindowState(client);

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -149,9 +149,6 @@ int TagManager::removeTag(Input input, Output output) {
     Ewmh::get().updateCurrentDesktop();
     Ewmh::get().updateDesktops();
     Ewmh::get().updateDesktopNames();
-    for (auto client : Root::common().clients()) {
-        Ewmh::get().windowUpdateTag(client.first, client.second->tag());
-    }
     tag_set_flags_dirty();
     hook_emit({"tag_removed", removedName, targetTag->name()});
 
@@ -260,7 +257,6 @@ void TagManager::moveClient(Client* client, HSTag* target) {
     client->tag()->stack->removeSlice(client->slice);
     client->setTag(target);
     client->tag()->stack->insertSlice(client->slice);
-    Ewmh::get().windowUpdateTag(client->window_, client->tag());
 
     // refresh things, hide things, layout it, and then show it if needed
     if (monitor_source && !monitor_target) {

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -8,12 +8,10 @@
 #include "ewmh.h"
 #include "frametree.h"
 #include "globals.h"
-#include "hlwmcommon.h"
 #include "ipc-protocol.h"
 #include "layout.h"
 #include "monitor.h"
 #include "monitormanager.h"
-#include "root.h"
 #include "stack.h"
 #include "utils.h"
 

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -1,0 +1,22 @@
+def test_net_wm_desktop_after_load(hlwm, x11):
+    hlwm.call('add anothertag')
+    win, _ = x11.create_client()
+    hlwm.call('true')
+    assert x11.get_property('_NET_WM_DESKTOP', win)[0] == 0
+    layout = hlwm.call('dump').stdout
+
+    hlwm.call(['load', 'anothertag', layout])
+
+    assert x11.get_property('_NET_WM_DESKTOP', win)[0] == 1
+
+
+def test_net_wm_desktop_after_bring(hlwm, x11):
+    hlwm.call('add anothertag')
+    win, winid = x11.create_client()
+    hlwm.call('true')
+    assert x11.get_property('_NET_WM_DESKTOP', win)[0] == 0
+
+    hlwm.call(['use', 'anothertag'])
+    hlwm.call(['bring', winid])
+
+    assert x11.get_property('_NET_WM_DESKTOP', win)[0] == 1


### PR DESCRIPTION
Now, Client::setTag() automatically calls ewmh to update
_NET_WM_DESKTOP. Also add testcases for the concrete cases where a
client is moved to a tag via 'load' or 'bring'.

This solves #577.