### PR TITLE
Update settings types in autostart and manpage

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -495,17 +495,17 @@ rotate::
     only manipulates the alignment of frames, not the content of them.
 
 set 'NAME' 'VALUE'::
-    Sets the specified setting 'NAME' to 'VALUE'. All <<SETTINGS,*SETTINGS*>>
-    are listed in the <<SETTINGS, section below>>.
+    Sets the specified setting 'NAME' to 'VALUE'. Allowed values for boolean
+    settings are 'on' or 'true' for on, 'off' or 'false' for off, 'toggle' to
+    toggle its value. All <<SETTINGS,*SETTINGS*>> are listed in the
+    <<SETTINGS, section below>>.
 
 get 'NAME'::
     Prints the value of setting 'NAME'. All <<SETTINGS,*SETTINGS*>>
     are listed in the <<SETTINGS, section below>>.
 
 toggle 'NAME'::
-    Toggles the setting 'NAME' if it's an integer setting: If its value is
-    unequal to 0, it becomes 0; else its previous value (which was unequal to 0)
-    is restored.
+    Toggles the setting 'NAME' if it's a boolean setting.
 
 cycle_value 'NAME' 'VALUES' ...::
     Cycles value of the setting 'NAME' through 'VALUES': I.e. it searches the

--- a/share/autostart
+++ b/share/autostart
@@ -114,8 +114,8 @@ hc set frame_border_normal_color '#101010'
 hc set frame_bg_normal_color '#565656'
 hc set frame_bg_active_color '#345F0C'
 hc set frame_border_width 1
-hc set always_show_frame 1
-hc set frame_bg_transparent 1
+hc set always_show_frame on
+hc set frame_bg_transparent on
 hc set frame_transparent_width 5
 hc set frame_gap 4
 
@@ -134,8 +134,8 @@ hc attr theme.background_color '#141414'
 
 hc set window_gap 0
 hc set frame_padding 0
-hc set smart_window_surroundings 0
-hc set smart_frame_surroundings 1
+hc set smart_window_surroundings off
+hc set smart_frame_surroundings on
 hc set mouse_recenter_gap 0
 
 # rules
@@ -162,7 +162,7 @@ hc unlock
 # find the panel
 panel=~/.config/herbstluftwm/panel.sh
 [ -x "$panel" ] || panel=/etc/xdg/herbstluftwm/panel.sh
-for monitor in $(herbstclient list_monitors | cut -d: -f1) ; do
+for monitor in $(hc list_monitors | cut -d: -f1) ; do
     # start it on each monitor
     "$panel" $monitor &
 done


### PR DESCRIPTION
Update default autostart to use boolean values and on the manpage description of `toggle` and `set` (allowed values for boolean settings).