### PR TITLE
Fix replacing the root frame

### DIFF
--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -147,7 +147,6 @@ int FrameTree::removeFrameCommand() {
     }
     auto clientFocusIndex = frame->getSelection();
     auto parent = frame->getParent();
-    auto pp = parent->getParent();
     bool insertAtFront = (frame == parent->firstChild());
     auto newparent =
             insertAtFront ? parent->secondChild() : parent->firstChild();
@@ -176,12 +175,8 @@ int FrameTree::removeFrameCommand() {
     int oldClientCount = (int)targetFrameLeaf->clientCount();
     targetFrameLeaf->addClients(removedFrameClients, insertAtFront);
     // now, frame is empty
-    if (pp) {
-        pp->replaceChild(parent, newparent);
-    } else {
-        // if parent was root frame
-        replaceNode(root_, newparent);
-    }
+    replaceNode(parent, newparent);
+
     // focus the same client again
     if (removedFrameClients.size() > 0) {
         if (insertAtFront) {
@@ -577,8 +572,9 @@ void FrameTree::replaceNode(shared_ptr<HSFrame> old,
     auto parent = old->getParent();
     if (!parent) {
         assert(old == root_);
-        // replacement->parent needs to be nulled?
         root_ = replacement;
+        // root frame should never have a parent:
+        assert(!root_->getParent());
     } else {
         parent->replaceChild(old, replacement);
     }

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -180,7 +180,7 @@ int FrameTree::removeFrameCommand() {
         pp->replaceChild(parent, newparent);
     } else {
         // if parent was root frame
-        root_ = newparent;
+        replaceNode(root_, newparent);
     }
     // focus the same client again
     if (removedFrameClients.size() > 0) {
@@ -577,6 +577,7 @@ void FrameTree::replaceNode(shared_ptr<HSFrame> old,
     auto parent = old->getParent();
     if (!parent) {
         assert(old == root_);
+        // replacement->parent needs to be nulled?
         root_ = replacement;
     } else {
         parent->replaceChild(old, replacement);

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -574,7 +574,7 @@ void FrameTree::replaceNode(shared_ptr<HSFrame> old,
         assert(old == root_);
         root_ = replacement;
         // root frame should never have a parent:
-        assert(!root_->getParent());
+        root_->parent_ = {};
     } else {
         parent->replaceChild(old, replacement);
     }

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -303,3 +303,10 @@ def test_split_simple(hlwm, running_clients, align, fraction):
     assert hlwm.call('dump').stdout == \
         '(split {}:{}:0 (clients vertical:0{}) (clients vertical:0))' \
         .format(align, fraction, ''.join([' ' + c for c in running_clients]))
+
+
+def test_split_and_remove(hlwm):
+    # Split an empty frame in two, then merge it again to one root frame
+    hlwm.call('split right 0.5')
+    hlwm.call('remove')
+    # Should not assert()...


### PR DESCRIPTION
When replacing the root frame, make sure it has no parent.
Otherwise smart_frame_surroundings draws frame surroundings...

Fixes bug #597 