### PR TITLE
Sync relative mouse movements in test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -668,6 +668,6 @@ def mouse(hlwm_process):
                 subprocess.check_call(['xdotool', 'click', button])
 
         def move_relative(self, delta_x, delta_y):
-            subprocess.check_call(f'xdotool mousemove_relative {delta_x} {delta_y}', shell=True)
+            subprocess.check_call(f'xdotool mousemove_relative --sync {delta_x} {delta_y}', shell=True)
 
     return Mouse()


### PR DESCRIPTION
CI is flaky at the moment, possibly because the xdotool was missing the
sync flag for the relative mouse movement in the 'drag' test.