### PR TITLE
herbstclient: do not crash if there is no display

### DIFF
--- a/ipc-client/ipc-client.c
+++ b/ipc-client/ipc-client.c
@@ -54,6 +54,9 @@ HCConnection* hc_connect_to_display(Display* display) {
 }
 
 void hc_disconnect(HCConnection* con) {
+    if (!con) {
+        return;
+    }
     if (con->client_window) {
         XDestroyWindow(con->display, con->client_window);
     }

--- a/ipc-client/main.c
+++ b/ipc-client/main.c
@@ -241,8 +241,7 @@ int main(int argc, char* argv[]) {
         char* output;
         HCConnection* con = hc_connect();
         if (!con) {
-            fprintf(stderr, "Error: Could not connect to display.\n");
-            hc_disconnect(con);
+            fprintf(stderr, "Error: Cannot open display.\n");
             return EXIT_FAILURE;
         }
         if (!hc_check_running(con)) {

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -6,6 +6,16 @@ import pytest
 HC_PATH = os.path.join(os.path.abspath(os.environ['PWD']), 'herbstclient')
 
 
+@pytest.mark.parametrize('argument', ['version', '--idle'])
+def test_herbstclient_no_display(argument):
+    result = subprocess.run([HC_PATH, argument],
+                            stderr=subprocess.PIPE,
+                            env={'DISPLAY': 'somethingwrong'},
+                            universal_newlines=True)
+    assert re.search(r'Cannot open display', result.stderr)
+    assert result.returncode == 1
+
+
 @pytest.mark.parametrize('hlwm_mode', ['never started', 'sigterm', 'sigkill'])
 @pytest.mark.parametrize('hc_parameter', ['true', '--wait'])
 def test_herbstclient_recognizes_hlwm_not_running(hlwm_spawner, x11, hlwm_mode, hc_parameter):


### PR DESCRIPTION
If in the herbstclient main, the HCConnection pointer is null, we do not
free it. This avoids a segfault.

Also add a test case for this.