### PR TITLE
Frame index for empty frame

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 herbstluftwm NEWS -- History of user-visible changes
 ----------------------------------------------------
 
+Current git version
+-------------------
+
+  * the frame index 'e' refers to the first empty frame (e.g. 'rule index=e' places
+    new windows in empty frames, if possible)
+
 Release 0.8.0 on 2020-04-09
 ---------------------------
 

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -115,9 +115,12 @@ The characters are interpreted as follows:
     * +1+: select the second subtree
     * +.+: select the subtree having the focus
     * +/+: select the subtree not having the focus
+    * +e+: finds a suitable empty frame: if the focused frame is not empty, this
+      selects the closest frame that is empty (in any subtree)
 
 Thus an empty string refers to the root frame, and "00" refers to the first
-subtree of the first subtree of the root frame.
+subtree of the first subtree of the root frame. Similarly "1e" refers to the
+first empty frame in the second subtree.
 
 As a special case, the string "@" always refers to the currently focused
 frame.

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -26,6 +26,8 @@ public:
 
     static void dump(std::shared_ptr<HSFrame> frame, Output output);
     static void prettyPrint(std::shared_ptr<HSFrame> frame, Output output);
+    static std::shared_ptr<HSFrameLeaf> findEmptyFrame(std::shared_ptr<HSFrame> subtree);
+    static std::shared_ptr<HSFrameLeaf> findEmptyFrameNearFocus(std::shared_ptr<HSFrame> subtree);
     std::shared_ptr<HSFrame> lookup(const std::string& path);
     static std::shared_ptr<HSFrameLeaf> focusedFrame(std::shared_ptr<HSFrame> node);
     std::shared_ptr<HSFrameLeaf> focusedFrame();

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -26,7 +26,6 @@ public:
 
     static void dump(std::shared_ptr<HSFrame> frame, Output output);
     static void prettyPrint(std::shared_ptr<HSFrame> frame, Output output);
-    static std::shared_ptr<HSFrameLeaf> findEmptyFrame(std::shared_ptr<HSFrame> subtree);
     static std::shared_ptr<HSFrameLeaf> findEmptyFrameNearFocus(std::shared_ptr<HSFrame> subtree);
     std::shared_ptr<HSFrame> lookup(const std::string& path);
     static std::shared_ptr<HSFrameLeaf> focusedFrame(std::shared_ptr<HSFrame> node);
@@ -61,6 +60,7 @@ public:
 public: // soon to be come private:
     std::shared_ptr<HSFrame> root_;
 private:
+    static std::shared_ptr<HSFrameLeaf> findEmptyFrameNearFocusGeometrically(std::shared_ptr<HSFrame> subtree);
     //! cycle the frames within the current tree
     void cycle_frame(std::function<size_t(size_t,size_t)> indexAndLenToIndex);
     void cycle_frame(int delta);

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -5,11 +5,14 @@
 #include <X11/Xutil.h>
 #include <algorithm>
 #include <cassert>
+#include <limits>
 #include <iomanip>
 
 #include "globals.h"
+#include "utils.h"
 
 using std::string;
+using std::vector;
 
 Color Color::black() {
     // currently, the constructor without arguments constructs black
@@ -138,6 +141,40 @@ Rectangle Rectangle::intersectionWith(const Rectangle &other) const
                 std::min(br().y, other.br().y));
 }
 
