### PR TITLE
Keyboard resizing of sizehints clients

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@ Current git version
     new windows in empty frames, if possible)
   * new setting 'hide_covered_windows' to improve the appearance when used with
     a compositor.
+  * resize floating windows with the same command ('resize') as in tiling mode
+    and thus the same keybindings as in tiling mode.
 
 Release 0.8.0 on 2020-04-09
 ---------------------------

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -479,9 +479,11 @@ bring 'WINID'::
 
 resize 'DIRECTION' 'FRACTIONDELTA'::
     Changes the next fraction in specified 'DIRECTION' by 'FRACTIONDELTA'.
-    'DIRECTION' behaves as specified at the 'focus' command. You should not omit
-    the sign '-' or '+', because in future versions, the behaviour may change if
-    the sign is omitted. Example:
+    'DIRECTION' behaves as specified at the 'focus' command. If a floating
+    window is focused, it is resized and grows into the specified 'DIRECTION'.
+    In the parameter 'FRACTIONDELTA', you should not omit the sign '-' or '+',
+    because in future versions, the behaviour may change if the sign is omitted.
+    Example:
 
         * resize right +0.05
         * resize down -0.1


### PR DESCRIPTION
As a follow up to #790 / b3e6419, make the keyboard resizing of floated
clients also work for floated clients with sizehints. The code is
getting a bit messy, but I leave the clean-up for future PRs.