### PR TITLE
Raise tiled focused clients

### DIFF
--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -166,8 +166,21 @@ void Monitor::applyLayout() {
         } else {
             tag->stack->sliceRemoveLayer(c->slice, LAYER_FULLSCREEN);
         }
-        if (!p.second.floated && p.second.needsRaise) {
-            c->raise();
+        // special raise rules for tiled clients:
+        if (!p.second.floated) {
+            // this client is the globally focused client if this monitor
+            // is focused and if this client is the focus on this monitor:
+            bool globallyFocusedClient = isFocused && res.focus == c;
+            // if this client is globally focused, then it has a different border color
+            // and so we raise it to make the look of overlapping shadows more pleasent if
+            // a compositor is running.
+            //
+            // Thus, raise this client if it needs to be raised according
+            // to the TilingResult (if it is the selected window in a max-frame) or
+            // if this client is focused:
+            if (p.second.needsRaise || globallyFocusedClient) {
+                c->raise();
+            }
         }
     }
     tag->stack->clearLayer(LAYER_FOCUS);

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -33,10 +33,9 @@ def helper_get_stack_as_list(hlwm, clients_only=True, strip_focus_layer=False):
     return winids_new
 
 
-@pytest.mark.parametrize('floatingmode', ['on', 'off'])
 @pytest.mark.parametrize('count', [2, 5])
-def test_clients_stacked_in_reverse_order_of_creation(hlwm, floatingmode, count):
-    hlwm.call(['floating', floatingmode])
+def test_clients_stacked_in_reverse_order_of_creation(hlwm, count):
+    hlwm.call('floating on')
 
     clients = hlwm.create_clients(count)
 


### PR DESCRIPTION
This improves the look and feel of compositor shadows. This
reestablishes the feature of 622cafe534 (#566), but now it does not
interfere with (global) floating mode or the floating layer since we
only raise them within the tiling layer.