### PR TITLE
Tests: Fix race condition in mouse button fixture

### DIFF
--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -191,6 +191,7 @@ def test_drag_resize_floating_client(hlwm, x11, mouse, live_update):
     final_size = (geom_before.width - 100, geom_before.height - 120)
 
     # check geometry during drag
+    x11.display.sync()
     geom_after = client.get_geometry()
     x_after, y_after = x11.get_absolute_top_left(client)
     assert (x_after, y_after) == (x_before + 100, y_before + 120)


### PR DESCRIPTION
When waiting for hlwm to process the mouse button events, it does not
suffice to wait for the respective 'ButtonPress' or 'ButtonRelease'
debug output on stderr, because this only indicates that hlwm is
starting to process the respective mouse button events. So if we
continue doing something via our own X connection, then the hlwm might
not be finished processing the button event.

Hence, for wait=True, we run the 'true' command because as soon as hlwm
processes some command, we know that the event handling is finished.

We do something similar for mouse move events.

I suppose/hope that this fixes #889.