### PR TITLE
Save regex source of keymask, since it's needed

### DIFF
--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -3,7 +3,7 @@
 #include <X11/Xlib.h>
 #include <algorithm>
 #include <iostream>
-#include <sstream>
+#include <sstream> // IWYU pragma: keep
 #include <stdexcept>
 
 #include "completion.h"

--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -3,7 +3,6 @@
 #include <X11/Xlib.h>
 #include <algorithm>
 #include <iostream>
-#include <regex>
 #include <stdexcept>
 
 #include "completion.h"

--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -107,14 +107,6 @@ string KeyCombo::str() const {
 }
 
 /*!
- * Returns true if the string representation of this KeyCombo matches the given
- * regex
- */
-bool KeyCombo::matches(const std::regex& regex) const {
-    return std::regex_match(str(), regex);
-}
-
-/*!
  * Determines a modifier mask value from a list of key combo tokens
  *
  * \throws meaningful exceptions on parsing errors

--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -3,6 +3,7 @@
 #include <X11/Xlib.h>
 #include <algorithm>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 #include "completion.h"

--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -2,7 +2,6 @@
 
 #include <X11/Xlib.h>
 #include <algorithm>
-#include <iostream>
 #include <sstream> // IWYU pragma: keep
 #include <stdexcept>
 

--- a/src/keycombo.h
+++ b/src/keycombo.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <X11/X.h>
-#include <regex>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -67,7 +67,6 @@ public:
     KeyCombo() = default;
 
     std::string str() const;
-    bool matches(const std::regex& regex) const;
     bool operator==(const KeyCombo& other) const;
     static KeySym keySymFromString(const std::string& str);
     static KeyCombo fromString(const std::string& str);

--- a/src/keymanager.cpp
+++ b/src/keymanager.cpp
@@ -45,7 +45,7 @@ int KeyManager::addKeybindCommand(Input input, Output output) {
     // Make sure there is no existing binding with same keysym/modifiers
     removeKeyBinding(newBinding->keyCombo);
 
-    if (!newBinding->keyCombo.matches(activeKeyMask_.regex)) {
+    if (!activeKeyMask_.matches(newBinding->keyCombo)) {
         // Grab for events on this keycode
         xKeyGrabber_.grabKeyCombo(newBinding->keyCombo);
         newBinding->grabbed = true;
@@ -160,7 +160,7 @@ void KeyManager::ensureKeyMask(const Client* client) {
 
     string targetMaskStr = (client != nullptr) ? client->keyMask_() : "";
 
-    if (activeKeyMask_.str == targetMaskStr) {
+    if (activeKeyMask_.str() == targetMaskStr) {
         // nothing to do
         return;
     }
@@ -181,7 +181,7 @@ void KeyManager::ensureKeyMask(const Client* client) {
 void KeyManager::setActiveKeyMask(const KeyMask& newMask) {
     for (auto& binding : binds) {
         auto name = binding->keyCombo.str();
-        bool isMasked = binding->keyCombo.matches(newMask.regex);
+        bool isMasked = newMask.matches(binding->keyCombo);
 
         if (!isMasked && !binding->grabbed) {
             xKeyGrabber_.grabKeyCombo(binding->keyCombo);
@@ -222,4 +222,14 @@ bool KeyManager::removeKeyBinding(const KeyCombo& comboToRemove) {
     // Remove binding
     binds.erase(removeIter);
     return True;
+}
+
+
+/*!
+ * Returns true if the string representation of the KeyCombo matches
+ * the given keymask
+ */
+bool KeyManager::KeyMask::matches(const KeyCombo &combo) const
+{
+    return std::regex_match(combo.str(), regex_);
 }

--- a/src/keymanager.h
+++ b/src/keymanager.h
@@ -37,17 +37,21 @@ private:
             KeyMask ret;
             if (str != "") {
                 // Simply pass on any exceptions thrown here:
-                ret.regex = std::regex(str, std::regex::extended);
+                ret.str_ = str;
+                ret.regex_ = std::regex(str, std::regex::extended);
             }
             return ret;
         }
 
-        bool operator==(const KeyMask& other) const {
-            return other.str == str;
-        }
+        bool matches(const KeyCombo& combo) const;
+        std::string str() const { return str_; }
 
-        std::string str;
-        std::regex regex;
+        bool operator==(const KeyMask& other) const {
+            return other.str_ == str_;
+        }
+    private:
+        std::string str_;
+        std::regex regex_;
     };
 
     /*!

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -166,3 +166,16 @@ def test_complete_keybind_validates_all_tokens(hlwm):
     complete = hlwm.complete('keybind Moo+Mo', partial=True, position=1)
 
     assert complete == []
+
+
+def test_keymask_focus_switch(hlwm, keyboard):
+    c1, _ = hlwm.create_client()
+    c2, _ = hlwm.create_client()
+    hlwm.call('keybind x set_attr clients.focus.pseudotile on')
+    hlwm.call(f'set_attr clients.{c1}.keymask x')
+    hlwm.call(f'jumpto {c1}')
+
+    hlwm.call(f'jumpto {c2}')
+    keyboard.press('x')
+
+    assert hlwm.get_attr('clients.focus.pseudotile') == 'true'


### PR DESCRIPTION
When initializing a KeyMask, also set the str member. Also move the
sourcecode regarding matching from KeyCombo to the KeyMask class.

This fixes issue #713.