### PR TITLE
Introduce keys_inactive client attribute

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ Current git version
   * detection of external panels
   * new command: apply_rules
   * new command: export (convenience wrapper around setenv)
+  * new client attribute: key_inactive (negation of keymask)
   * new command: drag (initiates moving/resizing a window by mouse)
   * if tags have been configured through EWMH before herbstluftwm starts (from
     a previous running window manager), then herbstluftwm re-uses these tags

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1230,6 +1230,9 @@ Each 'CONSEQUENCE' consists of a 'NAME'='VALUE' pair. Valid 'NAMES' are:
 +keymask+::
     sets the keymask for a client (see <<KEYMASK, explanation in OBJECTS>>).
 
++keys_inactive+::
+    sets a regex that determines which key bindings are inactive for a client (see <<KEYMASK, explanation in OBJECTS>>).
+
 A rule's behaviour can be configured by some special 'FLAGS':
 
     * +not+: negates the next 'CONDITION'.
@@ -1415,11 +1418,17 @@ listed as follows:
 |s - title                | its window title
 |s - keymask              | [[KEYMASK]]A regular expression that is matched
                             against the string representation of all key
-                            bindings (see list_keybinds). While this client is
-                            focused, only bindings that match the expression
-                            will be active. Any other bindings will be disabled.
-                            The default keymask is an empty string (""), which
-                            does not disable any keybinding.
+                            bindings (as they are printed by list_keybinds).
+                            While this client is focused, only bindings that
+                            match the expression will be active. Any other
+                            bindings will be disabled. The default keymask is an
+                            empty string (""), which does not disable any
+                            keybinding.
+|s - keys_inactive        | A regular expression that describes which
+                            keybindings are inactive for the client. If a key
+                            combination is pressed and its string representation
+                            (as given by list_keybinds) matches the regex, then
+                            the key press is propagated to the client.
 |s - tag                  | the tag it's currently on
 |i - pid                  | the process id of it (-1 if unset)
 |s - class                | the class of it (second entry in WM_CLASS)

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1425,10 +1425,11 @@ listed as follows:
                             empty string (""), which does not disable any
                             keybinding.
 |s - keys_inactive        | A regular expression that describes which
-                            keybindings are inactive for the client. If a key
-                            combination is pressed and its string representation
-                            (as given by list_keybinds) matches the regex, then
-                            the key press is propagated to the client.
+                            keybindings are inactive while the client is
+                            focused. If a key combination is pressed and its
+                            string representation (as given by list_keybinds)
+                            matches the regex, then the key press is propagated
+                            to the client.
 |s - tag                  | the tag it's currently on
 |i - pid                  | the process id of it (-1 if unset)
 |s - class                | the class of it (second entry in WM_CLASS)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -42,6 +42,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , tag_str_(this,  "tag", &Client::tagName)
     , window_id_str(this,  "winid", "")
     , keyMask_(this,  "keymask", "")
+    , keysInactive_(this,  "keys_inactive", "")
     , pid_(this,  "pid", -1)
     , pseudotile_(this,  "pseudotile", false)
     , ewmhrequests_(this, "ewmhrequests", true)
@@ -59,6 +60,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     window_id_str = WindowID(window).str();
     floating_.setWriteable();
     keyMask_.setWriteable();
+    keysInactive_.setWriteable();
     ewmhnotify_.setWriteable();
     ewmhrequests_.setWriteable();
     for (auto i : {&fullscreen_, &pseudotile_}) {
@@ -66,7 +68,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
         i->changed().connect([this](bool){ needsRelayout.emit(this->tag()); });
     }
 
