### PR TITLE
Check randr version before XRRGetMonitors()

### DIFF
--- a/src/monitordetection.cpp
+++ b/src/monitordetection.cpp
@@ -9,6 +9,7 @@
 
 #include <X11/extensions/Xrandr.h>
 
+using std::make_pair;
 using std::string;
 using std::vector;
 
@@ -46,6 +47,7 @@ RectangleVec detectMonitorsXinerama(XConnection& X) {
 #endif /* XINERAMA */
 
 RectangleVec detectMonitorsXrandr(XConnection& X) {
+    // see /usr/share/doc/xorgproto/randrproto.txt for documentation
     int outputs = 0;
     int event_base = 0;
     int error_base = 0;
@@ -53,6 +55,14 @@ RectangleVec detectMonitorsXrandr(XConnection& X) {
         HSDebug("no xrandr available\n");
         return {};
     }
+
+    int major_version = 0, minor_version = 0;
+    XRRQueryVersion(X.display(), &major_version, &minor_version);
+    if (make_pair(major_version, minor_version) < make_pair(1, 5)) {
+        HSDebug("RRGetMonitors only available since RandR 1.5");
+        return {};
+    }
+    // RRGetMonitors was added with randr 1.5
     XRRMonitorInfo* monitorInfo = XRRGetMonitors(X.display(), X.root(), true, &outputs);
     if (outputs <= 0 || !monitorInfo) {
         return {};


### PR DESCRIPTION
XRRGetMonitors() requires at least version 1.5. Check this, before
calling XRRGetMonitors().