### PR TITLE
Focus frames with the mouse

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ herbstluftwm NEWS -- History of user-visible changes
 Current git version
 -------------------
 
+  * Selection of empty frames by the mouse (by click or by hover if
+    focus_follows_mouse is enabled)
   * The commands 'close_and_remove' / 'close_or_remove' act like 'close' for
     floating clients
   * Bug fixes:

--- a/src/framedecoration.h
+++ b/src/framedecoration.h
@@ -2,9 +2,12 @@
 #define __HLWM_FRAME_DECORATION_H_
 
 #include <X11/X.h>
+#include <map>
+#include <memory>
 
 #include "x11-types.h"
 
+class FrameLeaf;
 class HSTag;
 class Slice;
 class Settings;
@@ -20,13 +23,18 @@ public:
 
 class FrameDecoration {
 public:
-    FrameDecoration(HSTag* tag, Settings* settings);
+    FrameDecoration(FrameLeaf& frame, HSTag* tag, Settings* settings);
     ~FrameDecoration();
     void render(const FrameDecorationData& data, bool isFocused);
     void updateVisibility(const FrameDecorationData& data, bool isFocused);
     void hide();
+    std::shared_ptr<FrameLeaf> frame();
+
+    static FrameDecoration* withWindow(Window winid);
 
 private:
+    static std::map<Window, FrameDecoration*> s_windowToFrameDecoration;
+    FrameLeaf& frame_; //! the owner of this decoration
     Window window;
     bool visible; // whether the window is visible at the moment
     bool window_transparent; // whether the window has a mask at the moment

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -47,7 +47,7 @@ FrameLeaf::FrameLeaf(HSTag* tag, Settings* settings, weak_ptr<FrameSplit> parent
     }
     layout = (LayoutAlgorithm) l;
 
-    decoration = new FrameDecoration(tag, settings);
+    decoration = new FrameDecoration(*this, tag, settings);
 }
 
 FrameSplit::FrameSplit(HSTag* tag, Settings* settings, weak_ptr<FrameSplit> parent, int fraction, SplitAlign align,

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -8,6 +8,7 @@
 #include "hlwmcommon.h"
 #include "hookmanager.h"
 #include "keymanager.h"
+#include "layout.h"
 #include "monitormanager.h"
 #include "mousemanager.h"
 #include "panelmanager.h"
@@ -98,6 +99,18 @@ Root::~Root()
     tmp.reset();
 
     children_.clear(); // avoid possible circular shared_ptr dependency
+}
+
+void Root::focusFrame(shared_ptr<FrameLeaf> frameToFocus)
+{
+    Monitor* monitor = monitors->byFrame(frameToFocus);
+    if (!monitor) {
+        return;
+    }
+    monitors->lock();
+    monitor->tag->focusFrame(frameToFocus);
+    monitor_focus_by_index(static_cast<unsigned int>(monitor->index()));
+    monitors->unlock();
 }
 
 HlwmCommon Root::common() {

--- a/src/root.h
+++ b/src/root.h
@@ -10,6 +10,7 @@
 
 class ClientManager; // IWYU pragma: keep
 class Ewmh;
+class FrameLeaf;
 class HlwmCommon;
 class HookManager; // IWYU pragma: keep
 class IpcServer;
@@ -65,6 +66,9 @@ public:
     // automatically from the signals emitted by ClientManager, etc
     std::unique_ptr<PanelManager> panels; // Using "pimpl" to avoid include
     std::unique_ptr<Ewmh> ewmh; // Using "pimpl" to avoid include
+
+    // global actions
+    void focusFrame(std::shared_ptr<FrameLeaf> frameToFocus);
 
 private:
     static std::shared_ptr<Root> root_;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -19,6 +19,7 @@
 using std::endl;
 using std::function;
 using std::make_shared;
+using std::shared_ptr;
 using std::string;
 
 static bool    g_tag_flags_dirty = true;
@@ -140,6 +141,13 @@ void HSTag::foreachClient(function<void (Client *)> loopBody)
     for (Client* c: floating_clients_) {
         loopBody(c);
     }
+}
+
+void HSTag::focusFrame(shared_ptr<FrameLeaf> frameToFocus)
+{
+    floating_focused = false;
+    FrameTree::focusFrame(frameToFocus);
+    needsRelayout_.emit();
 }
 
 Client *HSTag::focusedClient()

