### PR TITLE
Let floating accept no arguments

### DIFF
--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -336,7 +336,10 @@ int TagManager::floatingCmd(Input input, Output output) {
     } else if (input.size() == 1) {
         input >> newValue;
     } else {
-        return HERBST_NEED_MORE_ARGS;
+        tagName = "";
+    }
+    if (newValue.empty()) {
+        newValue = "toggle";
     }
     HSTag* tag = monitors_->focus()->tag;
     if (tagName != "") {

--- a/tests/test_floating.py
+++ b/tests/test_floating.py
@@ -43,3 +43,15 @@ def test_directional_focus(hlwm, clientFocused):
                 == clients[expected_target]
         else:
             hlwm.call_xfail(cmd).expect_stderr('No neighbour found')
+
+
+def test_floating_command_no_tag(hlwm):
+    assert hlwm.get_attr('tags.0.floating') == hlwm.bool(False)
+
+    # toggles the floating state of current tag
+    hlwm.call('floating')
+    assert hlwm.get_attr('tags.0.floating') == hlwm.bool(True)
+
+    # toggles the floating state again
+    hlwm.call('floating')
+    assert hlwm.get_attr('tags.0.floating') == hlwm.bool(False)


### PR DESCRIPTION
Bring back the old behaviour of the 'floating' command that toggled the
state for the current tag if no arguments were passed.

This solves issue #734.