### PR TITLE
Explicitly provide add() function in TilingResult

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -188,7 +188,7 @@ TilingResult HSFrameLeaf::layoutLinear(Rectangle rect, bool vertical) {
         // add the space, if count does not divide frameheight without remainder
         cur.height += (i == count-1) ? last_step_y : 0;
         cur.width += (i == count-1) ? last_step_x : 0;
-        res[client] = TilingStep(cur);
+        res.add(client, TilingStep(cur));
         cur.y += step_y;
         cur.x += step_x;
         i++;
@@ -203,7 +203,7 @@ TilingResult HSFrameLeaf::layoutMax(Rectangle rect) {
         if (client == clients[selection]) {
             step.needsRaise = true;
         }
-        res[client] = step;
+        res.add(client, step);
     }
     return res;
 }
@@ -252,7 +252,7 @@ TilingResult HSFrameLeaf::layoutGrid(Rectangle rect) {
             }
 
             // apply size
-            res[clients[i]] = TilingStep(cur);
+            res.add(clients[i], TilingStep(cur));
             cur.x += width;
             i++;
         }

--- a/src/tilingresult.cpp
+++ b/src/tilingresult.cpp
@@ -6,17 +6,16 @@ TilingStep::TilingStep(Rectangle rect)
     : geometry(rect)
 { }
 
-TilingStep& TilingResult::operator[](Client* client) {
-    TilingStep someStep = Rectangle();
-    data.push_back(make_pair(client, someStep));
-    return data.rbegin()->second;
+void TilingResult::add(Client* client, const TilingStep& client_data)
+{
+    data.push_back(make_pair(client, client_data));
+}
+
+void TilingResult::add(FrameDecoration* dec, const FrameDecorationData& frame_data) {
+    frames.push_back(make_pair(dec,frame_data));
 }
 
 void TilingResult::mergeFrom(TilingResult& other) {
     data.splice(data.end(), other.data);
     frames.splice(frames.end(), other.frames);
-}
-
-void TilingResult::add(FrameDecoration* dec, const FrameDecorationData& frame_data) {
-    frames.push_back(make_pair(dec,frame_data));
 }

--- a/src/tilingresult.h
+++ b/src/tilingresult.h
@@ -22,7 +22,6 @@ public:
 class TilingResult {
 public:
     TilingResult() = default;
-    TilingStep& operator[](Client* client);
     void add(Client* client, const TilingStep& client_data);
     void add(FrameDecoration* dec, const FrameDecorationData& frame_data);
 

--- a/src/tilingresult.h
+++ b/src/tilingresult.h
@@ -23,6 +23,7 @@ class TilingResult {
 public:
     TilingResult() = default;
     TilingStep& operator[](Client* client);
+    void add(Client* client, const TilingStep& client_data);
     void add(FrameDecoration* dec, const FrameDecorationData& frame_data);
 
     Client* focus = {}; // the focused client


### PR DESCRIPTION
The operator[] should not have side-effects (I ran into very unexpected
behaviour when calling 'res[client]' multiple times without know that it
adds element to the vector). For clarity, make it a function named
'add()'.