### PR TITLE
Print error messages if dragging fails

### DIFF
--- a/src/mousedraghandler.cpp
+++ b/src/mousedraghandler.cpp
@@ -44,7 +44,7 @@ void MouseDragHandlerFloating::assertDraggingStillSafe() {
             || !winDragClient_
             || winDragClient_->is_client_floated() == false)
     {
-        throw DragNotPossible();
+        throw DragNotPossible("Monitor or floating client disappeared");
     }
 }
 
@@ -189,11 +189,11 @@ MouseResizeFrame::MouseResizeFrame(MonitorManager *monitors, shared_ptr<HSFrameL
     : monitors_(monitors)
 {
     dragMonitor_ = monitors_->byFrame(frame);
-    if (!dragMonitor_) {
-        throw DragNotPossible();
-    }
     dragMonitorIndex_ = dragMonitor_->index();
     dragTag_ = dragMonitor_->tag;
+    if (!dragMonitor_) {
+        throw DragNotPossible("Frame not on any monitor");
+    }
     buttonDragStart_ = get_cursor_position();
     Rectangle frameRect = frame->lastRect();
     /* check whether the cursor is the following area:
@@ -244,7 +244,7 @@ MouseResizeFrame::MouseResizeFrame(MonitorManager *monitors, shared_ptr<HSFrameL
     }
     shared_ptr<HSFrame> neighbour = frame->neighbour(dir);
     if (!neighbour || !neighbour->getParent()) {
-        throw DragNotPossible();
+        throw DragNotPossible("No neighbour frame in the direction of the cursor");
     }
     dragFrame_ = neighbour->getParent();
     auto df = dragFrame_.lock();
@@ -294,6 +294,6 @@ void MouseResizeFrame::assertDraggingStillSafe()
             && dragTag_ == dragMonitor_->tag
             && !dragFrame_.expired();
     if (!allFine) {
-        throw DragNotPossible();
+        throw DragNotPossible("Monitor, tag or frame disappeared");
     }
 }

--- a/src/mousedraghandler.h
+++ b/src/mousedraghandler.h
@@ -26,8 +26,11 @@ public:
         /** the exception expresses that dragging the client is not possible or
          * not possible anymore. Ususally this happens, when some of the objects
          * involved (monitor, client, tag, frame) change or get destroyed. */
-        DragNotPossible() {}
+        DragNotPossible(std::string what) : what_(what) {}
         virtual ~DragNotPossible() throw () {}
+        virtual const char* what()  const noexcept { return what_.c_str(); }
+    private:
+        std::string what_;
     };
     //! possibly throws a DragNotPossible exception
     virtual ~MouseDragHandler() {};

--- a/src/mousemanager.h
+++ b/src/mousemanager.h
@@ -38,13 +38,15 @@ public:
     int dragCommand(Input input, Output output);
     void dragCompletion(Completion& complete);
 
-    void mouse_initiate_move(Client* client, const std::vector<std::string> &cmd);
-    void mouse_initiate_zoom(Client* client, const std::vector<std::string> &cmd);
-    void mouse_initiate_resize(Client* client, const std::vector<std::string> &cmd);
-    void mouse_call_command(Client* client, const std::vector<std::string> &cmd);
+    std::string mouse_initiate_move(Client* client, const std::vector<std::string> &cmd);
+    std::string mouse_initiate_zoom(Client* client, const std::vector<std::string> &cmd);
+    std::string mouse_initiate_resize(Client* client, const std::vector<std::string> &cmd);
+    std::string mouse_call_command(Client* client, const std::vector<std::string> &cmd);
 
 private:
-    using MouseFunction = void (MouseManager::*)(Client* client, const std::vector<std::string> &cmd);
+    //! start dragging for the specified client (possibly up to some arguments), and return a error message
+    //! if not possible
+    using MouseFunction = std::string (MouseManager::*)(Client* client, const std::vector<std::string> &cmd);
 
     class MouseBinding {
     public:
@@ -62,7 +64,8 @@ private:
 
     //! manually (forward-)declare MouseDragHandler::Constructor as MDC here:
     typedef std::function<std::shared_ptr<MouseDragHandler>(MonitorManager*, Client*)> MDC;
-    void mouse_initiate_drag(Client* client, const MDC& createHandler);
+    //! start a the drag, and if it does not work out, return an error message
+    std::string mouse_initiate_drag(Client* client, const MDC& createHandler);
 
     std::map<std::string, MouseFunction> mouseFunctions_;
     std::shared_ptr<MouseDragHandler> dragHandler_;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -677,11 +677,14 @@ def mouse(hlwm_process):
         def move_into(self, win_id, x=1, y=1):
             self.call_cmd(f'xdotool mousemove --sync --window {win_id} {x} {y}', shell=True)
 
-        def click(self, button, into_win_id=None):
+        def click(self, button, into_win_id=None, wait=True):
             if into_win_id:
                 self.move_into(into_win_id)
-            with hlwm_process.wait_stderr_match('ButtonPress'):
-                self.call_cmd(['xdotool', 'click', button])
+            if wait:
+                with hlwm_process.wait_stderr_match('ButtonPress'):
+                    subprocess.check_call(['xdotool', 'click', button])
+            else:
+                subprocess.check_call(['xdotool', 'click', button])
 
         def move_relative(self, delta_x, delta_y):
             self.call_cmd(f'xdotool mousemove_relative --sync {delta_x} {delta_y}', shell=True)

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -119,6 +119,23 @@ def test_drag_move(hlwm, x11, mouse, repeat):
     assert x11.get_absolute_top_left(client) == (x + 12, y + 15)
 
 
+def test_drag_no_frame_splits(hlwm):
+    winid, _ = hlwm.create_client()
+
+    hlwm.call_xfail(['drag', winid, 'resize']) \
+        .expect_stderr('No neighbour frame')
+
+
+def test_mouse_drag_no_frame_splits(hlwm, hlwm_process, mouse):
+    hlwm.call('mousebind B1 resize')
+    winid, _ = hlwm.create_client()
+
+    with hlwm_process.wait_stderr_match('No neighbour frame'):
+        # we do not wait because it clashes with the running
+        # wait_stderr_match() context here
+        mouse.click('1', winid, wait=False)
+
+
 def test_drag_invisible_client(hlwm):
     # check that we can't resize clients that are on a tag
     # that is not shown


### PR DESCRIPTION
In the 'drag' command, fail and print an error message if dragging
fails. For mouse events, print the reason for the failure of dragging to
HSDebug().