### PR TITLE
Raise client after focus if sensible

### DIFF
--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -270,7 +270,7 @@ void Ewmh::handleClientMessage(XClientMessageEvent* me) {
             if (focusStealingAllowed(me->data.l[0])) {
                 auto client = Root::common().client(me->window);
                 if (client) {
-                    focus_client(client, true, true);
+                    focus_client(client, true, true, true);
                 }
             }
             break;

--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -210,8 +210,7 @@ bool floating_focus_direction(Direction dir) {
     if (idx < 0) {
         return false;
     }
-    clients[idx]->raise();
-    focus_client(clients[idx], false, false);
+    focus_client(clients[idx], false, false, true);
     return true;
 }
 

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -717,8 +717,9 @@ Client* HSFrameLeaf::focusedClient() {
 // focus a window
 // switch_tag tells, whether to switch tag to focus to window
 // switch_monitor tells, whether to switch monitor to focus to window
+// raise tells whether to also raise the client
 // returns if window was focused or not
-bool focus_client(Client* client, bool switch_tag, bool switch_monitor) {
+bool focus_client(Client* client, bool switch_tag, bool switch_monitor, bool raise) {
     if (!client) {
         // client is not managed
         return false;
@@ -753,6 +754,9 @@ bool focus_client(Client* client, bool switch_tag, bool switch_monitor) {
     // now the right tag is visible
     // now focus it
     bool found = tag->focusClient(client);
+    if (found && raise) {
+        client->raise();
+    }
     cur_mon->applyLayout();
     g_monitors->unlock();
     return found;

--- a/src/layout.h
+++ b/src/layout.h
@@ -185,7 +185,7 @@ int frame_current_bring(int argc, char** argv, Output output);
 int frame_current_set_client_layout(int argc, char** argv, Output output);
 int frame_split_count_to_root(HSFrame* frame, int align);
 
-bool focus_client(Client* client, bool switch_tag, bool switch_monitor);
+bool focus_client(Client* client, bool switch_tag, bool switch_monitor, bool raise);
 // moves a window to an other frame
 int frame_move_window_command(int argc, char** argv, Output output);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -362,7 +362,7 @@ int jumpto_command(int argc, char** argv, Output output) {
     }
     auto client = get_client(argv[1]);
     if (client) {
-        focus_client(client, true, true);
+        focus_client(client, true, true, true);
         return 0;
     } else {
         output << argv[0] << ": Could not find client";

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -164,10 +164,8 @@ void XMainLoop::buttonpress(XButtonEvent* be) {
         // if the event was not handled by the mouse manager, pass it to the client:
         Client* client = root_->clients->client(be->window);
         if (client) {
-            focus_client(client, false, true);
-            if (root_->settings->raise_on_click()) {
-                    client->raise();
-            }
+            bool raise = root_->settings->raise_on_click();
+            focus_client(client, false, true, raise);
         }
     }
     XAllowEvents(X_.display(), ReplayPointer, be->time);
@@ -298,7 +296,7 @@ void XMainLoop::enternotify(XCrossingEvent* ce) {
             // don't allow focus_follows_mouse if another window would be
             // hidden during that focus change (which only occurs in max layout)
         } else if (c) {
-            focus_client(c, false, true);
+            focus_client(c, false, true, false);
         }
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,14 +136,19 @@ class HlwmBridge:
         attribute_path = '.'.join([str(x) for x in attribute_path])
         return self.call(['get_attr', attribute_path]).stdout
 
-    def create_client(self, term_command='sleep infinity', title=None, keep_running=False):
+    def create_client(self, term_command='sleep infinity', position=None, title=None, keep_running=False):
         """
         Launch a client that will be terminated on shutdown.
         """
         self.next_client_id += 1
         wmclass = 'client_{}'.format(self.next_client_id)
         title = ['-title', str(title)] if title else []
-        command = ['xterm'] + title + ['-class', wmclass, '-e', 'bash', '-c', term_command]
+        geometry = ['-geometry', '50x20+0+0']
+        if position is not None:
+            x, y = position
+            geometry[1] = '50x2%+d%+d' % (x, y)
+        command = ['xterm'] + title + geometry
+        command += ['-class', wmclass, '-e', 'bash', '-c', term_command]
 
         # enforce a hook when the window appears
         self.call(['rule', 'once', 'class=' + wmclass, 'hook=here_is_' + wmclass])

--- a/tests/test_basic_events.py
+++ b/tests/test_basic_events.py
@@ -1,0 +1,42 @@
+import pytest
+import test_stack
+
+@pytest.mark.parametrize("raise_on_click", [True, False])
+def test_focus_on_click(hlwm, mouse, raise_on_click):
+    hlwm.call('set_attr tags.focus.floating on')
+    hlwm.call(['set', 'raise_on_click', hlwm.bool(raise_on_click)])
+    c1, _ = hlwm.create_client(position=(0, 0))
+    c2, _ = hlwm.create_client(position=(300, 0))
+    hlwm.call(f'jumpto {c2}')  # also raises c2
+    assert hlwm.get_attr('clients.focus.winid') == c2
+    assert test_stack.helper_get_stack_as_list(hlwm) == [c2, c1]
+
+    mouse.click('1', into_win_id=c1)
+
+    assert hlwm.get_attr('clients.focus.winid') == c1
+    stack = test_stack.helper_get_stack_as_list(hlwm)
+    if raise_on_click:
+        # c1 gets back on top
+        assert stack == [c1, c2]
+    else:
+        # c2 stays on top
+        assert stack == [c2, c1]
+
+
+@pytest.mark.parametrize("focus_follows_mouse", [True, False])
+def test_focus_follows_mouse(hlwm, mouse, focus_follows_mouse):
+    hlwm.call('set_attr tags.focus.floating on')
+    hlwm.call(['set', 'focus_follows_mouse', hlwm.bool(focus_follows_mouse)])
+    c1, _ = hlwm.create_client(position=(0, 0))
+    c2, _ = hlwm.create_client(position=(300, 0))
+    hlwm.call(f'jumpto {c2}')  # also raises c2
+    assert hlwm.get_attr('clients.focus.winid') == c2
+    assert test_stack.helper_get_stack_as_list(hlwm) == [c2, c1]
+
+    mouse.move_into(c1)
+
+    c1_is_focused = hlwm.get_attr('clients.focus.winid') == c1
+    # c1 is focused iff focus_follows_mouse was activated
+    assert c1_is_focused == focus_follows_mouse
+    # stacking is unchanged
+    assert test_stack.helper_get_stack_as_list(hlwm) == [c2, c1]

--- a/tests/test_basic_events.py
+++ b/tests/test_basic_events.py
@@ -1,6 +1,7 @@
 import pytest
 import test_stack
 
+
 @pytest.mark.parametrize("raise_on_click", [True, False])
 def test_focus_on_click(hlwm, mouse, raise_on_click):
     hlwm.call('set_attr tags.focus.floating on')


### PR DESCRIPTION
Especially when focusing a client via a taskbar or 'jumpto', it must be
raised as well. However, if a client is focused only because of a mouse
hover (focus_follows_mouse), then it should not be raised.

Also add tests for raising/focus via mouse clicks and mouse hover.