### PR TITLE
Update fish completion script

### DIFF
--- a/share/herbstclient.fish
+++ b/share/herbstclient.fish
@@ -1,19 +1,23 @@
 # fish completion for herbstclient
 
-function _get_herbstluftwm_completion
-    set -l tokens (commandline -op)
+function _first_hlwm_command
+    # Find first hlwm command in given tokens (e.g. commandline -o)
+    # Print token position if found; exit status 0 if found, else 1
 
-    # Delete "herbstclient"
-    set -e tokens[1]
-
-    # Filter herbstclient options
-    for token in $tokens
-        if string match -q -- "-*" $token
-            set -e tokens[1]
-        else
-            break
+    for i in (seq 2 (count $argv)) # start after 'herbstclient'
+        if not string match -q -- "-*" $argv[$i]
+            echo $i
+            return 0
         end
     end
+    return 1
+end
+
+function _get_herbstluftwm_completion
+    set tokens (commandline -o)
+    set first (_first_hlwm_command $tokens)
+    if not test -n $first; return; end # no command found, we are done
+    set tokens $tokens[$first..-1]
 
     set -l position (count $tokens)
 
@@ -25,14 +29,23 @@ function _get_herbstluftwm_completion
     herbstclient -q complete $position $tokens
 end
 
+function _complete_herbstclient
+    # do not complete herbstclient options after commands
+    # TODO: this could check if cursor sits in front of said command
+    complete -fc herbstclient -n 'not _first_hlwm_command (commandline -o)' $argv
+end
+
+# add completions for herbstclient options
+_complete_herbstclient -s n -l no-newline -d 'Do not print a newline if output does not end with a newline.'
+_complete_herbstclient -s 0 -l print0 -d 'Use the null character as delimiter between the output of hooks.'
+_complete_herbstclient -s l -l last-arg -d 'When using -i or -w, only print the last argument of the hook.'
+_complete_herbstclient -s i -l idle -d 'Wait for hooks instead of executing commands.'
+_complete_herbstclient -s w -l wait -d 'Same as --idle but exit after first --count hooks.'
+_complete_herbstclient -s c -l count -r -d 'Let --wait exit after COUNT hooks were received and printed.'
+_complete_herbstclient -s q -l quiet -d 'Do not print error messages if herbstclient cannot connect to the running herbstluftwm instance.'
+_complete_herbstclient -s v -l version -d 'Print the herbstclient version.'
+_complete_herbstclient -s h -l help -d 'Print the herbstclient usage with its command line options.'
+
+# defer all other completions to herbstluftwm
 complete -xc herbstclient -d "" -a '(_get_herbstluftwm_completion)'
 
-complete -fc herbstclient -s n -l no-newline -d 'Do not print a newline if output does not end with a newline.'
-complete -fc herbstclient -s 0 -l print0 -d 'Use the null character as delimiter between the output of hooks.'
-complete -fc herbstclient -s l -l last-arg -d 'When using -i or -w, only print the last argument of the hook.'
-complete -fc herbstclient -s i -l idle -d 'Wait for hooks instead of executing commands.'
-complete -fc herbstclient -s w -l wait -d 'Same as --idle but exit after first --count hooks.'
-complete -fc herbstclient -s c -l count -r -d 'Let --wait exit after COUNT hooks were received and printed.'
-complete -fc herbstclient -s q -l quiet -d 'Do not print error messages if herbstclient cannot connect to the running herbstluftwm instance.'
-complete -fc herbstclient -s v -l version -d 'Print the herbstclient version.'
-complete -fc herbstclient -s h -l help -d 'Print the herbstclient usage with its command line options.'


### PR DESCRIPTION
Avoid spaces for partial completions. Fixes #797 with a workaround.
Also only complete herbstclient options where appropriate.

I would appreciate any feedback on the changes.

A small present for 0.8 release :smile_cat: 