### PR TITLE
Do not exit on X errors

### DIFF
--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -98,7 +98,11 @@ int XConnection::xerror(Display *dpy, XErrorEvent *ee) {
         HSDebug("Warning: ignoring X_BadDrawable\n");
         return 0;
     }
-    return g_xerrorxlib(dpy, ee); /* may call exit */
+    if (exitOnError_) {
+        return g_xerrorxlib(dpy, ee); // may call exit()
+    }
+    // otherwise, just ignore this error and try to proceed.
+    return 0;
 }
 
 


### PR DESCRIPTION
Only exit if --exit-on-xerrors was specified. Otherwise, print the error
to stderr and keep running