### PR TITLE
Auto float windows with transient-for hints

### DIFF
--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -19,6 +19,7 @@
 #include "tag.h"
 #include "tagmanager.h"
 #include "utils.h"
+#include "xconnection.h"
 
 using std::endl;
 using std::function;
@@ -256,6 +257,9 @@ ClientChanges ClientManager::applyDefaultRules(Window win)
     if (std::find(floated.begin(), floated.end(), windowType) != floated.end())
     {
         changes.floating = True;
+    }
+    if (ewmh->X().getTransientForHint(win).has_value()) {
+        changes.floating = true;
     }
     return changes;
 }

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -248,7 +248,16 @@ void XConnection::setPropertyCardinal(Window w, Atom property, const vector<long
     // if format = 32, then the data must be a long array.
     XChangeProperty(m_display, w, property,
         XA_CARDINAL, 32, PropModeReplace,
-        (unsigned char*)(value.data()), value.size());
+                    (unsigned char*)(value.data()), value.size());
+}
+
+std::experimental::optional<Window> XConnection::getTransientForHint(Window win)
+{
+    Window master;
+    if (XGetTransientForHint(m_display, win, &master) != 0) {
+        return master;
+    }
+    return {};
 }
 
 /** a sincere wrapper around XGetWindowProperty():

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -43,6 +43,7 @@ public:
     void setPropertyString(Window w, Atom property, const std::vector<std::string>& value);
     void setPropertyWindow(Window w, Atom property, const std::vector<Window>& value);
     void setPropertyCardinal(Window w, Atom property, const std::vector<long>& value);
+    std::experimental::optional<Window> getTransientForHint(Window win);
     std::vector<Window> queryTree(Window window);
     static void setExitOnError(bool exitOnError);
 private:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -614,6 +614,7 @@ def x11(x11_connection):
                           sync_hlwm=True,
                           wm_class=None,
                           window_type=None,
+                          transient_for=None,
                           ):
             w = self.root.create_window(
                 geometry[0],
@@ -629,6 +630,9 @@ def x11(x11_connection):
             )
             if wm_class is not None:
                 w.set_wm_class(wm_class[0], wm_class[1])
+
+            if transient_for is not None:
+                w.set_wm_transient_for(transient_for)
 
             # Keep track of window for later removal:
             self.windows.add(w)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -505,3 +505,15 @@ def test_dialog_window_floated(hlwm, hc_idle, x11, window_type):
                                  window_type=window_type)
     assert hlwm.get_attr(f'clients.{winid}.floating') == hlwm.bool(True)
     assert ['rule', 'mywindow', winid] in hc_idle.hooks()
+
+
+@pytest.mark.parametrize('transient_for', [True, False])
+def test_float_transient_for(hlwm, x11, transient_for):
+    mainwin, mainwinid = x11.create_client()
+    trans_for_win = None
+    if transient_for:
+        trans_for_win = mainwin
+    _, winid = x11.create_client(transient_for=trans_for_win)
+
+    assert hlwm.get_attr(f'clients.{mainwinid}.floating') == 'false'
+    assert hlwm.get_attr(f'clients.{winid}.floating') == hlwm.bool(transient_for)


### PR DESCRIPTION
Some dialog windows have window type 'normal', but have the
transient-for hint set, which refers to the main application window.
These dialog windows should be floated automatically (unless the user
defined rule say something else).

This closes #723.