### PR TITLE
Fix rule consequence for invalid tag names

### DIFF
--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -148,7 +148,10 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
     }
 
     if (!changes.tag_name.empty()) {
-        client->setTag(find_tag(changes.tag_name.c_str()));
+        HSTag* tag = find_tag(changes.tag_name.c_str());
+        if (tag) {
+            client->setTag(tag);
+        }
     }
     if (!changes.monitor_name.empty()) {
         Monitor *monitor = string_to_monitor(changes.monitor_name.c_str());

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -222,6 +222,9 @@ void Ewmh::updateCurrentDesktop() {
 }
 
 void Ewmh::windowUpdateTag(Window win, HSTag* tag) {
+    if (!tag) {
+        return;
+    }
     int index = tags_->index_of(tag);
     if (index < 0) {
         HSWarning("tag %s not found in internal list\n", tag->name->c_str());

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -455,3 +455,9 @@ def test_apply_rules_all_focus_retained(hlwm):
         hlwm.call('apply_rules --all')
 
         assert hlwm.get_attr('clients.focus.winid') == client
+
+
+def test_rule_tag_nonexisting(hlwm):
+    hlwm.call('rule tag=tagdoesnotexist')
+    # must not crash:
+    hlwm.create_client()


### PR DESCRIPTION
Do not crash for the rule tag=sometag when no tag named 'sometag'
exists. We fix this in two places: where the tag name is looked up and
in the EWMH function that updates the EWMH tag property of the window,
just to be sure.

Thanks to @fiete201 for finding and reporting this issue.