### PR TITLE
Move initial clients to their original desktop

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,9 @@ Current git version
   * new command: apply_rules
   * new command: export (convenience wrapper around setenv)
   * new command: drag (initiates moving/resizing a window by mouse)
+  * if tags have been configured through EWMH before herbstluftwm starts (from
+    a previous running window manager), then herbstluftwm re-uses these tags
+    (start with --no-tag-import to disable this)
   * The build system is now cmake. See the INSTALL file if you need to
     compile herbstluftwm yourself.
   * the 'remove' command now tries to preserve the focus and the client

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -31,6 +31,9 @@ of available <<COMMANDS,*COMMANDS*>> is listed below.
     *--exit-on-xerror*::
         Make herbstluftwm exit whenever xlib reports an error. This may only
         be activated for automated testing and never for actual sessions.
+    *--no-tag-import*::
+        Do not preserve the tags (virtual desktops) from a previous running
+        window manager.
     *--verbose*::
         print verbose information to stderr. This can be switched at run-time by
         the 'verbose' setting.

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -21,6 +21,7 @@
 #include "utils.h"
 
 using std::endl;
+using std::function;
 using std::string;
 using std::vector;
 
@@ -122,7 +123,8 @@ void ClientManager::remove(Window window)
     clients_.erase(window);
 }
 
