### PR TITLE
Move frame window collection to x11 fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -707,9 +707,9 @@ def x11(x11_connection):
             frame decoration windows"""
             cmd = ['xdotool', 'search', '--class', '_HERBST_FRAME']
             frame_wins = subprocess.run(cmd,
-                                  stdout=subprocess.PIPE,
-                                  universal_newlines=True,
-                                  check=True)
+                                        stdout=subprocess.PIPE,
+                                        universal_newlines=True,
+                                        check=True)
             res = []
             for winid_decimal_str in frame_wins.stdout.splitlines():
                 res.append(self.window(winid_decimal_str))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -702,6 +702,19 @@ def x11(x11_connection):
                 window = tree.parent
             return (x, y)
 
+        def get_hlwm_frames(self):
+            """get list of window handles of herbstluftwm
+            frame decoration windows"""
+            cmd = ['xdotool', 'search', '--class', '_HERBST_FRAME']
+            frame_wins = subprocess.run(cmd,
+                                  stdout=subprocess.PIPE,
+                                  universal_newlines=True,
+                                  check=True)
+            res = []
+            for winid_decimal_str in frame_wins.stdout.splitlines():
+                res.append(self.window(winid_decimal_str))
+            return res
+
         def shutdown(self):
             # Destroy all created windows:
             for window in self.windows:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,6 +1,5 @@
 import pytest
 import re
-import subprocess
 import math
 
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -377,11 +377,7 @@ def test_split_and_remove_with_smart_frame_surroundings(hlwm, x11, align):
     hlwm.call('remove')
 
     # Search for all frames, there should only be one
-    frame_win_id = subprocess.run(['xdotool', 'search', '--class', '_HERBST_FRAME'],
-                                  stdout=subprocess.PIPE,
-                                  universal_newlines=True,
-                                  check=True)
-    frame_x11 = x11.window(frame_win_id.stdout)
+    frame_x11 = x11.get_hlwm_frames()[0]
     frame_geom = frame_x11.get_geometry()
     assert (frame_geom.width, frame_geom.height) == (800, 600)
 


### PR DESCRIPTION
I thought I needed the list of frames in another testcase (but
fortunately it turned out that I don't). However, I think it's usefull
to have the get_hlwm_frames() in a separate method for further tests.