### PR TITLE
doc: Fix asciidoc table

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1494,24 +1494,24 @@ listed as follows:
   * +theme+ has attributes to configure the window decorations. +theme+ and many
     of its child objects have the following attributes
 +
-[format="csv",cols="m,"]
-|===========================
- i w border_width         , the base width of the border
- i w padding_top          , additional border width on the top
- i w padding_right        , on the right
- i w padding_bottom       , on the bottom
- i w padding_left         , and on the left of the border
- c w color                , the basic background color of the border
- i w inner_width          , width of the border around the clients content
- c w inner_color          , its color
- i w outer_width          , width of an additional border close to the edge
- c w outer_color          , its color
- c w background_color     , color behind window contents visible on resize
- b w tight_decoration     , specifies whether the size hints also affect the
+[cols="m,"]
+|=================================================================================
+|i w border_width         | the base width of the border
+|i w padding_top          | additional border width on the top
+|i w padding_right        | on the right
+|i w padding_bottom       | on the bottom
+|i w padding_left         | and on the left of the border
+|c w color                | the basic background color of the border
+|i w inner_width          | width of the border around the clients content
+|c w inner_color          | its color
+|i w outer_width          | width of an additional border close to the edge
+|c w outer_color          | its color
+|c w background_color     | color behind window contents visible on resize
+|b w tight_decoration     | specifies whether the size hints also affect the
                             window decoration or only the window contents of
                             tiled clients (requires enabled sizehints_tiling)
- s w reset                , Writing this resets all attributes to a default value
-|===========================
+|s w reset                | Writing this resets all attributes to a default value
+|=================================================================================
 +
 ----
 inner_color/inner_width


### PR DESCRIPTION
Use the |-syntax to make it clear that the lines of the description of
tight_decoration belong to the same table cell.