### PR TITLE
Respect inactive binds in KeyManager::regrabAll()

### DIFF
--- a/src/keymanager.cpp
+++ b/src/keymanager.cpp
@@ -139,8 +139,10 @@ void KeyManager::regrabAll() {
     xKeyGrabber_.ungrabAll();
 
     for (auto& binding : binds) {
-        xKeyGrabber_.grabKeyCombo(binding->keyCombo);
-        binding->grabbed = true;
+        // grab precisely those again, that have been grabbed before
+        if (binding->grabbed) {
+            xKeyGrabber_.grabKeyCombo(binding->keyCombo);
+        }
     }
 }
 

--- a/src/keymanager.h
+++ b/src/keymanager.h
@@ -60,7 +60,7 @@ private:
     public:
         KeyCombo keyCombo;
         std::vector<std::string> cmd;
-        bool grabbed;
+        bool grabbed = false;
     };
 
 public:

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -144,6 +144,21 @@ def test_complete_keybind_after_combo_offers_all_commands(hlwm):
     assert complete == hlwm.complete('', position=0)
 
 
+def test_keys_inactive_regrab_all(hlwm, keyboard):
+    hlwm.create_client()
+    hlwm.call('new_attr string clients.focus.my_x_pressed')
+    hlwm.call('keybind x set_attr clients.focus.my_x_pressed pressed')
+    hlwm.call('keybind y true')
+    # this disables the x binding
+    hlwm.call('set_attr clients.focus.keys_inactive x')
+
+    hlwm.call('keyunbind y')
+    keyboard.press('x')
+
+    # check that x is really disabled:
+    assert hlwm.get_attr('clients.focus.my_x_pressed') == ''
+
+
 def test_complete_keybind_offers_additional_mods_without_duplication(hlwm):
     complete = hlwm.complete('keybind Mod2+Mo', partial=True, position=1)
 


### PR DESCRIPTION
In regrabAll(), do not regrab all bindings but only that were enabled
before. For example, when a keybind is removed, then regrabAll() is
called, which did invalidate the current keys_inactive attribute (see
the new testcase).