### PR TITLE
Minor fixes in manpages

### DIFF
--- a/doc/herbstclient.txt
+++ b/doc/herbstclient.txt
@@ -81,8 +81,6 @@ other::
 
 BUGS
 ----
-It waits endlessly for a response from *herbstluftwm* (there is no timeout yet).
-
 See the *herbstluftwm* distribution BUGS file.
 
 COMMUNITY

--- a/doc/herbstclient.txt
+++ b/doc/herbstclient.txt
@@ -48,7 +48,7 @@ OPTIONS
     Same as *--idle* but exit after first *--count* hooks.
 
 *-c*, *--count* 'COUNT'::
-    Let *--wait* exit after 'COUNT' hooks were received and printed. The default of
+    Let *--wait* exit after 'COUNT' hooks were received and printed. The default
     'COUNT' is 1.
 
 *-q*, *--quiet*::

--- a/doc/herbstluftwm-tutorial.txt
+++ b/doc/herbstluftwm-tutorial.txt
@@ -292,7 +292,7 @@ perform several steps:
 $ herbstclient set_monitors 1440x900+0+0 1024x768+1440+0
 ----
 +
-Alternatively, if +xinerama+ works for your setup, simply run:
+Alternatively, if +xinerama+ or +xrandr+ works for your setup, simply run:
 +
 ----
 $ herbstclient detect_monitors

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -617,8 +617,8 @@ set_monitors 'RECTS' ...::
         * Existing monitors are deleted if there are more monitors than 'RECTS'
 
 detect_monitors '-l'|'--list'|'--list-all'|'--no-disjoin'::
-    Sets the list of monitors to the physically available monitors. If the
-    Xinerama extension is missing, it will fall back to one monitor across the
+    Sets the list of monitors to the physically available monitors. If both
+    Xinerama and xrandr are missing, it will fall back to one monitor across the
     entire screen. If the detected monitors overlap, the will be split into more
     monitors that are disjoint but cover the same area using +disjoin_rects+.
     +
@@ -714,7 +714,7 @@ from your shell or from a script, quote it properly!
 complete 'POSITION' ['COMMAND' 'ARGS ...']::
     Prints the result of tab completion for the partial 'COMMAND' with optional
     'ARGS'. You usually do not need this, because there is already tab
-    completion for bash. Example:
+    completion for bash, zsh and fish. Example:
 
         * complete 0 m +
           prints all commands beginning with m
@@ -1221,7 +1221,7 @@ Each 'CONSEQUENCE' consists of a 'NAME'='VALUE' pair. Valid 'NAMES' are:
     consequence.
 
 +keymask+::
-    sets the keymask for a client
+    sets the keymask for a client (see <<KEYMASK, explanation in OBJECTS>>).
 
 A rule's behaviour can be configured by some special 'FLAGS':
 
@@ -1406,13 +1406,13 @@ listed as follows:
 |===========================
 |s - winid                | its window id
 |s - title                | its window title
-|s - keymask              | A regular expression that is matched against the
-                            string representation of all key bindings (see
-                            list_keybinds). While this client is focused, only
-                            bindings that match the expression will be active.
-                            Any other bindings will be disabled. The default
-                            keymask is an empty string (""), which does not
-                            disable any keybinding.
+|s - keymask              | [[KEYMASK]]A regular expression that is matched
+                            against the string representation of all key
+                            bindings (see list_keybinds). While this client is
+                            focused, only bindings that match the expression
+                            will be active. Any other bindings will be disabled.
+                            The default keymask is an empty string (""), which
+                            does not disable any keybinding.
 |s - tag                  | the tag it's currently on
 |i - pid                  | the process id of it (-1 if unset)
 |s - class                | the class of it (second entry in WM_CLASS)

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -326,7 +326,7 @@ cycle ['DELTA']::
 cycle_all [*--skip-invisible*] ['DIRECTION']::
     Cycles through all windows and frames on the current tag. 'DIRECTION' = 1
     means forward, 'DIRECTION' = -1 means backward, 'DIRECTION' = 0 has no
-    effect. 'DIRECTION' defaults to 1. If there are multiple windows within on
+    effect. 'DIRECTION' defaults to 1. If there are multiple windows within one
     frame, then it acts similar to the 'cycle' command. (The 'cycle_all' command
     focuses the next/previous leaf in the 'layout' tree.). If
     *--skip-invisible* is given, then this only cycles through all visible
@@ -420,19 +420,19 @@ focus ['-i'|'-e'] 'DIRECTION'::
     be at frame C.
 +
 ----
- Tree:  V,0     Screen: ┌─────┐┌─────┐ (before)
+ Tree:  H,0     Screen: ┌─────┐┌─────┐ (before)
         ╱ ╲             │  B  ││  C  │
        ╱   ╲            └─────┘└─────┘
