### PR TITLE
Bring client object attributes for WM_CLASS back

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -48,6 +48,8 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , ewmhnotify_(this, "ewmhnotify", true)
     , sizehints_floating_(this, "sizehints_floating", true)
     , sizehints_tiling_(this, "sizehints_tiling", false)
+    , window_class_(this, "class", &Client::getWindowClass)
+    , window_instance_(this, "instance", &Client::getWindowInstance)
     , manager(cm)
     , theme(*cm.theme)
     , settings(*cm.settings)
@@ -544,6 +546,16 @@ void Client::updateEwmhState() {
         ewmhfullscreen_ = fullscreen_();
     }
     ewmh.updateWindowState(this);
+}
+
+std::string Client::getWindowClass()
+{
+    return ewmh.X().getClass(window_);
+}
+
+std::string Client::getWindowInstance()
+{
+    return ewmh.X().getInstance(window_);
 }
 
 void Client::set_pseudotile(bool state) {

--- a/src/client.h
+++ b/src/client.h
@@ -57,6 +57,8 @@ public:
     Attribute_<bool> ewmhnotify_; // send ewmh-notifications for this client
     Attribute_<bool> sizehints_floating_;  // respect size hints regarding this client in floating mode
     Attribute_<bool> sizehints_tiling_;  // respect size hints regarding this client in tiling mode
+    DynAttribute_<std::string> window_class_;
+    DynAttribute_<std::string> window_instance_;
 
 public:
     void init_from_X();
@@ -110,6 +112,8 @@ public:
 
     void updateEwmhState();
 private:
+    std::string getWindowClass();
+    std::string getWindowInstance();
     std::string triggerRelayoutMonitor();
     friend Decoration;
     ClientManager& manager;

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -134,6 +134,8 @@ public:
     bool sendEvent(Window window, WM proto, bool checkProtocols);
     void windowClose(Window window);
 
+    XConnection& X() { return X_; }
+
 private:
     bool focusStealingAllowed(long source);
     bool readClientList(Window** buf, unsigned long *count);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -583,6 +583,7 @@ def x11(x11_connection):
                           geometry=(50, 50, 300, 200),
                           force_unmanage=False,
                           sync_hlwm=True,
+                          wm_class=None,
                           ):
             w = self.root.create_window(
                 geometry[0],
@@ -596,6 +597,8 @@ def x11(x11_connection):
                 background_pixel=self.screen.white_pixel,
                 override_redirect=force_unmanage,
             )
+            if wm_class is not None:
+                w.set_wm_class(wm_class[0], wm_class[1])
 
             # Keep track of window for later removal:
             self.windows.add(w)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -125,3 +125,15 @@ def test_client_with_pid(hlwm, x11):
 def test_client_without_pid(hlwm, x11):
     _, winid = x11.create_client(pid=None)
     assert int(hlwm.get_attr('clients.focus.pid')) == -1
+
+
+def test_client_wm_class(hlwm, x11):
+    _, winid = x11.create_client(wm_class=('myinst', 'myclass'))
+    assert hlwm.get_attr('clients.{}.instance'.format(winid)) == 'myinst'
+    assert hlwm.get_attr('clients.{}.class'.format(winid)) == 'myclass'
+
+
+def test_client_wm_class_none(hlwm, x11):
+    _, winid = x11.create_client(wm_class=None)
+    assert hlwm.get_attr('clients.{}.instance'.format(winid)) == ''
+    assert hlwm.get_attr('clients.{}.class'.format(winid)) == ''


### PR DESCRIPTION
During the refactoring, we somehow lost the attributes 'class' and
'instance' of client objects. This brings them back and adds a test case
for them.

This resolves issue #687.