### PR TITLE
Fix active smart_window_surroundings

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -17,7 +17,6 @@
 #include "monitormanager.h"
 #include "mousemanager.h"
 #include "root.h"
-#include "settings.h"
 #include "stack.h"
 #include "tag.h"
 #include "theme.h"

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -244,12 +244,6 @@ void Client::raise() {
 }
 
 void Client::resize_tiling(Rectangle rect, bool isFocused) {
-    // apply border width
-    if (!this->pseudotile_ /* && !smart_window_surroundings_active(frame) */) {
-        // apply window gap
-        rect.width -= settings.window_gap();
-        rect.height -= settings.window_gap();
-    }
     auto& scheme = theme[Theme::Type::Tiling](isFocused, urgent_());
     if (this->pseudotile_) {
         auto inner = this->float_size_;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -297,15 +297,19 @@ TilingResult HSFrameLeaf::computeLayout(Rectangle rect) {
             // and 2. only one window is shown
             && (clientCount() == 1 || layout == LayoutAlgorithm::max);
 
+    auto window_gap = settings_->window_gap();
     if (!smart_window_surroundings_active) {
-        // apply window gap
-        auto window_gap = settings_->window_gap();
+        // dedunct 'window_gap' many pixels from the left
+        // and from the top border. Later, we will deduct
+        // 'window_gap' many pixels from the bottom and the
+        // right from every window
         rect.x += window_gap;
         rect.y += window_gap;
         rect.width -= window_gap;
         rect.height -= window_gap;
 
-        // apply frame padding
+        // apply frame padding: deduct 'frame_padding' pixels
+        // from all four sides:
         auto frame_padding = settings_->frame_padding();
         rect.x += frame_padding;
         rect.y += frame_padding;
@@ -326,6 +330,14 @@ TilingResult HSFrameLeaf::computeLayout(Rectangle rect) {
         case LayoutAlgorithm::horizontal:
             layoutResult = layoutHorizontal(rect);
             break;
+    }
+    if (!smart_window_surroundings_active) {
+        // apply window gap: deduct 'window_gap' many pixels from
+        // bottom and right of every window:
+        for (auto& it : layoutResult.data) {
+            it.second.geometry.width -= window_gap;
+            it.second.geometry.height -= window_gap;
+        }
     }
     res.mergeFrom(layoutResult);
     res.focus = clients[selection];


### PR DESCRIPTION
Handle smart_window_surroundings entirely in HSFrameLeaf::
computeLayout() and not (as formerly) in Client::resize_tiling(). Here,
we have all the necessary data available to decide whether the
window_gap needs to be applied or not.

Due to the migration, the relevant code in Client has been turned into a
commend, and with the rewrite/cleanup the client has no access to the
frame it lives in.

Also add a test case to check that the new computations are correct.

This solves issue #721. Thanks to @tiosgz for reporting this!