-Client* ClientManager::manage_client(Window win, bool visible_already, bool force_unmanage) {
+Client* ClientManager::manage_client(Window win, bool visible_already, bool force_unmanage,
+                                     function<void(ClientChanges&)> additionalRules) {
     if (is_herbstluft_window(g_display, win)) {
         // ignore our own window
         return nullptr;
@@ -139,6 +141,9 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
 
     // apply rules
     ClientChanges changes = applyDefaultRules(client->window_);
+    if (additionalRules) {
+        additionalRules(changes);
+    }
     changes = Root::get()->rules()->evaluateRules(client, changes);
     if (!changes.manage || force_unmanage) {
         // map it... just to be sure

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -51,7 +51,8 @@ public:
     void fullscreen_complete(Completion& complete);
 
     // adds a new client to list of managed client windows
-    Client* manage_client(Window win, bool visible_already, bool force_unmanage);
+    Client* manage_client(Window win, bool visible_already, bool force_unmanage,
+                          std::function<void(ClientChanges&)> additionalRules = {});
     ClientChanges applyDefaultRules(Window win);
 
     int applyRulesCmd(Input input, Output output);

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -4,7 +4,6 @@
 #include <X11/X.h>
 #include <X11/Xlib.h>
 #include <array>
-#include <map>
 #include <vector>
 
 #define ENUM_WITH_ALIAS(Identifier, Alias) \
@@ -100,8 +99,6 @@ public:
         std::vector<std::string> desktopNames;
         //! client list before hlwm start
         std::vector<Window> original_client_list_;
-        //! mapping clients to their desktop
-        std::map<Window, long> client2desktop;
         void print(FILE* file);
     };
 
@@ -115,7 +112,8 @@ public:
     void updateWmName();
 
     void updateClientList();
-    std::vector<Window> originalClientList() const;
+    const InitialState &initialState();
+    long windowGetInitialDesktop(Window win);
     void updateClientListStacking();
     void updateDesktops();
     void updateDesktopNames();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -414,11 +414,13 @@ void execute_autostart_file() {
 
 static void parse_arguments(int argc, char** argv, Globals& g) {
     int exit_on_xerror = g.exitOnXlibError;
+    int no_tag_import = 0;
     static struct option long_options[] = {
         {"autostart",       1, nullptr, 'c'},
         {"version",         0, nullptr, 'v'},
         {"locked",          0, nullptr, 'l'},
         {"exit-on-xerror",  0, &exit_on_xerror, 1},
+        {"no-tag-import",   0, &no_tag_import, 1},
         {"verbose",         0, &g_verbose, 1},
         {}
     };
@@ -445,6 +447,7 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
         }
     }
     g.exitOnXlibError = exit_on_xerror != 0;
+    g.importTagsFromEwmh = (no_tag_import == 0);
 }
 
 static void remove_zombies(int) {
@@ -508,9 +511,11 @@ int main(int argc, char* argv[]) {
     g_main_loop = &mainloop;
 
     // setup
-    const auto& initialState = root->ewmh->initialState();
-    for (auto n : initialState.desktopNames) {
-        root->tags->add_tag(n.c_str());
+    if (g.importTagsFromEwmh) {
+        const auto& initialState = root->ewmh->initialState();
+        for (auto n : initialState.desktopNames) {
+            root->tags->add_tag(n.c_str());
+        }
     }
     root->monitors()->ensure_monitors_are_available();
     mainloop.scanExistingClients();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -508,6 +508,10 @@ int main(int argc, char* argv[]) {
     g_main_loop = &mainloop;
 
     // setup
+    const auto& initialState = root->ewmh->initialState();
+    for (auto n : initialState.desktopNames) {
+        root->tags->add_tag(n.c_str());
+    }
     root->monitors()->ensure_monitors_are_available();
     mainloop.scanExistingClients();
     tag_force_update_flags();

--- a/src/root.h
+++ b/src/root.h
@@ -30,6 +30,7 @@ public:
     Globals() = default;
     int initial_monitors_locked = 0;
     bool exitOnXlibError = false;
+    bool importTagsFromEwmh = true;
 };
 
 class Root : public Object {

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -63,6 +63,10 @@ HSTag* TagManager::add_tag(const string& name) {
         // nothing to do
         return find_result;
     }
+    if (name.empty()) {
+        // empty name is not allowed
+        return nullptr;
+    }
     HSTag* tag = new HSTag(name, this, settings_);
     addIndexed(tag);
     tag->name.changed().connect([this,tag]() { this->onTagRename(tag); });

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -20,8 +20,10 @@
 #include "mousemanager.h"
 #include "panelmanager.h"
 #include "root.h"
+#include "rules.h"
 #include "settings.h"
 #include "tag.h"
+#include "tagmanager.h"
 #include "utils.h"
 #include "xconnection.h"
 
@@ -71,10 +73,23 @@ void XMainLoop::scanExistingClients() {
     XWindowAttributes wa;
     Window transientFor;
     auto clientmanager = root_->clients();
-    auto originalClients = root_->ewmh->originalClientList();
+    auto& initialEwmhState = root_->ewmh->initialState();
+    auto& originalClients = initialEwmhState.original_client_list_;
     auto isInOriginalClients = [&originalClients] (Window win) {
         return originalClients.end()
             != std::find(originalClients.begin(), originalClients.end(), win);
+    };
+    auto findTagForWindow = [this](Window win) {
+        return [this,win] (ClientChanges& changes) {
+            long idx = this->root_->ewmh->windowGetInitialDesktop(win);
+            if (idx < 0) {
+                return;
+            }
+            HSTag* tag = root_->tags->byIdx((size_t)idx);
+            if (tag) {
+                changes.tag_name = tag->name();
+            }
+        };
     };
     for (auto win : X_.queryTree(X_.root())) {
         if (!XGetWindowAttributes(X_.display(), win, &wa)
@@ -105,8 +120,10 @@ void XMainLoop::scanExistingClients() {
         }
         else if (wa.map_state == IsViewable
             || isInOriginalClients(win)) {
-            clientmanager->manage_client(win, true, false);
-            XMapWindow(X_.display(), win);
+            Client* c = clientmanager->manage_client(win, true, false, findTagForWindow(win));
+            if (root_->monitors->byTag(c->tag())) {
+                XMapWindow(X_.display(), win);
+            }
         }
     }
     // ensure every original client is managed again
@@ -119,7 +136,7 @@ void XMainLoop::scanExistingClients() {
             continue;
         }
         XReparentWindow(X_.display(), win, X_.root(), 0,0);
-        clientmanager->manage_client(win, true, false);
+        clientmanager->manage_client(win, true, false, findTagForWindow(win));
     }
 }
 

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <map>
 #include <X11/X.h>
 #include <X11/Xlib.h>
 

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <X11/X.h>
 #include <X11/Xlib.h>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -576,6 +576,30 @@ def x11(x11_connection):
                 return False
             return bool(hints.flags & Xutil.UrgencyHint)
 
+        def set_property_textlist(self, property_name, value, utf8=True, window=None):
+            """set a ascii textlist property by its string name on the root window, or any other window"""
+            if window is None:
+                window = self.root
+            prop = self.display.intern_atom(property_name)
+            bvalue = bytearray()
+            isfirst = True
+            for entry in value:
+                if isfirst:
+                    isfirst = False
+                else:
+                    bvalue.append(0)
+                bvalue += entry.encode()
+            proptype = Xatom.STRING
+            if utf8:
+                proptype = self.display.get_atom('UTF8_STRING')
+            window.change_property(prop, proptype, 8, bytes(bvalue))
+
+        def set_property_cardinal(self, property_name, value, window=None):
+            if window is None:
+                window = self.root
+            prop = self.display.intern_atom(property_name)
+            window.change_property(prop, Xatom.CARDINAL, 32, value)
+
         def get_property(self, property_name, window=None):
             """get a property by its string name from the root window, or any other window"""
             if window is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,7 +268,7 @@ def hlwm(hlwm_process):
 
 
 class HlwmProcess:
-    def __init__(self, tmpdir, env):
+    def __init__(self, tmpdir, env, args):
         autostart = tmpdir / 'herbstluftwm' / 'autostart'
         autostart.ensure()
         autostart.write(textwrap.dedent("""
@@ -278,7 +278,7 @@ class HlwmProcess:
         autostart.chmod(0o755)
         bin_path = os.path.join(BINDIR, 'herbstluftwm')
         self.proc = subprocess.Popen(
-            [bin_path, '--verbose'], env=env,
+            [bin_path, '--verbose'] + args, env=env,
             bufsize=0,  # essential for reading output with selectors!
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
@@ -487,19 +487,19 @@ def hlwm_spawner(tmpdir):
     """yield a function to spawn hlwm"""
     assert os.environ['DISPLAY'] != ':0', 'Refusing to run tests on display that might be your actual X server (not Xvfb)'
 
-    def spawn():
+    def spawn(args=[]):
         env = {
             'DISPLAY': os.environ['DISPLAY'],
             'XDG_CONFIG_HOME': str(tmpdir),
         }
-        return HlwmProcess(tmpdir, env)
+        return HlwmProcess(tmpdir, env, args)
     return spawn
 
 
 @pytest.fixture()
 def hlwm_process(hlwm_spawner):
     """Set up hlwm and also check that it shuts down gently afterwards"""
-    hlwm_proc = hlwm_spawner()
+    hlwm_proc = hlwm_spawner(['--no-tag-import'])
     kill_all_existing_windows(show_warnings=True)
 
     yield hlwm_proc

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -1,3 +1,8 @@
+import conftest
+import os
+import pytest
+
+
 def test_net_wm_desktop_after_load(hlwm, x11):
     hlwm.call('add anothertag')
     win, _ = x11.create_client()
@@ -20,3 +25,58 @@ def test_net_wm_desktop_after_bring(hlwm, x11):
     hlwm.call(['bring', winid])
 
     assert x11.get_property('_NET_WM_DESKTOP', win)[0] == 1
+
+
+@pytest.mark.parametrize('utf8names,desktop_names', [
+    (False, ['default']),
+    (False, ['foo']),
+    (True, ['föö', 'bär']),
+    (True, ['a', 'long', 'list', 'of', 'tag', 'names']),
+    (True, ['an', 'empty', '', '', 'tagname']),
+])
+def test_read_desktop_names(hlwm_spawner, x11, utf8names, desktop_names):
+    x11.set_property_textlist('_NET_DESKTOP_NAMES', desktop_names, utf8=utf8names)
+    x11.display.sync()
+
+    hlwm_proc = hlwm_spawner()
+    hlwm = conftest.HlwmBridge(os.environ['DISPLAY'], hlwm_proc)
+
+    desktop_names = [dn for dn in desktop_names if len(dn) > 0]
+
+    assert hlwm.list_children('tags.by-name') == sorted(desktop_names)
+    for idx, name in enumerate(desktop_names):
+        assert hlwm.get_attr(f'tags.{idx}.name') == name
+
+    hlwm_proc.shutdown()
+
+
+@pytest.mark.parametrize('desktops,client2desktop', [
+    (2, [0, 1]),
+    (2, [None, 1]),  # client without index set
+    (2, [2, 1, 8, 0]),  # clients exceeding the index range
+    (5, [1, 1, 0, 4, 4, 4]),
+])
+def test_client_initially_on_desktop(hlwm_spawner, x11, desktops, client2desktop):
+    desktop_names = ['tag{}'.format(i) for i in range(0, desktops)]
+    x11.set_property_textlist('_NET_DESKTOP_NAMES', desktop_names)
+    clients = []
+    for desktop_idx in client2desktop:
+        handle, winid = x11.create_client(sync_hlwm=False)
+        clients.append(winid)
+        if desktop_idx is not None:
+            x11.set_property_cardinal('_NET_WM_DESKTOP', [desktop_idx], window=handle)
+    x11.display.sync()
+
+    hlwm_proc = hlwm_spawner()
+    hlwm = conftest.HlwmBridge(os.environ['DISPLAY'], hlwm_proc)
+
+    for client_idx, desktop_idx in enumerate(client2desktop):
+        winid = clients[client_idx]
+        if desktop_idx is not None and desktop_idx in range(0, desktops):
+            assert hlwm.get_attr(f'clients.{winid}.tag') \
+                == desktop_names[desktop_idx]
+        else:
+            assert hlwm.get_attr(f'clients.{winid}.tag') \
+                == desktop_names[0]
+
+    hlwm_proc.shutdown()

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,9 @@ skipsdist = true
 #  * run a specific single test case: tox -- tests/test_layout.py::test_single_frame_layout
 #  * run tests matching a substring expression: tox -- _remove_
 #  * run tests in parallel: tox -- -n auto
+#
+# Library references:
+#  * ewmh: https://ewmh.readthedocs.io/en/latest/
 ###
 
 ###


### PR DESCRIPTION
On startup, restore the list of desktops from the EWMH properties on the
root window, and move all clients to the desktop in which they were
before hlwm was started.

Also add test cases for both.