### PR TITLE
ICCCM: Make WM_STATE of type WM_STATE

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ Current git version
     - Fix a crash in the error handler when a invalid monitor name is
       passed. (Affects list_padding move_monitor rename_monitor lock_tag
       unlock_tag)
+    - Fix the type of WM_STATE
 
 Release 0.8.1 on 2020-04-21
 ---------------------------

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -471,11 +471,13 @@ void Ewmh::updateFrameExtents(Window win, int left, int right, int top, int bott
 void Ewmh::windowUpdateWmState(Window win, WmState state) {
     /* set full WM_STATE according to
      * http://www.x.org/releases/X11R7.7/doc/xorg-docs/icccm/icccm.html#WM_STATE_Property
+     *
+     * It's crucial that the property has the type WM_STATE!
      */
-    X_.setPropertyCardinal(win, wmatom(WM::State), {
-        static_cast<long>(state), // WM_STATE.state
-        None // WM_STATE.icon
-    });
+    long wmstate[] = { static_cast<long>(state), None };
+    XChangeProperty(X_.display(), win,  wmatom(WM::State), wmatom(WM::State),
+                    32, PropModeReplace,
+                    reinterpret_cast<unsigned char*>(wmstate), LENGTH(wmstate));
 }
 
 bool Ewmh::isOwnWindow(Window win) {

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -1,6 +1,7 @@
 import conftest
 import os
 import pytest
+from Xlib import X
 
 
 def test_net_wm_desktop_after_load(hlwm, x11):
@@ -113,3 +114,11 @@ def test_manage_transient_for_windows_on_startup(hlwm_spawner, x11):
     assert hlwm.list_children('clients') \
         == sorted([master_id, dialog_id, 'focus'])
     hlwm_proc.shutdown()
+
+
+def test_wm_state_type(hlwm, x11):
+    win, _ = x11.create_client(sync_hlwm=True)
+    wm_state = x11.display.intern_atom('WM_STATE')
+    prop = win.get_full_property(wm_state, X.AnyPropertyType)
+    assert prop.property_type == wm_state
+    assert len(prop.value) == 2


### PR DESCRIPTION
Make the WM_STATE property of every window have the type WM_STATE, i.e.
apply what is in a5045733. When I originally tried to adapt this commit
to the new codebase I accidentally changed the type back to XA_CARDINAL
(84a6ed87), thus effectively reverting the fix a5045733.

There's also a test case for this now to avoid that this bug is
introduced a third time.

This fixes issue #849.