### PR TITLE
Enable some clang-analyzer-unix checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,7 @@
 #   # Checks: '*,-abseil-*,-android-*,-objc-*,-fuchsia-*,-mpi-*,-performance-*,-llvm-include-order'
 #   ###
 #
-Checks: '-clang-analyzer-unix.API,-clang-analyzer-unix.Malloc,-clang-analyzer-optin.portability.UnixAPI,-clang-analyzer-core.StackAddressEscape,-clang-analyzer-core.CallAndMessage,readability-braces-around-statements,google-readability-braces-around-statements,hicpp-braces-around-statements,readability-container-size-empty,readability-inconsistent-declaration-parameter-name'
+Checks: '-clang-analyzer-unix.Malloc,-clang-analyzer-optin.portability.UnixAPI,-clang-analyzer-core.StackAddressEscape,-clang-analyzer-core.CallAndMessage,readability-braces-around-statements,google-readability-braces-around-statements,hicpp-braces-around-statements,readability-container-size-empty,readability-inconsistent-declaration-parameter-name'
 
 # Uncomment this to make clang-tidy fail on any findings:
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,7 @@
 #   # Checks: '*,-abseil-*,-android-*,-objc-*,-fuchsia-*,-mpi-*,-performance-*,-llvm-include-order'
 #   ###
 #
-Checks: '-clang-analyzer-unix.Malloc,-clang-analyzer-optin.portability.UnixAPI,-clang-analyzer-core.StackAddressEscape,-clang-analyzer-core.CallAndMessage,readability-braces-around-statements,google-readability-braces-around-statements,hicpp-braces-around-statements,readability-container-size-empty,readability-inconsistent-declaration-parameter-name'
+Checks: '-clang-analyzer-optin.portability.UnixAPI,-clang-analyzer-core.StackAddressEscape,-clang-analyzer-core.CallAndMessage,readability-braces-around-statements,google-readability-braces-around-statements,hicpp-braces-around-statements,readability-container-size-empty,readability-inconsistent-declaration-parameter-name'
 
 # Uncomment this to make clang-tidy fail on any findings:
 WarningsAsErrors: '*'


### PR DESCRIPTION
These checks used to fail when initially adding clang-tidy to the pipeline.
The underlying issues have probably been fixed in the mean-time.