### PR TITLE
Register custom pytest marker

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,6 @@ ignore =
     E501, # line too long
     W503, # incompatible with pep8.. "Line break occurred before a binary operator"
 
+[pytest]
+markers =
+    exclude_from_coverage: Some tests are not relevant for the coverage report


### PR DESCRIPTION
We introduced a custom pytest marker to exclude some tests from the
coverage report. pytest wants these markers to be registered, so silence
the warning by doing so.

Fixes #656