### PR TITLE
Never compile a regex for the empty string

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,9 @@ Current git version
   * keybind now checks that the bound command exists.
   * cycle_all (Alt-Tab) now also traverses floating clients
   * new setting 'auto_detect_panels' controlling the panel detection algorithm.
+  * Bug fixes:
+    - Handle the regular expression "" correctly, since the grammar of extended
+      regular expressions does not allow "".
 
 Release 0.8.0 on 2020-04-09
 ---------------------------

--- a/src/keymanager.cpp
+++ b/src/keymanager.cpp
@@ -257,6 +257,8 @@ KeyManager::KeyMask::KeyMask()
 bool KeyManager::KeyMask::allowsBinding(const KeyCombo &combo) const
 {
     if (regex_.empty()) {
+        // an unset keymask allows every binding, regardless of
+        // the 'negated_' flag
         return true;
     } else {
         bool match = regex_.matches(combo.str());

--- a/src/regexstr.cpp
+++ b/src/regexstr.cpp
@@ -6,14 +6,20 @@ RegexStr::RegexStr()
 {
 }
 
-RegexStr RegexStr::fromStr(const string &source)
+RegexStr RegexStr::fromStr(const string& source)
 {
     RegexStr r;
     r.source_ = source;
-    try {
-        r.regex_ = std::regex(source, std::regex::extended);
-    }  catch (const std::exception& e) {
-        throw std::invalid_argument(e.what());
+    // An empty regex is not allowed in the POSIX grammar
+    // as one can infer from the grammar at
+    // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_05_03
+    // => So we must not compile "" to a regex
+    if (!source.empty()) {
+        try {
+            r.regex_ = std::regex(source, std::regex::extended);
+        }  catch (const std::exception& e) {
+            throw std::invalid_argument(e.what());
+        }
     }
     return r;
 }
@@ -25,7 +31,11 @@ bool RegexStr::operator==(const RegexStr& other) const
 
 bool RegexStr::matches(const string& str) const
 {
-    return std::regex_match(str, regex_);
+    if (source_.empty()) {
+        return false;
+    } else {
+        return std::regex_match(str, regex_);
+    }
 }
 
 template<> RegexStr Converter<RegexStr>::parse(const string& source) {

--- a/src/regexstr.h
+++ b/src/regexstr.h
@@ -13,13 +13,19 @@ class RegexStr
 {
 public:
     RegexStr();
-    //! may throw std::invalid_argument exception
+    /** Construct a regex. The case where source is "" means
+     * that the regex is inactive, see isUnset().
+     *
+     * may throw std::invalid_argument exception
+     */
     static RegexStr fromStr(const std::string& source);
     std::string str() const { return source_; }
-    /** returns when the source is the empty string, respectivelly is 'unset'
-     * (has nothing to do with the language of the regex being empty)
+    /** returns when the source string is empty, respectivelly the regex is 'unset'
      */
     bool empty() const { return source_.empty(); }
+    /** returns whether two regexes have the same source. In particular,
+     * two RegexStr objects are equal if they are both unset.
+     */
     bool operator==(const RegexStr& other) const;
     bool operator!=(const RegexStr& o) const { return ! operator==(o); }
     bool matches(const std::string& str) const;


### PR DESCRIPTION
An empty string is not allowed in the Posix grammar for extended regular
expressions. On openbsd, this led to a run time error on startup
because we initialize the keymask regexes with the empty string.

In the keymask code, we are using the empty string anyway as a special
case for an 'inactive' or 'unset' regular expression, so there is no
need to compile the regex for "".

Thanks to Lucas <lucas@sexy.is> and Florian Viehweger
<openbsd@out-of-creativity.de> for spotting and reporting this issue.