### PR TITLE
Do not ignore transient-for-windows on startup

### DIFF
--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -72,7 +72,6 @@ XMainLoop::XMainLoop(XConnection& X, Root* root)
 // from dwm.c
 void XMainLoop::scanExistingClients() {
     XWindowAttributes wa;
-    Window transientFor;
     auto clientmanager = root_->clients();
     auto& initialEwmhState = root_->ewmh->initialState();
     auto& originalClients = initialEwmhState.original_client_list_;
@@ -97,9 +96,7 @@ void XMainLoop::scanExistingClients() {
             };
     };
     for (auto win : X_.queryTree(X_.root())) {
-        if (!XGetWindowAttributes(X_.display(), win, &wa)
-            || wa.override_redirect
-            || XGetTransientForHint(X_.display(), win, &transientFor))
+        if (!XGetWindowAttributes(X_.display(), win, &wa) || wa.override_redirect)
         {
             continue;
         }
@@ -135,8 +132,7 @@ void XMainLoop::scanExistingClients() {
     for (auto win : originalClients) {
         if (clientmanager->client(win)) continue;
         if (!XGetWindowAttributes(X_.display(), win, &wa)
-            || wa.override_redirect
-            || XGetTransientForHint(X_.display(), win, &transientFor))
+            || wa.override_redirect)
         {
             continue;
         }

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -80,3 +80,17 @@ def test_client_initially_on_desktop(hlwm_spawner, x11, desktops, client2desktop
                 == desktop_names[0]
 
     hlwm_proc.shutdown()
+
+
+def test_manage_transient_for_windows_on_startup(hlwm_spawner, x11):
+    master_win, master_id = x11.create_client(sync_hlwm=False)
+    dialog_win, dialog_id = x11.create_client(sync_hlwm=False)
+    dialog_win.set_wm_transient_for(master_win)
+    x11.display.sync()
+
+    hlwm_proc = hlwm_spawner()
+    hlwm = conftest.HlwmBridge(os.environ['DISPLAY'], hlwm_proc)
+
+    assert hlwm.list_children('clients') \
+        == sorted([master_id, dialog_id, 'focus'])
+    hlwm_proc.shutdown()


### PR DESCRIPTION
This fixes a bug that exists since df7d2717, because I didn't understand
the dwm sourcecode back than. On startup, the window manager must also
manage the clients that already exist. Since dwm uses the transient-for
hint to place dialog windows smartly (namely on the same tag as their
master window), dwm first processes the non-transient-for windows and
then the transient-for windows afterwards.

Back then, I only had the second part as a comment and then removed it
in 92c54e1da. Leading to the bug that all transient-for-windows were
ignored on hlwm startup. (For example the 'About' dialog of thunar is a
transient-for-window)

the present commit fixes this bug and adds a test case to avoid this in
the future.