### PR TITLE
Enable theme setting tight_decoration again

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1505,6 +1505,9 @@ listed as follows:
  i w outer_width          , width of an additional border close to the edge
  c w outer_color          , its color
  c w background_color     , color behind window contents visible on resize
+ b w tight_decoration     , specifies whether the size hints also affect the
+                            window decoration or only the window contents of
+                            tiled clients (requires enabled sizehints_tiling)
  s w reset                , Writing this resets all attributes to a default value
 |===========================
 +

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -149,23 +149,25 @@ void Decoration::resize_outline(Rectangle outline, const DecorationScheme& schem
 
     auto tile = inner;
     client_->applysizehints(&inner.width, &inner.height);
-    if (!false) { // formely: if (!tight_decoration)
-        // center the window in the outline tile
-        // but only if it's relative coordinates would not be too close to the
-        // upper left tile border
-        int threshold = settings_.pseudotile_center_threshold;
-        int dx = tile.width/2 - inner.width/2;
-        int dy = tile.height/2 - inner.height/2;
-        inner.x = tile.x + ((dx < threshold) ? 0 : dx);
-        inner.y = tile.y + ((dy < threshold) ? 0 : dy);
-    }
+
+    // center the window in the outline tile
+    // but only if it's relative coordinates would not be too close to the
+    // upper left tile border
+    int threshold = settings_.pseudotile_center_threshold;
+    int dx = tile.width/2 - inner.width/2;
+    int dy = tile.height/2 - inner.height/2;
+    inner.x = tile.x + ((dx < threshold) ? 0 : dx);
+    inner.y = tile.y + ((dy < threshold) ? 0 : dy);
 
     //if (RECTANGLE_EQUALS(client->last_size, rect)
     //    && client->last_border_width == border_width) {
     //    return;
     //}
 
-    if (false) { // formely: if (tight_decoration)
+    if (scheme.tight_decoration()) {
+        // updating the outline only has an affect for tiled clients
+        // because for floating clients, this has been done already
+        // right when the window size changed.
         outline = scheme.inner_rect_to_outline(inner);
     }
     last_inner_rect = inner;

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -79,3 +79,12 @@ def test_minimal_theme(hlwm, reset):
         hlwm.call('set_attr theme.minimal.reset 1')
     for scheme in ['active', 'normal', 'urgent']:
         assert hlwm.get_attr(f'theme.minimal.{scheme}.border_width') == '0'
+
+
+@pytest.mark.parametrize("tight_dec", [True, False])
+def test_tight_decoration(hlwm, tight_dec):
+    hlwm.call('set_attr theme.tight_decoration {}'.format(hlwm.bool(tight_dec)))
+    # it's not easy to test the tight decration, so we only
+    # check that it does not crash
+    hlwm.create_client()
+    hlwm.call('split explode')


### PR DESCRIPTION
The tight_decoration attribute specifies whether the window sizehints
affect the decoration window or only the window content itself. Other
than in the old code base of v0.7.2, we now always center the window if
the size hints change the window size.

This only affects tiled clients with sizehints_tiling enabled. A visual
demonstration of the tight_decoration setting can be found in the
pull-request for this commit:
https://github.com/herbstluftwm/herbstluftwm/pull/858

Effectively, this commit only removes a redundant "if (!false)" and
replaced one "if (false)" by "if (scheme.tight_decoration())". The rest
is documentation and tests.