### PR TITLE
Drop -Wno-error=cast-function-type flag

### DIFF
--- a/cmake/debugflags.cmake
+++ b/cmake/debugflags.cmake
@@ -26,13 +26,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         -Wduplicated-cond -Wduplicated-branches -Wlogical-op
         )
 
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
-        list(APPEND FLAGS
-            # This is in since GCC-8 and triggers on known issues:
-            -Wno-error=cast-function-type
-            )
-    endif()
-
     # Add GCC- *and* C++-specific flags
     set(CXX_FLAGS ${CXX_FLAGS}
         # Additional warnings that don't come with Wall/Wextra:


### PR DESCRIPTION
It appears that the underlying issue triggering the warning has been
fixed by now, so this suppression is not necessary anymore.