+//! the minimum distance between any two points from the one and the other
+//! rectangle
+int Rectangle::manhattanDistanceTo(Rectangle &other) const
+{
+    if (intersectionWith(other)) {
+        return 0; // distance 0 if there is an intersection
+    }
+    // if they don't intersect but are below each other
+    if (intervals_intersect(x, x + width, other.x, other.x + other.width)) {
+        return std::min(
+                    // this is below the other:
+                    std::abs(y - (other.y + other.height)),
+                    // this is above the other:
+                    std::abs(other.y - (y + height)));
+    }
+    // if they don't intersect but are next to each other
+    if (intervals_intersect(y, y + height, other.y, other.y + other.height)) {
+        return std::min(
+                    // this is right of the other
+                    std::abs(x - (other.x + other.width)),
+                    // this is left of the other
+                    std::abs(other.x - (x + width)));
+    }
+    vector<Point2D> thisCorners = { tl(), tr(), bl(), br() };
+    vector<Point2D> otherCorners = { other.tl(), other.tr(), other.bl(), other.br() };
+    int minDist = std::numeric_limits<int>::max();
+    for (const auto& p1 : thisCorners) {
+        for (const auto& p2 : otherCorners) {
+            minDist = std::min(minDist, (p1 - p2).manhattanLength());
+        }
+    }
+    return minDist;
+}
+
 std::ostream& operator<< (std::ostream& stream, const Rectangle& rect) {
     stream
         << rect.width << "x" << rect.height
@@ -147,3 +184,8 @@ std::ostream& operator<< (std::ostream& stream, const Rectangle& rect) {
     return stream;
 }
 
+
+int Point2D::manhattanLength() const
+{
+    return std::abs(x) + std::abs(y);
+}

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -5,8 +5,8 @@
 #include <X11/Xutil.h>
 #include <algorithm>
 #include <cassert>
-#include <limits>
 #include <iomanip>
+#include <limits>
 
 #include "globals.h"
 #include "utils.h"

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -66,6 +66,7 @@ struct Point2D {
     bool biggerSlopeThan(const Point2D& other) const {
        return y * other.x > other.y * x;
     }
+    int manhattanLength() const;
 };
 
 struct Rectangle {
@@ -89,6 +90,7 @@ struct Rectangle {
     operator bool() const;
 
     Rectangle intersectionWith(const Rectangle& other) const;
+    int manhattanDistanceTo(Rectangle& other) const;
 
     int x;
     int y;

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -497,10 +497,11 @@ def test_resize_nested_split(hlwm):
 
 
 @pytest.mark.parametrize('layout', [
-    # layouts where existing windows are marked by W and the new window
-    # is marked by N
+    # layouts where existing windows are marked by W and the target
+    # frame for the new window is marked by T
     '(clients max:0 T)',
     '(clients max:0 W T)',
+    '(split vertical:0.5:1 (clients max:0 W) (clients max:0 W T))',
     # the selected frame isn't the first empty frame in order but
     # is perfectly fine, because it's empty:
     '(split vertical:0.5:1 (clients max:0) (clients max:0 T))',
@@ -516,6 +517,28 @@ def test_resize_nested_split(hlwm):
     # here, no frames are empty, so the focused frame is taken
     '(split horizontal:0.5:0 (split vertical:0.5:1 \
         (clients max:0 W) (clients max:0 W T)) (clients grid:0 W))',
+    # let geometry come into play:
+    # +-----+-----+
+    # |+-+-+|     |  here, the new window should go to (T)
+    # || |T||  W  |  even though it's neighbour frame comes first
+    # |+-+-+|     |  when traversing the tree
+    # +-----+-----+
+    '(split horizontal:0.5:1 \
+        (split horizontal:0.5:0 (clients max:0) (clients max:0 T)) \
+        (clients max:0 W))',
+    #
+    # +---+---+
+    # |Foc|W| |   <- the new window should go to T, even though
+    # | W +-+-+      the top right frame comes first when traversing
+    # |   | T |      the layout tree.
+    # +---+---+
+    #
+    '(split horizontal:0.5:0 \
+        (clients vertical:0 W) \
+        (split vertical:0.5:1 \
+            (split horizontal:0.5:1 (clients vertical:0 W) \
+                                    (clients vertical:0)) \
+            (clients vertical:0 T)))',
 ])
 def test_index_empty_frame_global(hlwm, layout):
     layout = re.sub(r' [ ]*', ' ', layout)


### PR DESCRIPTION
A new frame index 'e' specifier that finds an empty frame as close as
possible to the focused frame.

This implements #710.