### PR TITLE
New flag --exit-on-xerror for automated testing

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,7 @@ Current git version
     dialog (e.g. a rofi menu or a notification) closes.
   * list_rules now prints regex-based rule conditions with '~' instead of '='
   * new attributes on every monitor for pad_up pad_down pad_left pad_right
+  * new flag --exit-on-xerror (to be used in automated testing only)
   * Formerly, double dots in object paths were allowed (similar to double
     slashes in file paths in unix). Right now, they are only allowed at the end
     (which is necessary for the tab-completion of attr):

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -28,6 +28,9 @@ of available <<COMMANDS,*COMMANDS*>> is listed below.
         print version and exit
     *-l*, *--locked*::
         Initially set the monitors_locked setting to 1
+    *--exit-on-xerror*::
+        Make herbstluftwm exit whenever xlib reports an error. This may only
+        be activated for automated testing and never for actual sessions.
     *--verbose*::
         print verbose information to stderr. This can be switched at run-time by
         the 'verbose' setting.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -412,11 +412,13 @@ void execute_autostart_file() {
 }
 
 static void parse_arguments(int argc, char** argv, Globals& g) {
+    int exit_on_xerror = g.exitOnXlibError;
     static struct option long_options[] = {
-        {"autostart",   1, nullptr, 'c'},
-        {"version",     0, nullptr, 'v'},
-        {"locked",      0, nullptr, 'l'},
-        {"verbose",     0, &g_verbose, 1},
+        {"autostart",       1, nullptr, 'c'},
+        {"version",         0, nullptr, 'v'},
+        {"locked",          0, nullptr, 'l'},
+        {"exit-on-xerror",  0, &exit_on_xerror, 1},
+        {"verbose",         0, &g_verbose, 1},
         {}
     };
     // parse options
@@ -441,6 +443,7 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
                 exit(EXIT_FAILURE);
         }
     }
+    g.exitOnXlibError = exit_on_xerror != 0;
 }
 
 static void remove_zombies(int) {
@@ -470,6 +473,7 @@ static void sigaction_signal(int signum, void (*handler)(int)) {
 int main(int argc, char* argv[]) {
     Globals g;
     parse_arguments(argc, argv, g);
+    XConnection::setExitOnError(g.exitOnXlibError);
     XConnection* X = XConnection::connect();
     g_display = X->display();
     if (!g_display) {

--- a/src/root.h
+++ b/src/root.h
@@ -29,6 +29,7 @@ class Globals {
 public:
     Globals() = default;
     int initial_monitors_locked = 0;
+    bool exitOnXlibError = false;
 };
 
 class Root : public Object {

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -15,6 +15,13 @@ using std::pair;
 using std::string;
 using std::vector;
 
+bool XConnection::exitOnError_ = false;
+
+void XConnection::setExitOnError(bool exitOnError)
+{
+    exitOnError_ = exitOnError;
+}
+
 XConnection::XConnection(Display* disp)
     : m_display(disp) {
     m_screen = DefaultScreen(m_display);
@@ -43,7 +50,7 @@ static bool g_other_wm_running = false;
 // from dwm.c
 /* Startup Error handler to check if another window manager
  * is already running. */
-static int xerrorstart(Display *dpy, XErrorEvent *ee) {
+static int xerrorstart(Display*, XErrorEvent*) {
     g_other_wm_running = true;
     return -1;
 }
@@ -54,7 +61,7 @@ static int (*g_xerrorxlib)(Display *, XErrorEvent *);
 /* There's no way to check accesses to destroyed windows, thus those cases are
  * ignored (especially on UnmapNotify's).  Other types of errors call Xlibs
  * default error handler, which may call exit.  */
-int xerror(Display *dpy, XErrorEvent *ee) {
+int XConnection::xerror(Display *dpy, XErrorEvent *ee) {
     if(ee->error_code == BadWindow
     || ee->error_code == BadGC
     || ee->error_code == BadPixmap
@@ -88,8 +95,8 @@ bool XConnection::checkotherwm() {
     if(g_other_wm_running) {
         return true;
     } else {
-        XSetErrorHandler(xerror);
-        XSync(g_display, False);
+        XSetErrorHandler(XConnection::xerror);
+        XSync(m_display, False);
         return false;
     }
 }

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -41,13 +41,16 @@ public:
     void setPropertyWindow(Window w, Atom property, const std::vector<Window>& value);
     void setPropertyCardinal(Window w, Atom property, const std::vector<long>& value);
     std::vector<Window> queryTree(Window window);
+    static void setExitOnError(bool exitOnError);
 private:
+    static int xerror(Display *dpy, XErrorEvent *ee);
     Display* m_display;
     int      m_screen;
     Window   m_root;
     int      m_screen_width;
     int      m_screen_height;
     Atom     utf8StringAtom_;
+    static bool     exitOnError_; //! exit on any xlib error
 };
 
 #endif


### PR DESCRIPTION
We can use this in the CI testsuite in the future to avoid even more
errors. Currently, there are some tests that produce xerrors.