### PR TITLE
Retry if the display closes during X startup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -546,6 +546,12 @@ def x11_connection():
             # wait for a moment, and then try again..
             time.sleep(2)
             attempts_left -= 1
+        except Xlib.error.ConnectionClosedError as msg:
+            print("!!! Xlib.error.ConnectionClosedError: %s" % msg, file=sys.stderr)
+            # maybe the display was still shutting down
+            # wait for a moment, and then try again..
+            time.sleep(2)
+            attempts_left -= 1
     yield display
     display.close()
 


### PR DESCRIPTION
For some reason in the test suite, the display sometimes closes during
the initialization phase. My only explanation for this is that the
display still exists from a previous test case and that this display is
about to close.

One attempt is to simply retry opening the connection after two seconds.
It will take some time until we'll see whether this works around the
issue.