### PR TITLE
'resize' command: make delta parameter optional

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,8 @@ Current git version
   * new setting 'hide_covered_windows' to improve the appearance when used with
     a compositor.
   * resize floating windows with the same command ('resize') as in tiling mode
-    and thus the same keybindings as in tiling mode.
+    and thus the same keybindings as in tiling mode. Therefore, the
+    'fractiondelta' parameter to the 'resize' command is now optional.
   * keybind now checks that the bound command exists.
   * cycle_all (Alt-Tab) now also traverses floating clients
   * new setting 'auto_detect_panels' controlling the panel detection algorithm.

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -477,13 +477,13 @@ bring 'WINID'::
     <<WINDOW_IDS, section on WINDOW IDS>> on how to reference a certain window.
 
 
-resize 'DIRECTION' 'FRACTIONDELTA'::
-    Changes the next fraction in specified 'DIRECTION' by 'FRACTIONDELTA'.
-    'DIRECTION' behaves as specified at the 'focus' command. If a floating
-    window is focused, it is resized and grows into the specified 'DIRECTION'.
-    In the parameter 'FRACTIONDELTA', you should not omit the sign '-' or '+',
-    because in future versions, the behaviour may change if the sign is omitted.
-    Example:
+resize 'DIRECTION' ['FRACTIONDELTA']::
+    Changes the next fraction in specified 'DIRECTION' by 'FRACTIONDELTA' (which
+    defaults to 0.02 if none is supplied). 'DIRECTION' behaves as specified at
+    the 'focus' command. If a floating window is focused, it is resized and
+    grows into the specified 'DIRECTION'. In the parameter 'FRACTIONDELTA', you
+    should not omit the sign '-' or '+', because in future versions, the
+    behaviour may change if the sign is omitted. Example:
 
         * resize right +0.05
         * resize down -0.1

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -344,8 +344,8 @@ void HSTag::cycleAllCompletion(Completion& complete)
 
 int HSTag::resizeCommand(Input input, Output output)
 {
-    string dir_str, delta_str;
-    if (!(input >> dir_str >> delta_str)) {
+    string dir_str;
+    if (!(input >> dir_str)) {
         return HERBST_NEED_MORE_ARGS;
     }
     Direction direction;
@@ -355,7 +355,6 @@ int HSTag::resizeCommand(Input input, Output output)
         output << input.command() << ": " << e.what() << "\n";
         return HERBST_INVALID_ARGUMENT;
     }
-    double delta_double = atof(delta_str.c_str());
     Client* client = focusedClient();
     if (client && client->is_client_floated()) {
         if (!floating_resize_direction(this, client, direction)) {
@@ -363,6 +362,11 @@ int HSTag::resizeCommand(Input input, Output output)
             return HERBST_FORBIDDEN;
         }
     } else {
+        double delta_double = 0.02;
+        string delta_str;
+        if (input >> delta_str) {
+            delta_double = atof(delta_str.c_str());
+        }
         if (!frame->resizeFrame(delta_double, direction)) {
             output << input.command() << ": No neighbour found\n";
             return HERBST_FORBIDDEN;

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -532,6 +532,26 @@ def test_resize_flat_split(hlwm, splittype, dir_work, dir_dummy):
             .expect_stderr('No neighbour found')
 
 
+@pytest.mark.parametrize('direction', ['left', 'right'])
+def test_resize_default_delta(hlwm, direction):
+    layout = '(split horizontal:0.4:1'
+    layout += ' (clients vertical:0)'
+    layout += ' (clients vertical:0)'
+    layout += ')'
+    hlwm.call(['load', layout])
+    assert hlwm.call('dump').stdout == layout
+
+    # resize
+    hlwm.call(['resize', direction])
+    assert hlwm.call('dump').stdout != layout
+
+    # we expect the fraction to have changed by 0.02.
+    # to verify this, we adjust the fraction by -0.02
+    # and check that we're back at the original layout
+    hlwm.call(['resize', direction, '-0.02'])
+    assert hlwm.call('dump').stdout == layout
+
+
 def test_resize_nested_split(hlwm):
     # a layout for a 2x2 grid of frames, where the
     # top left frame is focused


### PR DESCRIPTION
Recently the 'resize' command became also functional in the floating
mode, where the 'FRACTIONDELTA' parameter is not used at all. In the
tiling mode, the parameter is most likely '0.02' for most people. Hence,
it makes sense to make the parameter optional, so one can now run e.g.

   herbstclient resize up

to make the focused client (or frame) grow into the upward direction.