### PR TITLE
Allow to re-apply the rules to all clients

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -755,8 +755,9 @@ unrule 'LABEL'|*--all*|*-F*::
     Removes all rules named 'LABEL'. If --all or -F is passed, then all rules
     are removed.
 
-apply_rules 'WINID'::
-    Apply the rules to the specified window 'WINID'.
+apply_rules 'WINID'|*--all*::
+    Apply the rules to the specified window 'WINID'. If *--all* is passed, then
+    the rules are applied to all clients.
 
 fullscreen [*on*|*off*|*toggle*]::
     Sets or toggles the fullscreen state of the focused client. If no argument

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -327,7 +327,7 @@ int ClientManager::applyRules(Client* client, Output output, bool changeFocus)
 void ClientManager::applyRulesCompletion(Completion& complete)
 {
     if (complete == 0) {
-        complete.full("-all");
+        complete.full("--all");
         completeClients(complete);
     } else {
         complete.none();

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -53,7 +53,7 @@ public:
     Client* manage_client(Window win, bool visible_already, bool force_unmanage);
 
     int applyRulesCmd(Input input, Output output);
-    int applyRules(Client* client, Output output);
+    int applyRules(Client* client, Output output, bool changeFocus = true);
     void applyRulesCompletion(Completion& complete);
 
 protected:


### PR DESCRIPTION
Add a switch --all to apply_rules that re-applies the rules to all
(managed) clients.