--- a/src/tag.h
+++ b/src/tag.h
@@ -18,6 +18,7 @@ enum {
 
 class Client;
 class Completion;
+class FrameLeaf;
 class FrameTree;
 class Settings;
 class Stack;
@@ -46,6 +47,7 @@ public:
     void setVisible(bool visible);
     bool removeClient(Client* client);
     void foreachClient(std::function<void(Client*)> loopBody);
+    void focusFrame(std::shared_ptr<FrameLeaf> frameToFocus);
     Client* focusedClient();
 
     void insertClient(Client* client, std::string frameIndex = {}, bool focus = true);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -809,6 +809,11 @@ def mouse(hlwm_process):
             else:
                 subprocess.check_call(['xdotool', 'click', button])
 
+        def move_to(self, abs_x, abs_y):
+            abs_x = str(int(abs_x))
+            abs_y = str(int(abs_y))
+            self.call_cmd(f'xdotool mousemove --sync {abs_x} {abs_y}', shell=True)
+
         def move_relative(self, delta_x, delta_y):
             self.call_cmd(f'xdotool mousemove_relative --sync {delta_x} {delta_y}', shell=True)
 

--- a/tests/test_basic_events.py
+++ b/tests/test_basic_events.py
@@ -50,3 +50,32 @@ def test_focus_follows_mouse(hlwm, mouse, focus_follows_mouse, single_floating):
     assert c1_is_focused == focus_follows_mouse
     # stacking is unchanged
     assert test_stack.helper_get_stack_as_list(hlwm) == [c2, c1]
+
+
+@pytest.mark.parametrize("click", [True, False])
+@pytest.mark.parametrize("focus_follows_mouse", [True, False])
+def test_focus_frame_by_mouse(hlwm, mouse, click, focus_follows_mouse):
+    hlwm.call('set always_show_frame on')
+    hlwm.call('set frame_bg_transparent off')
+    hlwm.call(['set', 'focus_follows_mouse', hlwm.bool(focus_follows_mouse)])
+    layout_template = '(split horizontal:0.5:{}'
+    layout_template += ' (clients vertical:0)'
+    layout_template += ' (clients vertical:0))'
+    # a layout where the left frame is focused
+    hlwm.call(['load', layout_template.format(0)])
+    assert layout_template.format(0) == hlwm.call('dump').stdout
+    width, height = [int(v) for v in hlwm.call('monitor_rect').stdout.split(' ')][2:]
+
+    # go to left frame
+    mouse.move_to(width * 0.25, height * 0.5)
+
+    # go to right frame
+    mouse.move_to(width * 0.75, height * 0.5)
+    if click:
+        mouse.click('1')
+
+    # we expect the focus to go to the second frame
+    # if focus_follows_mouse is enabled or if we click explicitly
+    expected_focus = 1 if focus_follows_mouse or click else 0
+    assert layout_template.format(expected_focus) \
+        == hlwm.call('dump').stdout


### PR DESCRIPTION
This adds basic support for selecting frames with the mouse: either by
click or by mouse hover (if focus_follows_mouse is enabled). This change
only concerns the actual frame. If there is no frame shown (because
always_show_frame=off) or if there is a hole in the frame (because
frame_bg_transparent=on), then we only obtain events for the root window
that are currently ignored. (Interpreting event coordinates on the root
window is in the scope of another change)

On the implementation level, this introduces a static map that
transforms window ids into frame decorations (I think a 'framemanager'
is overkill here). The focusFrame() function is added to the root
window, because it affects the global state of hlwm (and I think
focus_client() should go to Root at some point, too).

This solves issue #20 (in principle) and adds a test case for it.