### PR TITLE
Do not apply rules to own unmanaged windows

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -52,7 +52,7 @@ string window_class_to_string(Display* dpy, Window window) {
 
 bool is_herbstluft_window(Display* dpy, Window window) {
     auto str = window_class_to_string(dpy, window);
-    return str == HERBST_FRAME_CLASS;
+    return str == HERBST_FRAME_CLASS || str == HERBST_DECORATION_CLASS;
 }
 
 // duplicates an argument-vector

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -345,7 +345,8 @@ void XMainLoop::mapnotify(XMapEvent* event) {
         }
         // also update the window title - just to be sure
         c->update_title();
-    } else {
+    } else if (root_->ewmh->isOwnWindow(event->window)
+               && is_herbstluft_window(X_.display(), event->window)) {
         // the window is not managed.
         HSDebug("MapNotify: briefly managing 0x%lx to apply rules\n", event->window);
         root_->clients()->manage_client(event->window, true, true);

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -345,8 +345,8 @@ void XMainLoop::mapnotify(XMapEvent* event) {
         }
         // also update the window title - just to be sure
         c->update_title();
-    } else if (root_->ewmh->isOwnWindow(event->window)
-               && is_herbstluft_window(X_.display(), event->window)) {
+    } else if (!root_->ewmh->isOwnWindow(event->window)
+               && !is_herbstluft_window(X_.display(), event->window)) {
         // the window is not managed.
         HSDebug("MapNotify: briefly managing 0x%lx to apply rules\n", event->window);
         root_->clients()->manage_client(event->window, true, true);

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -462,8 +462,8 @@ def test_no_rules_for_own_windows(hlwm):
     hlwm.call('rule once focus=on')
     assert len(hlwm.call('list_rules').stdout.splitlines()) == 2
 
-    # this must not fire the rules, even though frame decorations
-    # appear and disappear
+    # this must not fire the rules, even though the decoration
+    # windows appear and disappear
     hlwm.call('use othertag')
     hlwm.call('split v')
     hlwm.call('use_index 0')

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -461,3 +461,19 @@ def test_rule_tag_nonexisting(hlwm):
     hlwm.call('rule tag=tagdoesnotexist')
     # must not crash:
     hlwm.create_client()
+
+
+def test_no_rules_for_own_windows(hlwm):
+    hlwm.call('add othertag')
+    hlwm.create_client()
+    hlwm.call('rule once pseudotile=on')
+    hlwm.call('rule once focus=on')
+    assert len(hlwm.call('list_rules').stdout.splitlines()) == 2
+
+    # this must not fire the rules, even though frame decorations
+    # appear and disappear
+    hlwm.call('use othertag')
+    hlwm.call('split v')
+    hlwm.call('use_index 0')
+
+    assert len(hlwm.call('list_rules').stdout.splitlines()) == 2


### PR DESCRIPTION
We apply the rules to all unmanaged windows when they appear (e.g. for
rules) as introduced by 738a0ce5914aee44c9f3d3e559c1c18af6c55c36 and
ported by a2ecbe5da746f56adb7e7f6cda165cc8e7d1c6a7. This makes no sense
for our own frame windows and even is harmful sometimes (see new test
case that failed before this commit), because 'once' rules get
destroyed.