### PR TITLE
Let keybind check if the command exists

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ Current git version
     a compositor.
   * resize floating windows with the same command ('resize') as in tiling mode
     and thus the same keybindings as in tiling mode.
+  * keybind now checks that the bound command exists.
 
 Release 0.8.0 on 2020-04-09
 ---------------------------

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -274,6 +274,14 @@ int Commands::call(Input args, Output out) {
     return command_table->callCommand(args, out);
 }
 
+bool Commands::commandExists(const std::string& commandName)
+{
+    if (!command_table) {
+        return false;
+    }
+    return command_table->find(commandName) != command_table->end();
+}
+
 shared_ptr<const CommandTable> Commands::get() {
     if (!command_table) {
         throw std::logic_error("CommandTable not initialized, but get() called.");

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -274,7 +274,7 @@ int Commands::call(Input args, Output out) {
     return command_table->callCommand(args, out);
 }
 
-bool Commands::commandExists(const std::string& commandName)
+bool Commands::commandExists(const string& commandName)
 {
     if (!command_table) {
         return false;

--- a/src/command.h
+++ b/src/command.h
@@ -136,6 +136,7 @@ namespace Commands {
     void initialize(std::unique_ptr<const CommandTable> commands);
     /* Call the command args[0] */
     int call(Input args, Output out);
+    bool commandExists(const std::string& commandName);
     void complete(Completion& completion);
     std::shared_ptr<const CommandTable> get();
 }

--- a/src/keymanager.cpp
+++ b/src/keymanager.cpp
@@ -41,6 +41,14 @@ int KeyManager::addKeybindCommand(Input input, Output output) {
     // Store remaining input as the associated command
     newBinding->cmd = {input.begin(), input.end()};
 
+    // newBinding->cmd is not empty because the size before the input.shift() was >= 2
+    if (!Commands::commandExists(newBinding->cmd[0])) {
+        output << input.command() << ": the command \""
+               << newBinding->cmd[0] << "\" does not exist."
+               << " Did you forget \"spawn\"?\n";
+        return HERBST_COMMAND_NOT_FOUND;
+    }
+
     // Make sure there is no existing binding with same keysym/modifiers
     removeKeyBinding(newBinding->keyCombo);
 

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -309,3 +309,8 @@ def test_keymask_and_keys_inactive(hlwm, keyboard):
     assert hlwm.get_attr('my_f_pressed') == ''
     # z is disallowed by keymask but not disabled by keys_inactive
     assert hlwm.get_attr('my_z_pressed') == ''
+
+
+def test_keybind_unknown_binding(hlwm):
+    hlwm.call_xfail('keybind x xterm') \
+        .expect_stderr('command.*not exist')


### PR DESCRIPTION
It is a common mistake to forget the 'spawn' in keybinds to commands.
Now, the keybind already fails if the command does not exist. Before,
the keybind succeeded and the command failed silently when the key was
pressed.