### PR TITLE
Insert at bottom of stack for global floating

### DIFF
--- a/src/plainstack.h
+++ b/src/plainstack.h
@@ -8,8 +8,12 @@ template<typename T>
 class PlainStack {
 public:
     //! insert at the top
-    void insert(const T& element) {
-        data_.insert(data_.begin(), element);
+    void insert(const T& element, bool insertOnTop = true) {
+        if (insertOnTop) {
+            data_.insert(data_.begin(), element);
+        } else {
+            data_.push_back(element);
+        }
     }
     void remove(const T& element) {
         data_.erase(std::remove(data_.begin(), data_.end(), element), data_.end());

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -154,14 +154,16 @@ void Stack::markDirty() {
     dirty = true;
 }
 
-void Stack::sliceAddLayer(Slice* slice, HSLayer layer) {
+//! insert the slice to the given layer. if 'insertOnTop' is set, insert at the top
+//! otherwise insert at the bottom of the layer
+void Stack::sliceAddLayer(Slice* slice, HSLayer layer, bool insertOnTop) {
     if (slice->layers.count(layer) != 0) {
         /* nothing to do */
         return;
     }
 
     slice->layers.insert(layer);
-    layers_[layer].insert(slice);
+    layers_[layer].insert(slice, insertOnTop);
     dirty = true;
 }
 

--- a/src/stack.h
+++ b/src/stack.h
@@ -60,7 +60,7 @@ public:
     void removeSlice(Slice* elem);
     void raiseSlice(Slice* slice);
     void markDirty();
-    void sliceAddLayer(Slice* slice, HSLayer layer);
+    void sliceAddLayer(Slice* slice, HSLayer layer, bool insertOnTop = true);
     void sliceRemoveLayer(Slice* slice, HSLayer layer);
     bool isLayerEmpty(HSLayer layer);
     void clearLayer(HSLayer layer);

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -240,7 +240,9 @@ void HSTag::onGlobalFloatingChange(bool newState)
     // move tiling client slices between layers
     frame->foreachClient([this,newState](Client* client) {
         if (newState) {
-            stack->sliceAddLayer(client->slice, LAYER_FLOATING);
+            // we add the tiled clients from the bottom such that they do not
+            // cover single-floated clients
+            stack->sliceAddLayer(client->slice, LAYER_FLOATING, false);
         } else {
             stack->sliceRemoveLayer(client->slice, LAYER_FLOATING);
         }


### PR DESCRIPTION
When changing the floating state of a tag, we add the tiled clients to
the floating layer. We now do this at the bottom, such that they do not
cover the single-floating windows.