### PR TITLE
Hard-wire rules for some EWMH window types

### DIFF
--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -1,7 +1,7 @@
 #include "clientmanager.h"
 
-#include <algorithm>
 #include <X11/Xlib.h>
+#include <algorithm>
 #include <string>
 
 #include "client.h"

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -1,5 +1,6 @@
 #include "clientmanager.h"
 
+#include <algorithm>
 #include <X11/Xlib.h>
 #include <string>
 
@@ -137,7 +138,8 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
     Monitor* m = get_current_monitor();
 
     // apply rules
-    ClientChanges changes = Root::get()->rules()->evaluateRules(client);
+    ClientChanges changes = applyDefaultRules(client->window_);
+    changes = Root::get()->rules()->evaluateRules(client, changes);
     if (!changes.manage || force_unmanage) {
         // map it... just to be sure
         XMapWindow(g_display, win);
@@ -216,6 +218,41 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
     Root::get()->mouse->grab_client_buttons(client, false);
 
     return client;
+}
+
+//! apply some built in rules that reflect the EWMH specification
+//! and regarding sensible single-window floating settings
+ClientChanges ClientManager::applyDefaultRules(Window win)
+{
+    ClientChanges changes;
+    const int windowType = ewmh->getWindowType(win);
+    vector<int> unmanaged= {
+        NetWmWindowTypeDesktop,
+        NetWmWindowTypeDock,
+    };
+    if (std::find(unmanaged.begin(), unmanaged.end(), windowType)
+            != unmanaged.end())
+    {
+        changes.manage = False;
+    }
+    vector<int> floated = {
+        NetWmWindowTypeToolbar,
+        NetWmWindowTypeMenu,
+        NetWmWindowTypeUtility,
+        NetWmWindowTypeSplash,
+        NetWmWindowTypeDialog,
+        NetWmWindowTypeDropdownMenu,
+        NetWmWindowTypePopupMenu,
+        NetWmWindowTypeTooltip,
+        NetWmWindowTypeNotification,
+        NetWmWindowTypeCombo,
+        NetWmWindowTypeDnd,
+    };
+    if (std::find(floated.begin(), floated.end(), windowType) != floated.end())
+    {
+        changes.floating = True;
+    }
+    return changes;
 }
 
 /** apply simple attribute based client changes. We do not apply 'fullscreen' here because

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -52,6 +52,7 @@ public:
 
     // adds a new client to list of managed client windows
     Client* manage_client(Window win, bool visible_already, bool force_unmanage);
+    ClientChanges applyDefaultRules(Window win);
 
     int applyRulesCmd(Input input, Output output);
     int applyRules(Client* client, Output output, bool changeFocus = true);

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 
 #include "client.h"
+#include "ewmh.h"
 #include "hlwmcommon.h"
 #include "layout.h"
 #include "monitor.h"

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -7,7 +7,6 @@
 #include <limits>
 
 #include "client.h"
-#include "ewmh.h"
 #include "hlwmcommon.h"
 #include "layout.h"
 #include "monitor.h"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -584,6 +584,7 @@ def x11(x11_connection):
                           force_unmanage=False,
                           sync_hlwm=True,
                           wm_class=None,
+                          window_type=None,
                           ):
             w = self.root.create_window(
                 geometry[0],
@@ -606,6 +607,12 @@ def x11(x11_connection):
             w.set_wm_name('Some Window')
             if urgent:
                 w.set_wm_hints(flags=Xutil.UrgencyHint)
+
+            if window_type is not None:
+                w.change_property(self.display.intern_atom('_NET_WM_WINDOW_TYPE'),
+                                  Xatom.ATOM,
+                                  32,
+                                  [self.display.intern_atom(window_type)])
 
             if pid is not None:
                 w.change_property(self.display.intern_atom('_NET_WM_PID'),

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -469,3 +469,27 @@ def test_no_rules_for_own_windows(hlwm):
     hlwm.call('use_index 0')
 
     assert len(hlwm.call('list_rules').stdout.splitlines()) == 2
+
+
+@pytest.mark.parametrize('window_type', [
+    '_NET_WM_WINDOW_TYPE_DESKTOP',
+    '_NET_WM_WINDOW_TYPE_DOCK',
+])
+def test_desktop_window_not_managed(hlwm, hc_idle, x11, window_type):
+    hlwm.call('rule hook=mywindow')
+    _, winid = x11.create_client(sync_hlwm=False,
+                                 window_type=window_type)
+    assert ['rule', 'mywindow', winid] in hc_idle.hooks()
+    assert hlwm.list_children('clients') == []
+
+
+@pytest.mark.parametrize('window_type', [
+    '_NET_WM_WINDOW_TYPE_DIALOG',
+    '_NET_WM_WINDOW_TYPE_SPLASH',
+])
+def test_dialog_window_floated(hlwm, hc_idle, x11, window_type):
+    hlwm.call('rule hook=mywindow')
+    _, winid = x11.create_client(sync_hlwm=False,
+                                 window_type=window_type)
+    assert hlwm.get_attr(f'clients.{winid}.floating') == hlwm.bool(True)
+    assert ['rule', 'mywindow', winid] in hc_idle.hooks()


### PR DESCRIPTION
Automatically unmanage desktop and panel windows and float dialog
windows. These rules are hard-wired in client manager, but their results
still can be overwritten by the rules of the user.