### PR TITLE
Remove unused Ewmh::readClientList()

### DIFF
--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -191,21 +191,6 @@ const Ewmh::InitialState &Ewmh::initialState()
     return initialState_;
 }
 
-bool Ewmh::readClientList(Window** buf, unsigned long *count) {
-    Atom actual_type;
-    int format;
-    unsigned long bytes_left;
-    if (Success != XGetWindowProperty(X_.display(), X_.root(),
-            g_netatom[NetClientList], 0, ~0L, False, XA_WINDOW, &actual_type,
-            &format, count, &bytes_left, (unsigned char**)buf)) {
-        return false;
-    }
-    if (bytes_left || actual_type != XA_WINDOW || format != 32) {
-        return false;
-    }
-    return true;
-}
-
 void Ewmh::updateClientListStacking() {
     // First: get the windows currently visible
     vector<Window> buf;

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -149,7 +149,6 @@ public:
 
 private:
     bool focusStealingAllowed(long source);
-    bool readClientList(Window** buf, unsigned long *count);
     Root* root_ = nullptr;
     TagManager* tags_ = nullptr;
     XConnection& X_;


### PR DESCRIPTION
Thanks to XConnection::getWindowPropertyWindow(), this is now a
one-liner in Ewmh::readInitialEwmhState().