### PR TITLE
hc: Fix a potential malloc of zero

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,7 @@
 #   # Checks: '*,-abseil-*,-android-*,-objc-*,-fuchsia-*,-mpi-*,-performance-*,-llvm-include-order'
 #   ###
 #
-Checks: '-clang-analyzer-optin.portability.UnixAPI,-clang-analyzer-core.CallAndMessage,readability-braces-around-statements,google-readability-braces-around-statements,hicpp-braces-around-statements,readability-container-size-empty,readability-inconsistent-declaration-parameter-name,bugprone-macro-parentheses,bugprone-bool-pointer-implicit-conversion,bugprone-suspicious-string-compare'
+Checks: '-clang-analyzer-core.CallAndMessage,readability-braces-around-statements,google-readability-braces-around-statements,hicpp-braces-around-statements,readability-container-size-empty,readability-inconsistent-declaration-parameter-name,bugprone-macro-parentheses,bugprone-bool-pointer-implicit-conversion,bugprone-suspicious-string-compare'
 
 # Uncomment this to make clang-tidy fail on any findings:
 WarningsAsErrors: '*'

--- a/ipc-client/main.c
+++ b/ipc-client/main.c
@@ -38,6 +38,9 @@ static void quit_herbstclient(int signal) {
 }
 
 void init_hook_regex(int argc, char* argv[]) {
+    if (argc == 0) {
+        return;
+    }
     g_hook_regex = (regex_t*)malloc(sizeof(regex_t)*argc);
     assert(g_hook_regex != NULL);
     int i;

--- a/ipc-client/main.c
+++ b/ipc-client/main.c
@@ -38,7 +38,7 @@ static void quit_herbstclient(int signal) {
 }
 
 void init_hook_regex(int argc, char* argv[]) {
-    if (argc == 0) {
+    if (argc <= 0) {
         return;
     }
     g_hook_regex = (regex_t*)malloc(sizeof(regex_t)*argc);


### PR DESCRIPTION
Found by clang-tidy. Returning in case of argc being 0 should be fine.

Also enable the correspoding clang-tidy check now.