### PR TITLE
Remove git from Docker images used for CI builds

### DIFF
--- a/ci/Dockerfile.ci-eoan
+++ b/ci/Dockerfile.ci-eoan
@@ -8,7 +8,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
     curl \
     g++-9 \
-    git \
     iwyu \
     lcov \
     libx11-dev \

--- a/ci/Dockerfile.ci-trusty
+++ b/ci/Dockerfile.ci-trusty
@@ -10,7 +10,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake3 \
     g++-4.8-multilib \
     gcc-4.8-multilib \
-    git \
     libx11-dev:i386 \
     libxext-dev:i386 \
     libxinerama-dev:i386 \


### PR DESCRIPTION
This used to be necessary, but it is not anymore. Leaving it out, should
speed up the build a bit, due to smaller image sizes.