-     H,1   H,0          ┌─────┐┌─────┐
+     V,1   V,0          ┌─────┐┌─────┐
      ╱ ╲   ╱ ╲          │  A* ││  D  │
-    A*  B C   D         └─────┘└─────┘
+    B  A* C   D         └─────┘└─────┘
 
- Tree:  V,0     Screen: ┌─────┐┌─────┐ (after focus right)
+ Tree:  H,1     Screen: ┌─────┐┌─────┐ (after focus right)
         ╱ ╲             │  B  ││  C* │
        ╱   ╲            └─────┘└─────┘
-     H,1   H,0          ┌─────┐┌─────┐
+     V,1   V,0          ┌─────┐┌─────┐
      ╱ ╲   ╱ ╲          │  A  ││  D  │
-    A   B C*  D         └─────┘└─────┘
+    B   A C*  D         └─────┘└─────┘
 ----
  ::
     If the currently focused client is floated, then the next floating window in
@@ -613,8 +613,8 @@ set_monitors 'RECTS' ...::
     Sets the list of monitors *exactly* to the list of given rectangles:
 
         * The i'th existing monitor is moved to the i'th given 'RECT'
-        * New monitors are created if there are more 'RECTS' then monitors
-        * Existing monitors are deleted if there are more monitors then 'RECTS'
+        * New monitors are created if there are more 'RECTS' than monitors
+        * Existing monitors are deleted if there are more monitors than 'RECTS'
 
 detect_monitors '-l'|'--list'|'--list-all'|'--no-disjoin'::
     Sets the list of monitors to the physically available monitors. If the
@@ -729,8 +729,8 @@ complete_shell 'POSITION' ['COMMAND' 'ARGS ...']::
         * A space is appended to each full completion result.
         * Special characters will be escaped in the output.
 
-emit_hook 'ARGS ...'::
-    Emits a custom hook to all idling herbstclients.
+emit_hook 'NAME' 'ARGS ...'::
+    Emits a custom hook 'NAME' to all idling herbstclients.
 
 tag_status ['MONITOR']::
     Print a tab separated list of all tags for the specified 'MONITOR' index. If
@@ -750,10 +750,10 @@ WARNING: If you use a tab in one of the tag names, then tag_status is probably
 quite useless for you.
 
 floating [['TAG'] *on*|*off*|*toggle*|*status*]::
-    Changes the current tag to floating/tiling mode on specified 'TAG' or prints
-    it current status. If no 'TAG' is given, the current tag is used. If no
-    argument is given, floating mode is toggled. If *status* is given, then *on*
-    or *off* is printed, depending of the floating state of 'TAG'.
+    Changes specified 'TAG' to floating/tiling mode or prints its current
+    status. If no 'TAG' is given, the current tag is used. If no argument is
+    given, floating mode is toggled. If *status* is given, then *on* or *off* is
+    printed, depending of the floating state of 'TAG'.
 
 rule [\[--]'FLAG'|\[--]'LABEL'|\[--]'CONDITION'|\[--]'CONSEQUENCE' ...]::
     Defines a rule which will be applied to all new clients. Its behaviour is
@@ -905,7 +905,7 @@ window_gap (Integer)::
 
 snap_distance (Integer)::
     If a client is dragged in floating mode, then it snaps to neighbour clients
-    if the distance between them is smaller then snap_distance.
+    if the distance between them is smaller than snap_distance.
 
 snap_gap (Integer)::
     Specifies the remaining gap if a dragged client snaps to an edge in floating
@@ -936,7 +936,7 @@ frame_bg_normal_color (String/Color)::
 
 frame_bg_transparent (Integer)::
     If set, the background of frames are transparent. That means a rectangle is
-    cut out frome the inner such that only the frame border and a stripe of
+    cut out from the inner such that only the frame border and a stripe of
     width 'frame_transparent_width' can be seen. Use 'frame_active_opacity' and
     'frame_normal_opacity' for real transparency.
 
@@ -992,7 +992,7 @@ window_border_inner_color (String/Color)::
 
 always_show_frame (Boolean)::
     If set, all frames are displayed. If unset, only frames with focus or with
-    windows in it are displayed.
+    windows in them are displayed.
 
 frame_active_opacity (Integer)::
     Focused frame opacity in percent. Requires a running compositing manager to
@@ -1009,7 +1009,7 @@ default_frame_layout (Integer)::
 
 default_direction_external_only (Boolean)::
     This setting controls the behaviour of focus and shift if no '-e' or '-i'
-    argument is given. if set, then focus and shift changes the focused frame
+    argument is given. If set, then focus and shift changes the focused frame
     even if there are other clients in this frame in the specified 'DIRECTION'.
     Else, a client within current frame is selected if it is in the specified
     'DIRECTION'.
@@ -1066,11 +1066,11 @@ tree_style (String)::
 ----
 X-.
   #-. child 0
-  | #-* child 01
-  | +-* child 02
+  | #-* child 00
+  | +-* child 01
   +-. child 1
   : #-* child 10
