### PR TITLE
Explicitly hide covered windows in max layout

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ Current git version
 
   * the frame index 'e' refers to the first empty frame (e.g. 'rule index=e' places
     new windows in empty frames, if possible)
+  * new setting 'hide_covered_windows' to improve the appearance when used with
+    a compositor.
 
 Release 0.8.0 on 2020-04-09
 ---------------------------

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1026,6 +1026,13 @@ gapless_grid (Boolean)::
     this frame. If unset, then the last client has the same size as all other
     clients in this frame.
 
+hide_covered_windows (Boolean)::
+    If activated, windows are explicitly hidden when they are covered by another
+    window in a frame with max layout. This only has a visible effect if a
+    compositor is used. If activated, shadows do not stack up and transparent
+    windows show the wallpaper behind them instead of the other clients in the
+    max layout.
+
 smart_frame_surroundings (Boolean)::
     If set, frame borders and gaps will be removed when there's no ambiguity
     regarding the focused frame.

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -198,8 +198,19 @@ TilingResult HSFrameLeaf::layoutLinear(Rectangle rect, bool vertical) {
 
 TilingResult HSFrameLeaf::layoutMax(Rectangle rect) {
     TilingResult res;
-    for (auto client : clients) {
+    // go through all clients from top to bottom and remember
+    // whether they are still visible. The stacking order is such that
+    // the windows at the end of 'clients' are on top of the windows
+    // at the beginning of 'clients'. So start at the selection and go
+    // downwards in the stack, i.e. backwards in the 'clients' array
+    bool stillVisible = true;
+    for (size_t idx = 0; idx < clients.size(); idx++) {
+        Client* client = clients[(selection + clients.size() - idx) % clients.size()];
         TilingStep step(rect);
+        step.visible = stillVisible;
+        // the next is only visible, if the current client is visible
+        // and if the current client is pseudotiled
+        stillVisible = stillVisible && client->pseudotile_();
         if (client == clients[selection]) {
             step.needsRaise = true;
         }

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -158,6 +158,21 @@ void Monitor::applyLayout() {
             p.second.floated = true;
         }
     }
+    // preprocessing
+    for (auto& p : res.data) {
+        if (p.first->fullscreen_() || p.second.floated) {
+            // do not hide fullscreen windows
+            p.second.visible = true;
+        }
+        if (settings->hide_covered_windows) {
+            // apply hiding of windows: move them to out of the screen:
+            if (!p.second.visible) {
+                Rectangle& geo = p.second.geometry;
+                geo.x = -100 - geo.width;
+                geo.y = -100 - geo.height;
+            }
+        }
+    }
     // 1. Update stack (TODO: why stack first?)
     for (auto& p : res.data) {
         Client* c = p.first;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -70,6 +70,7 @@ Settings::Settings()
         &raise_on_focus_temporarily,
         &raise_on_click,
         &gapless_grid,
+        &hide_covered_windows,
         &smart_frame_surroundings,
         &smart_window_surroundings,
         &monitors_locked,
@@ -89,6 +90,7 @@ Settings::Settings()
     for (auto i : {&frame_gap, &frame_padding, &window_gap}) {
         i->changed().connect([] { all_monitors_apply_layout(); });
     }
+    hide_covered_windows.changed().connect([] { all_monitors_apply_layout(); });
     for (auto i : {
          &frame_border_active_color,
          &frame_border_normal_color,

--- a/src/settings.h
+++ b/src/settings.h
@@ -57,6 +57,7 @@ public:
     Attribute_<bool>          raise_on_focus_temporarily = {"raise_on_focus_temporarily", false};
     Attribute_<bool>          raise_on_click = {"raise_on_click", true};
     Attribute_<bool>          gapless_grid = {"gapless_grid", true};
+    Attribute_<bool>          hide_covered_windows = {"hide_covered_windows", false};
     Attribute_<bool>          smart_frame_surroundings = {"smart_frame_surroundings", false};
     Attribute_<bool>          smart_window_surroundings = {"smart_window_surroundings", false};
     Attribute_<int>           monitors_locked = {"monitors_locked", 0};

--- a/src/tilingresult.h
+++ b/src/tilingresult.h
@@ -16,6 +16,8 @@ public:
     Rectangle geometry;
     bool floated = false;
     bool needsRaise = false;
+    bool visible = true; //! whether this window is entirely covered
+                         //! by another window (e.g. in max layout)
 };
 
 // a tiling result contains the movement commands etc. for all clients


### PR DESCRIPTION
This improves the appearance when a compositor is used.

This implements #673.