### PR TITLE
Mergify: Take commit message from first PR body

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,3 +9,4 @@ pull_request_rules:
           merge:
               method: squash
               strict: smart
+              commit_message: title+body


### PR DESCRIPTION
Usually, when handing in a pull request, it consists of one commit with
a meaningful commit message. Then smaller commits with very short commit
titles like "Update comment", "Moar", "Remove whitespace" follow. Usually,
these messages do not have any meaning in the squashed commit that is
created when merging the PR. So they don't belong to the commit message.
Instead, with "commit_message: title+body" we can actively edit the
commit message before the PR is merged.