### PR TITLE
Only listen for PropertyChangeMask early

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -105,12 +105,13 @@ void Client::make_full_client() {
                             ButtonPressMask | ButtonReleaseMask |
                             ExposureMask |
                             SubstructureRedirectMask | FocusChangeMask));
-}
-
-void Client::listen_for_events() {
     XSelectInput(g_display, window_,
                             StructureNotifyMask|FocusChangeMask
                             |EnterWindowMask|PropertyChangeMask);
+}
+
+void Client::listen_for_events() {
+    XSelectInput(g_display, window_, PropertyChangeMask);
 }
 
 void Client::setTag(HSTag *tag) {


### PR DESCRIPTION
The other event mask may trigger an xlib error if we activate it to
early: herbstluftwm: fatal error: request code=14, error code=9