-  : +-* child 01
+  : +-* child 11
 ----
 +
 Useful values for 'tree_style' are: +╾│ ├└╼─┐+ or +-| |'--.+ or +╾│ ├╰╼─╮+.
@@ -1092,7 +1092,7 @@ pseudotile_center_threshold (Integer)::
 update_dragged_clients (Integer)::
     If set, a client's window content is resized immediately during resizing
     it with the mouse. If unset, the client's content is resized after the mouse
-    button are released.
+    button is released.
 
 verbose (Boolean)::
     If set, verbose output is logged to herbstluftwm's stderr. The default value
@@ -1103,7 +1103,7 @@ RULES
 -----
 
 Rules are used to change default properties for certain clients when they
-appear and when the 'apply_rules' command is called. Each rule matches against a
+appear or when the 'apply_rules' command is called. Each rule matches against a
 certain subset of all clients and defines a set of properties for them (called
 __CONSEQUENCE__s). A rule can be defined with this command:
 
@@ -1177,7 +1177,7 @@ Each 'CONSEQUENCE' consists of a 'NAME'='VALUE' pair. Valid 'NAMES' are:
     specified, but switchtag was not, ignore this consequence.
 
 +focus+::
-    decides whether the client gets the input focus on his tag.  The default is
+    decides whether the client gets the input focus in its tag. The default is
     *off*. 'VALUE' can be *on*, *off* or *toggle*.
 
 +switchtag+::
@@ -1262,7 +1262,7 @@ follows:
     window.
   - +urgent+ references some window that is urgent.
   - +0x+'HEXID' -- where 'HEXID' is some hexadecimal number -- references the
-    window with hexadecimal X11 window id is 'HEXID'.
+    window with hexadecimal X11 window id 'HEXID'.
   - 'DECID' -- where 'DECID' is some decimal number -- references the window
     with the decimal X11 window id 'DECID'.
 

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -495,17 +495,17 @@ rotate::
     only manipulates the alignment of frames, not the content of them.
 
 set 'NAME' 'VALUE'::
-    Sets the specified setting 'NAME' to 'VALUE'. All <<SETTINGS,*SETTINGS*>>
-    are listed in the <<SETTINGS, section below>>.
+    Sets the specified setting 'NAME' to 'VALUE'. Allowed values for boolean
+    settings are 'on' or 'true' for on, 'off' or 'false' for off, 'toggle' to
+    toggle its value. All <<SETTINGS,*SETTINGS*>> are listed in the
+    <<SETTINGS, section below>>.
 
 get 'NAME'::
     Prints the value of setting 'NAME'. All <<SETTINGS,*SETTINGS*>>
     are listed in the <<SETTINGS, section below>>.
 
 toggle 'NAME'::
-    Toggles the setting 'NAME' if it's an integer setting: If its value is
-    unequal to 0, it becomes 0; else its previous value (which was unequal to 0)
-    is restored.
+    Toggles the setting 'NAME' if it's a boolean setting.
 
 cycle_value 'NAME' 'VALUES' ...::
     Cycles value of the setting 'NAME' through 'VALUES': I.e. it searches the

--- a/share/autostart
+++ b/share/autostart
@@ -114,8 +114,8 @@ hc set frame_border_normal_color '#101010'
 hc set frame_bg_normal_color '#565656'
 hc set frame_bg_active_color '#345F0C'
 hc set frame_border_width 1
-hc set always_show_frame 1
-hc set frame_bg_transparent 1
+hc set always_show_frame on
+hc set frame_bg_transparent on
 hc set frame_transparent_width 5
 hc set frame_gap 4
 
@@ -134,8 +134,8 @@ hc attr theme.background_color '#141414'
 
 hc set window_gap 0
 hc set frame_padding 0
-hc set smart_window_surroundings 0
-hc set smart_frame_surroundings 1
+hc set smart_window_surroundings off
+hc set smart_frame_surroundings on
 hc set mouse_recenter_gap 0
 
 # rules
@@ -162,7 +162,7 @@ hc unlock
 # find the panel
 panel=~/.config/herbstluftwm/panel.sh
 [ -x "$panel" ] || panel=/etc/xdg/herbstluftwm/panel.sh
-for monitor in $(herbstclient list_monitors | cut -d: -f1) ; do
+for monitor in $(hc list_monitors | cut -d: -f1) ; do
     # start it on each monitor
     "$panel" $monitor &
 done


### PR DESCRIPTION
There are also some things I wasn't brave enough to edit as I'm not sure about them/didn't know how exactly to do that:
* herbstclient has in its bugs that it waits endlessly, while this is not true now
* also detection via xrandr works (tutorial — pre-last paragraph; main manpage — detect_monitors)
* `complete` — now completion works also with zsh and fish ("because there is already completion for *bash*")
* `keymask` in RULES section deserves a link to its explanation in OBJECTS