### PR TITLE
Apply rules on clients whose WM_CLASS changes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ Current git version
     as printf. Formerly it stayed '%%'.
   * The 'keybind' command now accepts all valid key symbols, even if they are
     not present on the current keyboard layout at the time of setup.
+  * the rules are also applied to those clients that change their WM_CLASS
+    after being shown already.
   * 'detect_monitors' has an additional '--list-all' parameter
   * do not change the focus (for focus_follows_mouse=1) when an unmanaged
     dialog (e.g. a rofi menu or a notification) closes.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -105,6 +105,9 @@ void Client::make_full_client() {
                             ButtonPressMask | ButtonReleaseMask |
                             ExposureMask |
                             SubstructureRedirectMask | FocusChangeMask));
+}
+
+void Client::listen_for_events() {
     XSelectInput(g_display, window_,
                             StructureNotifyMask|FocusChangeMask
                             |EnterWindowMask|PropertyChangeMask);

--- a/src/client.h
+++ b/src/client.h
@@ -61,6 +61,7 @@ public:
     void init_from_X();
 
     void make_full_client();
+    void listen_for_events();
 
 
     // setter and getter for attributes

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -132,6 +132,7 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
 
     // init client
     auto client = new Client(win, visible_already, *this);
+    client->listen_for_events();
     Monitor* m = get_current_monitor();
 
     // apply rules
@@ -252,6 +253,11 @@ int ClientManager::applyRulesCmd(Input input, Output output) {
         output << "No such (managed) client: " << winid << "\n";
         return HERBST_INVALID_ARGUMENT;
     }
+    return applyRules(client, output);
+}
+
+int ClientManager::applyRules(Client* client, Output output)
+{
     ClientChanges changes;
     changes.focus = client == focus();
     changes = Root::get()->rules()->evaluateRules(client, changes);

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -53,6 +53,7 @@ public:
     Client* manage_client(Window win, bool visible_already, bool force_unmanage);
 
     int applyRulesCmd(Input input, Output output);
+    int applyRules(Client* client, Output output);
     void applyRulesCompletion(Completion& complete);
 
 protected:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -404,3 +404,16 @@ def test_bring(hlwm, from_other_mon):
 
     assert hlwm.get_attr('clients.{}.tag'.format(winid)) \
         == hlwm.get_attr('tags.focus.name')
+
+
+def test_wm_class_too_late(hlwm, x11):
+    hlwm.call('add tag2')
+    hlwm.call('rule class=SomeTmpClassTooLate tag=tag2')
+    winref, winid = x11.create_client()
+    assert hlwm.get_attr('clients.{}.tag'.format(winid)) != 'tag2'
+
+    # change window class after the window has appeared already
+    winref.set_wm_class('someInstance', 'SomeTmpClassTooLate')
+    x11.display.sync()
+
+    assert hlwm.get_attr('clients.{}.tag'.format(winid)) == 'tag2'


### PR DESCRIPTION
According to ICCCM, the WM_CLASS has to be set before a client files a
maprequest. Clients (e.g. spotify) that set the WM_CLASS later, lack
the correct WM_CLASS entry when the rules are evaluated. Thus, whenever
the WM_CLASS of an existing client changes, apply the rules again such
that the rules matching against the class name are taking into account.

This solves #643.