### PR TITLE
MouseManager: do not print empty debug message

### DIFF
--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -122,7 +122,9 @@ bool MouseManager::mouse_handle_event(unsigned int modifiers, unsigned int butto
         return true;
     }
     string errorMsg = (this ->* (b->action))(client, b->cmd);
-    HSDebug("can not start drag: %s\n", errorMsg.c_str());
+    if (!errorMsg.empty()) {
+        HSDebug("can not start drag: %s\n", errorMsg.c_str());
+    }
     return true;
 }
 

--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -123,7 +123,7 @@ bool MouseManager::mouse_handle_event(unsigned int modifiers, unsigned int butto
     }
     string errorMsg = (this ->* (b->action))(client, b->cmd);
     if (!errorMsg.empty()) {
-        HSDebug("can not start drag: %s\n", errorMsg.c_str());
+        HSDebug("cannot start drag: %s\n", errorMsg.c_str());
     }
     return true;
 }


### PR DESCRIPTION
If there is no error message, do not print a debug message