### PR TITLE
Fix narrowing warning in ewmh.cpp

### DIFF
--- a/cmake/debugflags.cmake
+++ b/cmake/debugflags.cmake
@@ -16,7 +16,7 @@ set(FLAGS
     -Wno-unused-parameter
 
     # Disable warnings that trigger due to known unresolved issues:
-    -Wno-sign-compare -Wno-narrowing
+    -Wno-sign-compare
     )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -460,6 +460,9 @@ bool Ewmh::isFullscreenSet(Window win) {
 }
 
 void Ewmh::setWindowOpacity(Window win, double opacity) {
+    /* Based on the EWMH proposal
+     * https://mail.gnome.org/archives/wm-spec-list/2003-December/msg00035.html
+     */
     long long_opacity = 0xffffffff * CLAMP(opacity, 0, 1);
     X_.setPropertyCardinal(win, g_netatom[NetWmWindowOpacity], { long_opacity });
 }

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -4,7 +4,6 @@
 #include <X11/Xlib.h>
 #include <algorithm>
 #include <cstdio>
-#include <limits>
 
 #include "client.h"
 #include "hlwmcommon.h"

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -460,9 +460,7 @@ bool Ewmh::isFullscreenSet(Window win) {
 }
 
 void Ewmh::setWindowOpacity(Window win, double opacity) {
-    long long_opacity = std::numeric_limits<long>::max()
-                            * CLAMP(opacity, 0, 1);
-
+    long long_opacity = 0xffffffff * CLAMP(opacity, 0, 1);
     X_.setPropertyCardinal(win, g_netatom[NetWmWindowOpacity], { long_opacity });
 }
 

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -460,10 +460,10 @@ bool Ewmh::isFullscreenSet(Window win) {
 }
 
 void Ewmh::setWindowOpacity(Window win, double opacity) {
-    uint32_t int_opacity = std::numeric_limits<uint32_t>::max()
+    long long_opacity = std::numeric_limits<long>::max()
                             * CLAMP(opacity, 0, 1);
 
-    X_.setPropertyCardinal(win, g_netatom[NetWmWindowOpacity], { int_opacity });
+    X_.setPropertyCardinal(win, g_netatom[NetWmWindowOpacity], { long_opacity });
 }
 
 void Ewmh::updateFrameExtents(Window win, int left, int right, int top, int bottom) {


### PR DESCRIPTION
Also enable the narrowing warning in debug builds again, now this is
fixed.