### PR TITLE
x11.create_client() wait for hlwm to process

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,11 @@ BINDIR = os.path.join(os.path.abspath(os.environ['PWD']))
 class HlwmBridge:
 
     HC_PATH = os.path.join(BINDIR, 'herbstclient')
+    # if there is some HlwmBridge, then it is registered here:
+    INSTANCE = None
 
     def __init__(self, display, hlwm_process):
+        HlwmBridge.INSTANCE = self
         self.client_procs = []
         self.next_client_id = 0
         self.env = {
@@ -536,11 +539,11 @@ def x11_connection():
 
 
 @pytest.fixture()
-def x11(x11_connection, hlwm):
+def x11(x11_connection):
     """ Short-lived fixture for interacting with the X11 display and creating
     clients that are automatically destroyed at the end of each test. """
     class X11:
-        def __init__(self, x11_connection, hlwm):
+        def __init__(self, x11_connection):
             self.display = x11_connection
             self.windows = set()
             self.screen = self.display.screen()
@@ -579,6 +582,7 @@ def x11(x11_connection, hlwm):
         def create_client(self, urgent=False, pid=None,
                           geometry=(50, 50, 300, 200),
                           force_unmanage=False,
+                          sync_hlwm=True,
                           ):
             w = self.root.create_window(
                 geometry[0],
@@ -608,9 +612,16 @@ def x11(x11_connection, hlwm):
 
             w.map()
             self.display.sync()
-            # wait for hlwm to fully recognize it as a client
-            hlwm.call('true')
+            if sync_hlwm:
+                # wait for hlwm to fully recognize it as a client
+                self.sync_with_hlwm()
             return w, self.winid_str(w)
+
+        def sync_with_hlwm(self):
+            # wait for hlwm to flush all events:
+            hlwm_bridge = HlwmBridge.INSTANCE
+            assert hlwm_bridge is not None, "hlwm must be running"
+            hlwm_bridge.call('true')
 
         def get_absolute_top_left(self, window):
             """return the absolute (x,y) coordinate of the given window,
@@ -621,6 +632,8 @@ def x11(x11_connection, hlwm):
                 # the following coordinates are only relative
                 # to the parent of window
                 geom = window.get_geometry()
+                print('Geometry of {} is: x={} y={} w={} h={}'.format(
+                      self.winid_str(window), geom.x, geom.y, geom.width, geom.height))
                 x += geom.x
                 y += geom.y
                 # check if the window's parent is already the root window
@@ -638,7 +651,7 @@ def x11(x11_connection, hlwm):
                 window.destroy()
             self.display.sync()
 
-    x11_ = X11(x11_connection, hlwm)
+    x11_ = X11(x11_connection)
     yield x11_
     x11_.shutdown()
 

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -101,7 +101,10 @@ def test_complete_mousebind_validates_all_button(hlwm):
     assert complete == []
 
 
-def test_drag_move(hlwm, x11, mouse):
+# we had a race condition here, so increase the likelyhood
+# that we really fixed it:
+@pytest.mark.parametrize('repeat', list(range(0, 100)))
+def test_drag_move(hlwm, x11, mouse, repeat):
     hlwm.call('set_attr tags.focus.floating on')
     client, winid = x11.create_client()
     x, y = x11.get_absolute_top_left(client)

--- a/tests/test_x11.py
+++ b/tests/test_x11.py
@@ -34,7 +34,8 @@ def test_client_moveresizes_itself(hlwm, x11):
     hlwm.call('move_monitor 0 500x600+12+13 14 15 16 17')
     hlwm.call('floating on')
     hlwm.call('set_attr theme.border_width 0')
-    w, _ = x11.create_client(geometry=(25, 26, 27, 28))
+    # FIXME: why doesn't this work with sync_hlwm=True?
+    w, _ = x11.create_client(geometry=(25, 26, 27, 28), sync_hlwm=False)
 
     # resize the window to some other geometry
     w.configure(x=60, y=70, width=300, height=200)


### PR DESCRIPTION
In the x11.create_client() function, wait for hlwm to empty its X event
queue. By this we are sure that everything related to managing the
client is completed.

Hopefully, this makes the test case test_drag_move more stable. It
definitely fixes a race condition, but I'm unsure whether there is
another one.

Many thanks to @The-Compiler and @blarz who helped a lot with debuging
this unstable test case!