### PR TITLE
Add apply_rules command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ Current git version
 
   * monitor detection via xrandr
   * detection of external panels
+  * new command: apply_rules
   * new command: export (convenience wrapper around setenv)
   * The build system is now cmake. See the INSTALL file if you need to
     compile herbstluftwm yourself.

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -755,6 +755,9 @@ unrule 'LABEL'|*--all*|*-F*::
     Removes all rules named 'LABEL'. If --all or -F is passed, then all rules
     are removed.
 
+apply_rules 'WINID'::
+    Apply the rules to the specified window 'WINID'.
+
 fullscreen [*on*|*off*|*toggle*]::
     Sets or toggles the fullscreen state of the focused client. If no argument
     is given, fullscreen mode is toggled.
@@ -1091,9 +1094,9 @@ RULES
 -----
 
 Rules are used to change default properties for certain clients when they
-appear. Each rule matches against a certain subset of all clients and defines a
-set of properties for them (called __CONSEQUENCE__s). A rule can be defined
-with this command:
+appear and when the 'apply_rules' command is called. Each rule matches against a
+certain subset of all clients and defines a set of properties for them (called
+__CONSEQUENCE__s). A rule can be defined with this command:
 
 +rule+ [\[--]'FLAG'|\[--]'LABEL'|\[--]'CONDITION'|\[--]'CONSEQUENCE' ...]
 
@@ -1200,8 +1203,7 @@ Each 'CONSEQUENCE' consists of a 'NAME'='VALUE' pair. Valid 'NAMES' are:
     *off* or *toggle*, it defaults to *on*.
 
 +fullscreen+::
-    sets the fullscreen flag of the client. 'VALUE' can be *on*, *off* or
-    *toggle*.
+    sets the fullscreen flag of the client. 'VALUE' can be *on* or *off*.
 
 +hook+::
     emits the custom hook +rule+ 'VALUE' 'WINID' when this rule is triggered by

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -295,10 +295,8 @@ int ClientManager::applyRulesCmd(Input input, Output output) {
         tagman->moveClient(client, tag, changes.tree_index, changes.focus);
     } else if (changes.focus && (client != focus())) {
         // focus the client
-        HSDebug("FOCUSSING CLIENT %s\n", client->window_id_str().c_str());
         client->tag()->focusClient(client);
         Root::get()->monitors->relayoutTag(client->tag());
-        HSDebug("FOCUS = %s\n", focus()->window_id_str().c_str());
     }
     if (monitor && switch_tag && tag) {
         monitor_set_tag(monitor, tag);

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -9,6 +9,7 @@
 #include "signal.h"
 
 class Client;
+class ClientChanges;
 class Completion;
 class Ewmh;
 class HSTag;
@@ -26,6 +27,7 @@ public:
 
     Client* client(Window window);
     Client* client(const std::string &identifier);
+    void completeClients(Completion& complete);
     const std::unordered_map<Window, Client*>&
     clients() { return clients_; }
 
@@ -50,8 +52,12 @@ public:
     // adds a new client to list of managed client windows
     Client* manage_client(Window win, bool visible_already, bool force_unmanage);
 
+    int applyRulesCmd(Input input, Output output);
+    void applyRulesCompletion(Completion& complete);
+
 protected:
     int clientSetAttribute(std::string attribute, Input input, Output output);
+    void setSimpleClientAttributes(Client* client, const ClientChanges& changes);
     Theme* theme;
     Settings* settings;
     Ewmh* ewmh;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -810,7 +810,7 @@ bool focus_client(Client* client, bool switch_tag, bool switch_monitor) {
     }
     // now the right tag is visible
     // now focus it
-    bool found = tag->frame->focusClient(client);
+    bool found = tag->focusClient(client);
     cur_mon->applyLayout();
     g_monitors->unlock();
     return found;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,6 +164,8 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                    &RuleManager::addRuleCompletion}},
         {"unrule",         {rules, &RuleManager::unruleCommand,
                                    &RuleManager::unruleCompletion}},
+        {"apply_rules",    {clients, &ClientManager::applyRulesCmd,
+                                     &ClientManager::applyRulesCompletion}},
         {"list_rules",     {rules, &RuleManager::listRulesCommand }},
         {"layout",         tags->frameCommand(&FrameTree::dumpLayoutCommand, &FrameTree::dumpLayoutCompletion)},
         {"stack",          { monitors, &MonitorManager::stackCommand }},

