### PR TITLE
Fix 'bring' if the client is on the same tag

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -439,9 +439,8 @@ int frame_current_bring(int argc, char** argv, Output output) {
     auto frame = tag->frame->root_->frameWithClient(client);
     if (!client->is_client_floated() && !frame->isFocused()) {
         frame->removeClient(client);
-        tag->frame->focusedFrame()->insertClient(client);
+        tag->frame->focusedFrame()->insertClient(client, true);
     }
-    focus_client(client, false, false, true);
     return 0;
 }
 

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -436,6 +436,12 @@ int frame_current_bring(int argc, char** argv, Output output) {
     }
     HSTag* tag = get_current_monitor()->tag;
     global_tags->moveClient(client, tag, {}, true);
+    auto frame = tag->frame->root_->frameWithClient(client);
+    if (!client->is_client_floated() && !frame->isFocused()) {
+        frame->removeClient(client);
+        tag->frame->focusedFrame()->insertClient(client);
+    }
+    focus_client(client, false, false, true);
     return 0;
 }
 

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -441,6 +441,7 @@ int frame_current_bring(int argc, char** argv, Output output) {
         frame->removeClient(client);
         tag->frame->focusedFrame()->insertClient(client, true);
     }
+    focus_client(client, false, false, true);
     return 0;
 }
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -149,6 +149,7 @@ def test_bring_from_different_tag(hlwm, x11):
     hlwm.call(['bring', bonnie])
 
     assert hlwm.get_attr(f'clients.{bonnie}.tag') == 'anothertag'
+    assert hlwm.get_attr('clients.focus.winid') == bonnie
 
 
 def test_bring_from_same_tag_different_frame(hlwm, x11):
@@ -161,3 +162,4 @@ def test_bring_from_same_tag_different_frame(hlwm, x11):
 
     hlwm.call(['bring', winid])
     assert int(hlwm.get_attr('tags.0.curframe_wcount')) == 1
+    assert hlwm.get_attr('clients.focus.winid') == winid

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -137,3 +137,27 @@ def test_client_wm_class_none(hlwm, x11):
     _, winid = x11.create_client(wm_class=None)
     assert hlwm.get_attr('clients.{}.instance'.format(winid)) == ''
     assert hlwm.get_attr('clients.{}.class'.format(winid)) == ''
+
+
+def test_bring_from_different_tag(hlwm, x11):
+    _, bonnie = x11.create_client()
+    hlwm.call('true')
+    hlwm.call('add anothertag')
+    hlwm.call('use anothertag')
+    assert hlwm.get_attr(f'clients.{bonnie}.tag') == 'default'
+
+    hlwm.call(['bring', bonnie])
+
+    assert hlwm.get_attr(f'clients.{bonnie}.tag') == 'anothertag'
+
+
+def test_bring_from_same_tag_different_frame(hlwm, x11):
+    hlwm.call('split horizontal')
+    hlwm.call('focus right')
+    _, winid = x11.create_client()
+    hlwm.call('true')
+    hlwm.call('focus left')
+    assert int(hlwm.get_attr('tags.0.curframe_wcount')) == 0
+
+    hlwm.call(['bring', winid])
+    assert int(hlwm.get_attr('tags.0.curframe_wcount')) == 1

--- a/tests/test_floating.py
+++ b/tests/test_floating.py
@@ -94,3 +94,16 @@ def test_floating_command_no_tag(hlwm):
     # toggles the floating state again
     hlwm.call('floating')
     assert hlwm.get_attr('tags.0.floating') == hlwm.bool(False)
+
+
+def test_bring_floating_from_different_tag(hlwm, x11):
+    win, winid = x11.create_client()
+    hlwm.call('true')
+    hlwm.call(f'set_attr clients.{winid}.floating true')
+    hlwm.call('add anothertag')
+    hlwm.call('use anothertag')
+    assert hlwm.get_attr(f'clients.{winid}.tag') == 'default'
+    hlwm.call(['bring', winid])
+
+    assert hlwm.get_attr(f'clients.{winid}.tag') == 'anothertag'
+    assert hlwm.get_attr(f'clients.{winid}.floating') == hlwm.bool(True)


### PR DESCRIPTION
Basically reverts changes from 41ec3f1d7afcdaabacf6a9e46a8b141a8f9e96c5
but considers floating clients, too. Add some tests, of course.

Fixes #818