### PR TITLE
First draft of keyboard resizing in floating mode

### DIFF
--- a/src/floating.h
+++ b/src/floating.h
@@ -4,6 +4,9 @@
 #include "types.h"
 #include "x11-types.h"
 
+class Client;
+class HSTag;
+
 void floating_init();
 void floating_destroy();
 
@@ -17,6 +20,7 @@ int find_edge_right_of(RectangleIdxVec rects, int idx);
 // actual implementations
 bool floating_focus_direction(Direction dir);
 bool floating_shift_direction(Direction dir);
+bool floating_resize_direction(HSTag* tag, Client* client, Direction dir);
 
 
 #endif

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -267,9 +267,17 @@ int HSTag::resizeCommand(Input input, Output output)
         return HERBST_INVALID_ARGUMENT;
     }
     double delta_double = atof(delta_str.c_str());
-    if (!frame->resizeFrame(delta_double, direction)) {
-        output << input.command() << ": No neighbour found\n";
-        return HERBST_FORBIDDEN;
+    Client* client = focusedClient();
+    if (client && client->is_client_floated()) {
+        if (!floating_resize_direction(this, client, direction)) {
+            // no error message because this shouldn't happen anyway
+            return HERBST_FORBIDDEN;
+        }
+    } else {
+        if (!frame->resizeFrame(delta_double, direction)) {
+            output << input.command() << ": No neighbour found\n";
+            return HERBST_FORBIDDEN;
+        }
     }
     needsRelayout_.emit();
     return 0;


### PR DESCRIPTION
This makes the resize command also work for clients in floating mode at
resizes the window into the specified direction to the next visible edge
on the screen. If growing is not possible anymore, then the window
shrinks again.

The current implementation does not work entirely for windows with
sizehints, such as terminals: if the resize delta is within the size
granularity, the current algorithm thinks that a resize is not possible
instead of looking for the next edge.