### PR TITLE
Make cycle_all traverse also floating clients

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ Current git version
   * resize floating windows with the same command ('resize') as in tiling mode
     and thus the same keybindings as in tiling mode.
   * keybind now checks that the bound command exists.
+  * cycle_all (Alt-Tab) now also traverses floating clients
 
 Release 0.8.0 on 2020-04-09
 ---------------------------

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -298,8 +298,9 @@ int HSTag::cycleAllCommand(Input input, Output output)
         FrameTree::CycleDelta cdelta = (delta == 1)
                 ? FrameTree::CycleDelta::Next
                 : FrameTree::CycleDelta::Previous;
-        bool succeeded = frame->cycleAll(cdelta, skip_invisible);
-        if (!succeeded) {
+        bool focusChanged = frame->cycleAll(cdelta, skip_invisible);
+        if (!focusChanged) {
+            // if frame->cycleAll() reached the end of the tiling layer
             if (floating_clients_.empty()) {
                 // we need to wrap. when cycling forward, we wrap to the beginning
                 FrameTree::CycleDelta rewind = (delta == 1)
@@ -310,10 +311,10 @@ int HSTag::cycleAllCommand(Input input, Output output)
                 // if there are floating clients, switch to the floating layer
                 floating_focused = true;
                 if (delta == 1) {
-                    // wrap to last client
+                    // wrap (forward) to first client
                     floating_clients_focus_ = 0;
                 } else {
-                    // wrap to last client
+                    // wrap (backward) to last client
                     floating_clients_focus_ = floating_clients_.size() - 1;
                 }
             }

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -282,16 +282,46 @@ int HSTag::cycleAllCommand(Input input, Output output)
     if (delta == 0) {
         return 0; // nothing to do
     }
-    FrameTree::CycleDelta cdelta = (delta == 1)
-            ? FrameTree::CycleDelta::Next
-            : FrameTree::CycleDelta::Previous;
-    bool succeeded = frame->cycleAll(cdelta, skip_invisible);
-    if (!succeeded) {
-        // we need to wrap. when cycling forward, we wrap to the beginning
-        FrameTree::CycleDelta rewind = (delta == 1)
-                    ? FrameTree::CycleDelta::Begin
-                    : FrameTree::CycleDelta::End;
-        frame->cycleAll(rewind, skip_invisible);
+    if (floating_focused()) {
+        int newIndex = static_cast<int>(floating_clients_focus_) + delta;
+        if (newIndex < 0) {
+            floating_focused = false;
+            frame->cycleAll(FrameTree::CycleDelta::End, skip_invisible);
+        } else if (static_cast<size_t>(newIndex) >= floating_clients_.size()) {
+            floating_focused = false;
+            frame->cycleAll(FrameTree::CycleDelta::Begin, skip_invisible);
+        } else {
+            floating_clients_focus_ = static_cast<size_t>(newIndex);
+            floating_clients_[floating_clients_focus_]->raise();
+        }
+    } else {
+        FrameTree::CycleDelta cdelta = (delta == 1)
+                ? FrameTree::CycleDelta::Next
+                : FrameTree::CycleDelta::Previous;
+        bool succeeded = frame->cycleAll(cdelta, skip_invisible);
+        if (!succeeded) {
+            if (floating_clients_.empty()) {
+                // we need to wrap. when cycling forward, we wrap to the beginning
+                FrameTree::CycleDelta rewind = (delta == 1)
+                            ? FrameTree::CycleDelta::Begin
+                            : FrameTree::CycleDelta::End;
+                frame->cycleAll(rewind, skip_invisible);
+            } else {
+                // if there are floating clients, switch to the floating layer
+                floating_focused = true;
+                if (delta == 1) {
+                    // wrap to last client
+                    floating_clients_focus_ = 0;
+                } else {
+                    // wrap to last client
+                    floating_clients_focus_ = floating_clients_.size() - 1;
+                }
+            }
+        }
+    }
+    Client* newFocus = focusedClient();
+    if (newFocus && newFocus->is_client_floated()) {
+        newFocus->raise();
     }
     // finally, redraw the layout
     needsRelayout_.emit();

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -276,10 +276,13 @@ def test_cycle_all_skip_invisible(hlwm, running_clients, delta):
     assert visited_winids[0] != visited_winids[1]
 
 
+@pytest.mark.parametrize("one_client_floating", [True, False])
 @pytest.mark.parametrize("delta", [1, -1])
-def test_cycle_all_wraps(hlwm, delta):
+def test_cycle_all_wraps(hlwm, delta, one_client_floating):
     c1, _ = hlwm.create_client()
     c2, _ = hlwm.create_client()
+    if one_client_floating:
+        hlwm.call(f'set_attr clients.{c2}.floating true')
 
     focus = hlwm.get_attr('clients.focus.winid')
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -276,21 +276,21 @@ def test_cycle_all_skip_invisible(hlwm, running_clients, delta):
     assert visited_winids[0] != visited_winids[1]
 
 
-@pytest.mark.parametrize("one_client_floating", [True, False])
+@pytest.mark.parametrize("num_tiling", [1, 2])
+@pytest.mark.parametrize("num_floating", [0, 2])
 @pytest.mark.parametrize("delta", [1, -1])
-def test_cycle_all_wraps(hlwm, delta, one_client_floating):
-    c1, _ = hlwm.create_client()
-    c2, _ = hlwm.create_client()
-    if one_client_floating:
-        hlwm.call(f'set_attr clients.{c2}.floating true')
+def test_cycle_all_traverses_tiling_and_floating(hlwm, delta, num_tiling, num_floating):
+    tiled = hlwm.create_clients(num_tiling)
+    floated = hlwm.create_clients(num_floating)
+    for c in floated:
+        hlwm.call(f'set_attr clients.{c}.floating true')
+    expected_clients = tiled + floated + [tiled[0]]
+    if delta == -1:
+        expected_clients = reversed(expected_clients)
 
-    focus = hlwm.get_attr('clients.focus.winid')
-
-    hlwm.call(['cycle_all', delta])
-    assert focus != hlwm.get_attr('clients.focus.winid')
-    hlwm.call(['cycle_all', delta])
-
-    assert focus == hlwm.get_attr('clients.focus.winid')
+    for focus in expected_clients:
+        assert focus == hlwm.get_attr('clients.focus.winid')
+        hlwm.call(['cycle_all', delta])
 
 
 @pytest.mark.parametrize("delta", [1, -1])

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -299,6 +299,24 @@ def test_cycle_all_empty_frame(hlwm, delta):
     assert layout == hlwm.call('dump').stdout
 
 
+@pytest.mark.parametrize("floating_clients", [1, 2])
+@pytest.mark.parametrize("delta", [1, -1])
+def test_cycle_all_with_floating_clients(hlwm, delta, floating_clients):
+    hlwm.call('rule floating=on')
+    clients = hlwm.create_clients(floating_clients)
+    # None = No client is selected in the tiling layer
+    traversal = [None] + clients + [None]
+    if delta == -1:
+        traversal = reversed(traversal)
+
+    for expected_focus in traversal:
+        if expected_focus is None:
+            assert 'focus' not in hlwm.list_children('clients')
+        else:
+            assert expected_focus == hlwm.get_attr('clients.focus.winid')
+        hlwm.call(['cycle_all', delta])
+
+
 @pytest.mark.parametrize("running_clients_num", [2, 5])
 @pytest.mark.parametrize("num_splits", [0, 1, 2, 3])
 @pytest.mark.parametrize("delta", [1, -1])


### PR DESCRIPTION
There is no need to adjust the description of the cycle_all command in
the man page because it is still/again true that cycle_all traverses all
windows and frames on a tag.

This fixes #732.