### PR TITLE
Synchronize mouse press/release with hlwm output

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -860,11 +860,21 @@ def mouse(hlwm_process):
         def move_relative(self, delta_x, delta_y):
             self.call_cmd(f'xdotool mousemove_relative --sync {delta_x} {delta_y}', shell=True)
 
-        def mouse_press(self, button):
-            self.call_cmd(f'xdotool mousedown {button}', shell=True)
+        def mouse_press(self, button, wait=True):
+            cmd = ['xdotool', 'mousedown', button]
+            if wait:
+                with hlwm_process.wait_stderr_match('ButtonPress'):
+                    subprocess.check_call(cmd)
+            else:
+                subprocess.check_call(cmd)
 
-        def mouse_release(self, button):
-            self.call_cmd(f'xdotool mouseup {button}', shell=True)
+        def mouse_release(self, button, wait=True):
+            cmd = ['xdotool', 'mouseup', button]
+            if wait:
+                with hlwm_process.wait_stderr_match('ButtonRelease'):
+                    subprocess.check_call(cmd)
+            else:
+                subprocess.check_call(cmd)
 
         def call_cmd(self, cmd, shell=False):
             print('calling: {}'.format(cmd), file=sys.stderr)

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -205,7 +205,10 @@ def test_drag_resize_floating_client(hlwm, x11, mouse, live_update):
     assert (geom_after.width, geom_after.height) == final_size
 
 
-def test_move_client_via_decoration(hlwm, x11, mouse):
+# we had a race condition here, so increase the likelyhood
+# that we really fixed it:
+@pytest.mark.parametrize('repeat', list(range(0, 100)))
+def test_move_client_via_decoration(hlwm, x11, mouse, repeat):
     hlwm.call('attr theme.padding_top 20')
     client, winid = x11.create_client(geometry=(50, 50, 300, 200))
     hlwm.call(f'set_attr clients.{winid}.floating true')
@@ -220,6 +223,7 @@ def test_move_client_via_decoration(hlwm, x11, mouse):
     expected_position = (x_before + 130, y_before + 110)
 
     mouse.mouse_release('1')
+    x11.display.sync()
     # the size didn't change
     size_after = client.get_geometry()
     assert (size_before.width, size_before.height) \
@@ -228,7 +232,10 @@ def test_move_client_via_decoration(hlwm, x11, mouse):
     assert expected_position == x11.get_absolute_top_left(client)
 
 
-def test_resize_client_via_decoration(hlwm, x11, mouse):
+# we had a race condition here, so increase the likelyhood
+# that we really fixed it:
+@pytest.mark.parametrize('repeat', list(range(0, 100)))
+def test_resize_client_via_decoration(hlwm, x11, mouse, repeat):
     hlwm.call('attr theme.border_width 20')
     client, winid = x11.create_client(geometry=(50, 50, 300, 200))
     hlwm.call(f'set_attr clients.{winid}.floating true')
@@ -246,6 +253,7 @@ def test_resize_client_via_decoration(hlwm, x11, mouse):
     mouse.mouse_release('1')
 
     # the size changed
+    x11.display.sync()
     size_after = client.get_geometry()
     assert expected_size == (size_after.width, size_after.height)
     # and also the location

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -224,6 +224,7 @@ def test_move_client_via_decoration(hlwm, x11, mouse, repeat):
 
     mouse.mouse_release('1')
     x11.display.sync()
+    assert 'dragged' not in hlwm.list_children('clients')
     # the size didn't change
     size_after = client.get_geometry()
     assert (size_before.width, size_before.height) \
@@ -254,6 +255,7 @@ def test_resize_client_via_decoration(hlwm, x11, mouse, repeat):
 
     # the size changed
     x11.display.sync()
+    assert 'dragged' not in hlwm.list_children('clients')
     size_after = client.get_geometry()
     assert expected_size == (size_after.width, size_after.height)
     # and also the location


### PR DESCRIPTION
In the mouse fixture, wait for herbstluftwm to process the ButtonPress
and ButtonRelease events as we were doing it already in the Mouse.click()
method. This should fix the current flakyness of
test_drag_resize_floating_client