### PR TITLE
Make globals from ewmh.cpp members of Ewmh

### DIFF
--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -21,16 +21,8 @@
 using std::string;
 using std::vector;
 
-Atom g_netatom[NetCOUNT];
-
-// module internal globals:
-static vector<Window> g_windows; // array with Window-IDs in initial mapping order
-static Window      g_wm_window;
-
-static int WM_STATE;
-
 /* list of names of all _NET-atoms */
-const std::array<const char*,NetCOUNT>g_netatom_names =
+const std::array<const char*,NetCOUNT> Ewmh::g_netatom_names =
   ArrayInitializer<const char*,NetCOUNT>({
     { NetSupported                   , "_NET_SUPPORTED"                    },
     { NetClientList                  , "_NET_CLIENT_LIST"                  },
@@ -525,6 +517,16 @@ bool Ewmh::sendEvent(Window window, Ewmh::WM proto, bool checkProtocols) {
 
 void Ewmh::windowClose(Window window) {
     sendEvent(window, WM::Delete, false);
+}
+
+Atom Ewmh::netatom(int netatomEnum)
+{
+    return g_netatom[netatomEnum];
+}
+
+const char* Ewmh::netatomName(int netatomEnum)
+{
+    return g_netatom_names[static_cast<unsigned long>(netatomEnum)];
 }
 
 //! convenience wrapper around wmatom_

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -83,10 +83,6 @@ class Root;
 class TagManager;
 class XConnection;
 
-extern Atom g_netatom[NetCOUNT];
-
-extern const std::array<const char*,NetCOUNT> g_netatom_names;
-
 class Ewmh {
 public:
     Ewmh(XConnection& xconnection);
@@ -146,6 +142,8 @@ public:
     void windowClose(Window window);
 
     XConnection& X() { return X_; }
+    Atom netatom(int netatomEnum);
+    const char* netatomName(int netatomEnum);
 
 private:
     bool focusStealingAllowed(long source);
@@ -156,6 +154,14 @@ private:
     void readInitialEwmhState();
     Atom wmatom(WM proto);
     Atom wmatom_[(int)WM::Last];
+
+    std::vector<Window> g_windows; // array with Window-IDs in initial mapping order
+    Window      g_wm_window;
+
+    int WM_STATE;
+
+    Atom g_netatom[NetCOUNT];
+    static const std::array<const char*,NetCOUNT> g_netatom_names;
 };
 
 #endif

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -224,11 +224,12 @@ bool Condition::matchesMaxage(const Client* client) const {
 }
 
 bool Condition::matchesWindowtype(const Client* client) const {
-    int wintype = Ewmh::get().getWindowType(client->x11Window());
+    auto& ewmh = Ewmh::get();
+    int wintype = ewmh.getWindowType(client->x11Window());
     if (wintype < 0) {
         return false;
     }
-    return matches(g_netatom_names[wintype]);
+    return matches(ewmh.netatomName(wintype));
 }
 
 bool Condition::matchesWindowrole(const Client* client) const {

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -450,7 +450,7 @@ void XMainLoop::propertynotify(XPropertyEvent* ev) {
                     m->applyLayout();
                 }
             } else if (ev->atom == XA_WM_NAME ||
-                       ev->atom == g_netatom[NetWmName]) {
+                       ev->atom == root_->ewmh->netatom(NetWmName)) {
                 client->update_title();
             } else if (ev->atom == XA_WM_CLASS && client) {
                 // according to the ICCCM specification, the WM_CLASS property may only


### PR DESCRIPTION
Nearly all these globals are only used in the Ewmh class anyway. And for
the few occasions where it's needed outside of Ewmh, provide a getter
function.

This only moves the variables but does not rename them, which is in the
scope of a separate commit.