-    keyMask_.changed().connect([this] {
+    keysInactive_.changed().connect([this] {
             if (Root::get()->clients()->focus() == this) {
                 Root::get()->keys()->ensureKeyMask();
             }

--- a/src/client.h
+++ b/src/client.h
@@ -50,7 +50,8 @@ public:
     Attribute_<std::string> title_;  // or also called window title; this is never NULL
     DynAttribute_<std::string> tag_str_;
     Attribute_<std::string> window_id_str;
-    Attribute_<std::string> keyMask_; // keymask applied to mask out keybindins
+    Attribute_<std::string> keyMask_; // regex for key bindings that are active on this window
+    Attribute_<std::string> keysInactive_; // regex for key bindings that are inactive on this window
     Attribute_<int>  pid_;
     Attribute_<bool> pseudotile_; // only move client but don't resize (if possible)
     Attribute_<bool> ewmhrequests_; // accept ewmh-requests for this client

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -283,6 +283,9 @@ void ClientManager::setSimpleClientAttributes(Client* client, const ClientChange
     if (changes.keyMask.has_value()) {
         client->keyMask_ = changes.keyMask.value();
     }
+    if (changes.keysInactive.has_value()) {
+        client->keysInactive_ = changes.keysInactive.value();
+    }
 }
 
 int ClientManager::applyRulesCmd(Input input, Output output) {

--- a/src/keymanager.h
+++ b/src/keymanager.h
@@ -31,27 +31,37 @@ private:
         /*!
          * Creates a Keymask object from the given regex string
          *
+         * if negated=false, then this keymask only allows those keybindings
+         * that match the given regex.
+         *
+         * if negated=true, then this keymask only allows those keybindings
+         * that do not match the given regex.
+         *
+         * if the regex is "", then every keybinding is allowed (regardless of 'negated')
          * /throws exceptions thrown by std::regex
          */
-        static KeyMask fromString(const std::string& str = "") {
+        static KeyMask fromString(const std::string& str, bool negated) {
             KeyMask ret;
+            ret.negated_ = negated;
+            ret.str_ = str;
             if (str != "") {
                 // Simply pass on any exceptions thrown here:
-                ret.str_ = str;
                 ret.regex_ = std::regex(str, std::regex::extended);
             }
             return ret;
         }
 
-        bool matches(const KeyCombo& combo) const;
+        bool allowsBinding(const KeyCombo& combo) const;
         std::string str() const { return str_; }
 
         bool operator==(const KeyMask& other) const {
-            return other.str_ == str_;
+            return  (other.str_.empty() && str_.empty())
+                 || (other.str_ == str_ && other.negated_ == negated_);
         }
     private:
         std::string str_;
-        std::regex regex_;
+        std::regex  regex_;
+        bool        negated_ = true;
     };
 
     /*!
@@ -80,7 +90,7 @@ public:
 
     void regrabAll();
     void ensureKeyMask(const Client* client = nullptr);
-    void setActiveKeyMask(const KeyMask& newMask);
+    void setActiveKeyMask(const KeyMask& keysInactive);
     void clearActiveKeyMask();
 
     // TODO: This is not supposed to exist. It only does as a workaround,

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -37,6 +37,7 @@ const std::map<string, Consequence::Applier> Consequence::appliers = {
     { "ewmhnotify",     &Consequence::applyEwmhnotify      },
     { "hook",           &Consequence::applyHook            },
     { "keymask",        &Consequence::applyKeyMask         },
+    { "keys_inactive",  &Consequence::applyKeysInactive    },
     { "monitor",        &Consequence::applyMonitor         },
 };
 
@@ -289,6 +290,11 @@ void Consequence::applyHook(const Client* client, ClientChanges* changes) const 
 
 void Consequence::applyKeyMask(const Client* client, ClientChanges* changes) const {
     changes->keyMask = value;
+}
+
+void Consequence::applyKeysInactive(const Client *client, ClientChanges *changes) const
+{
+    changes->keysInactive = value;
 }
 
 void Consequence::applyMonitor(const Client* client, ClientChanges* changes) const {

--- a/src/rules.h
+++ b/src/rules.h
@@ -71,6 +71,7 @@ public:
     bool            manage = true; // whether we should manage it
     std::experimental::optional<bool> fullscreen;
     std::experimental::optional<std::string> keyMask; // Which keymask rule should be applied for this client
+    std::experimental::optional<std::string> keysInactive; // Which keymask rule should be applied for this client
 
     std::experimental::optional<bool> floating;
     std::experimental::optional<bool> pseudotile;
@@ -104,6 +105,7 @@ private:
     void applyEwmhnotify(const Client* client, ClientChanges* changes) const;
     void applyHook(const Client* client, ClientChanges* changes) const;
     void applyKeyMask(const Client* client, ClientChanges* changes) const;
+    void applyKeysInactive(const Client* client, ClientChanges* changes) const;
     void applyMonitor(const Client* client, ClientChanges* changes) const;
 };
 

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -168,7 +168,7 @@ def test_complete_keybind_validates_all_tokens(hlwm):
     assert complete == []
 
 
-def test_keys_inactive(hlwm, keyboard):
+def test_keys_inactive_on_other_client(hlwm, keyboard):
     c1, _ = hlwm.create_client()
     c2, _ = hlwm.create_client()
     hlwm.call('keybind x set_attr clients.focus.pseudotile on')

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -79,19 +79,19 @@ def test_trigger_selfremoving_binding(hlwm, keyboard):
     assert hlwm.call('list_keybinds').stdout == ''
 
 
-@pytest.mark.parametrize('maskmethod', ('rule', 'set_attr'))  # how keymask gets set
+@pytest.mark.parametrize('maskmethod', ('rule', 'set_attr'))  # how keys_inactive gets set
 @pytest.mark.parametrize('whenbind', ('existing', 'added_later'))  # when keybinding is set up
 @pytest.mark.parametrize('refocus', (True, False))  # whether to defocus+refocus before keypress
-def test_keymask(hlwm, keyboard, maskmethod, whenbind, refocus):
+def test_keys_inactive(hlwm, keyboard, maskmethod, whenbind, refocus):
     if whenbind == 'existing':
         hlwm.call('keybind x add tag2')
     if maskmethod == 'rule':
-        hlwm.call('rule once keymask=^x$')
+        hlwm.call('rule once keys_inactive=^x$')
 
     _, client_proc = hlwm.create_client(term_command='read -n 1')
 
     if maskmethod == 'set_attr':
-        hlwm.call('set_attr clients.focus.keymask ^x$')
+        hlwm.call('set_attr clients.focus.keys_inactive ^x$')
     if whenbind == 'added_later':
         hlwm.call('keybind x add tag2')
 
@@ -115,15 +115,15 @@ def test_keymask(hlwm, keyboard, maskmethod, whenbind, refocus):
 
 
 @pytest.mark.parametrize('maskmethod', ('rule', 'set_attr'))
-def test_invalid_keymask_has_no_effect(hlwm, keyboard, maskmethod):
+def test_invalid_keys_inactive(hlwm, keyboard, maskmethod):
     hlwm.call('keybind x close')
     if maskmethod == 'rule':
-        hlwm.call('rule once keymask=[b-a]')
+        hlwm.call('rule once keys_inactive=[b-a]')
     hlwm.create_client()
     if maskmethod == 'set_attr':
         # Note: In future work, we could make this fail right away. But
         # currently, that is not the case.
-        hlwm.call('set_attr clients.focus.keymask [b-a]')
+        hlwm.call('set_attr clients.focus.keys_inactive [b-a]')
 
     keyboard.press('x')
 
@@ -168,11 +168,11 @@ def test_complete_keybind_validates_all_tokens(hlwm):
     assert complete == []
 
 
-def test_keymask_focus_switch(hlwm, keyboard):
+def test_keys_inactive(hlwm, keyboard):
     c1, _ = hlwm.create_client()
     c2, _ = hlwm.create_client()
     hlwm.call('keybind x set_attr clients.focus.pseudotile on')
-    hlwm.call(f'set_attr clients.{c1}.keymask x')
+    hlwm.call(f'set_attr clients.{c1}.keys_inactive x')
     hlwm.call(f'jumpto {c1}')
 
     hlwm.call(f'jumpto {c2}')

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -28,6 +28,7 @@ consequences = [
     'fullscreen',
     'hook',
     'keymask',
+    'keys_inactive',
 ]
 
 
@@ -319,6 +320,17 @@ def test_bool_consequence_with_corresponding_attribute(hlwm, name, value, apply_
     winid = create_client(hlwm, apply_rules, [name + '=' + hlwm.bool(value)])
 
     assert hlwm.get_attr('clients.{}.{}'.format(winid, name)) == hlwm.bool(value)
+
+
+@pytest.mark.parametrize(
+    'name',
+    ['keymask', 'keys_inactive'])
+@pytest.mark.parametrize('apply_rules', [True, False])
+def test_regex_consequence_with_corresponding_attribute(hlwm, name, apply_rules):
+    value = 'someregex'
+    winid = create_client(hlwm, apply_rules, [name + '=' + value])
+
+    assert hlwm.get_attr('clients.{}.{}'.format(winid, name)) == value
 
 
 @pytest.mark.parametrize('manage', ['on', 'off'])


### PR DESCRIPTION
The current winterbreeze implementation of keymask was wrong (negated).
Since this is proven to be useful, to block certain keybindings for
concrete clients, we call this feature 'keys_inactive'.

This makes 'keymask' currently an attribute without any effect. The next
step is then to bring back the old behaviour of 'keymask'

See also #713.