--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -212,9 +212,7 @@ void RuleManager::addRuleCompletion(Completion& complete) {
 
 
 //! Evaluate rules against a given client
-ClientChanges RuleManager::evaluateRules(Client* client) {
-    ClientChanges changes(client);
-
+ClientChanges RuleManager::evaluateRules(Client* client, ClientChanges changes) {
     auto ruleIter = rules_.begin();
     while (ruleIter != rules_.end()) {
         auto& rule = *ruleIter;

--- a/src/rulemanager.h
+++ b/src/rulemanager.h
@@ -13,7 +13,7 @@ public:
     int unruleCommand(Input input, Output output);
     void unruleCompletion(Completion& complete);
     int listRulesCommand(Output output);
-    ClientChanges evaluateRules(Client* client);
+    ClientChanges evaluateRules(Client* client, ClientChanges inital = {});
 
 private:
     size_t removeRules(std::string label);

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -167,9 +167,9 @@ void Rule::print(Output output) {
 }
 
 // rules applying //
-ClientChanges::ClientChanges(Client *client)
-    : fullscreen(Root::get()->ewmh->isFullscreenSet(client->window_))
-{}
+ClientChanges::ClientChanges()
+{
+}
 
 /// CONDITIONS ///
 bool Condition::matches(const string& str) const {
@@ -262,7 +262,7 @@ void Consequence::applyPseudotile(const Client* client, ClientChanges* changes) 
 }
 
 void Consequence::applyFullscreen(const Client* client, ClientChanges* changes) const {
-    changes->fullscreen = Converter<bool>::parse(value, changes->fullscreen);
+    changes->fullscreen = Converter<bool>::parse(value);
 }
 
 void Consequence::applySwitchtag(const Client* client, ClientChanges* changes) const {

--- a/src/rules.h
+++ b/src/rules.h
@@ -57,7 +57,7 @@ private:
 
 class ClientChanges {
 public:
-    ClientChanges(Client *client);
+    ClientChanges();
 
     // For tag_name and monitor_name, an empty string means "no change",
     // because empty strings are not considered valid here. TODO: Use
@@ -69,8 +69,8 @@ public:
     bool            focus = false; // if client should get focus
     bool            switchtag = false; // if the tag may be switched for focusing it
     bool            manage = true; // whether we should manage it
-    bool            fullscreen;
-    std::string     keyMask; // Which keymask rule should be applied for this client
+    std::experimental::optional<bool> fullscreen;
+    std::experimental::optional<std::string> keyMask; // Which keymask rule should be applied for this client
 
     std::experimental::optional<bool> pseudotile;
     std::experimental::optional<bool> ewmhRequests;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -39,6 +39,12 @@ void HSTag::setIndexAttribute(unsigned long new_index) {
     index = new_index;
 }
 
+//! give the focus within this tag to the specified client
+bool HSTag::focusClient(Client* client)
+{
+    return frame->focusClient(client);
+}
+
 int HSTag::computeFrameCount() {
     int count = 0;
     frame->root_->fmap([](HSFrameSplit*) {},

--- a/src/tag.h
+++ b/src/tag.h
@@ -14,6 +14,7 @@ enum {
     TAG_FLAG_USED   = 0x02, // the opposite of empty
 };
 
+class Client;
 class FrameTree;
 class Settings;
 class Stack;
@@ -34,6 +35,7 @@ public:
     int             flags;
     std::shared_ptr<Stack> stack;
     void setIndexAttribute(unsigned long new_index) override;
+    bool focusClient(Client* client);
 private:
     //! get the number of clients on this tag
     int computeClientCount();

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -239,22 +239,27 @@ void TagManager::moveFocusedClient(HSTag* target) {
     moveClient(client, target);
 }
 
-void TagManager::moveClient(Client* client, HSTag* target) {
+void TagManager::moveClient(Client* client, HSTag* target, std::string frameIndex, bool focus) {
     HSTag* tag_source = client->tag();
     Monitor* monitor_source = find_monitor_with_tag(tag_source);
-    if (tag_source == target) {
+    if (tag_source == target && frameIndex == "") {
         // nothing to do
         return;
     }
     Monitor* monitor_target = find_monitor_with_tag(target);
     tag_source->frame->root_->removeClient(client);
     // insert window into target
-    target->frame->focusedFrame()->insertClient(client);
+    auto frame = FrameTree::focusedFrame(target->frame->lookup(frameIndex));
+    frame->insertClient(client);
     // enfoce it to be focused on the target tag
-    target->frame->focusClient(client);
-    client->tag()->stack->removeSlice(client->slice);
-    client->setTag(target);
-    client->tag()->stack->insertSlice(client->slice);
+    if (focus) {
+        target->frame->focusClient(client);
+    }
+    if (tag_source != target) {
+        client->tag()->stack->removeSlice(client->slice);
+        client->setTag(target);
+        client->tag()->stack->insertSlice(client->slice);
+    }
 
     // refresh things, hide things, layout it, and then show it if needed
     if (monitor_source && !monitor_target) {

--- a/src/tagmanager.h
+++ b/src/tagmanager.h
@@ -33,7 +33,7 @@ public:
     HSTag* ensure_tags_are_available();
     HSTag* byIndexStr(const std::string& index_str, bool skip_visible_tags);
     HSTag* unusedTag();
-    void moveClient(Client* client, HSTag* target);
+    void moveClient(Client* client, HSTag* target, std::string frameIndex = {}, bool focus = true);
     void moveFocusedClient(HSTag* target);
     std::function<int(Input, Output)> frameCommand(FrameCommand cmd);
     CommandBinding frameCommand(FrameCommand cmd, FrameCompleter completer);

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -163,7 +163,10 @@ def test_completable_commands(hlwm, request, run_destructives):
         'shift': {6},
         'focus': {6},
     }
-    allowed_stderr = re.compile('A (monitor|tag) with the name.*already exists')
+    allowed_stderr = re.compile('({})'.format('|'.join([
+        'A (monitor|tag) with the name.*already exists',
+        'No such.*client: urgent',  # for apply_rules
+    ])))
     # a set of commands that make other commands break
     # hence we need to run them separately
     destructive_commands = {

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -404,5 +404,3 @@ def test_bring(hlwm, from_other_mon):
 
     assert hlwm.get_attr('clients.{}.tag'.format(winid)) \
         == hlwm.get_attr('tags.focus.name')
-
-


### PR DESCRIPTION
The apply_rules command applies all rules to a specified already managed
client. This is useful for experimenting with rules and for the handling
of clients that change their WM_CLASS after the window appears.