### PR TITLE
Fix exit code of 'focus' command

### DIFF
--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -241,6 +241,7 @@ int HSTag::focusInDirCommand(Input input, Output output)
         int idx = g_monitors->indexInDirection(get_current_monitor(), direction);
         if (idx >= 0) {
             monitor_focus_by_index(idx);
+            return 0;
         }
     }
     if (!neighbour_found) {

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -656,6 +656,23 @@ def test_index_empty_frame_subtree(hlwm):
     assert layout.replace('T', winid) == hlwm.call('dump').stdout
 
 
+@pytest.mark.parametrize("setting", [True, False])
+@pytest.mark.parametrize("other_mon_exists", [True, False])
+def test_focus_other_monitor(hlwm, other_mon_exists, setting):
+    hlwm.call(['set', 'focus_crosses_monitor_boundaries', hlwm.bool(setting)])
+    hlwm.call('add othertag')
+    if other_mon_exists:
+        hlwm.call('add_monitor 800x600+800+0')
+    assert hlwm.get_attr('monitors.focus.index') == '0'
+
+    if setting and other_mon_exists:
+        hlwm.call('focus right')
+        assert hlwm.get_attr('monitors.focus.index') == '1'
+    else:
+        hlwm.call_xfail('focus right') \
+            .expect_stderr('No neighbour found')
+
+
 def test_set_layout_invalid_layout_name(hlwm):
     hlwm.call_xfail('set_layout foobar') \
         .expect_stderr('set_layout: Invalid layout name: "foobar"')


### PR DESCRIPTION
If 'focus' successfully finds another monitor, then it should exit with
returncode 0. Also add a testcase for this.