### PR TITLE
Fix EWMH urgency add for clients without wm hints

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -489,11 +489,13 @@ void Client::set_urgent_force(bool state) {
 
     setup_border(this == manager.focus());
 
-    XWMHints *wmh;
+    XWMHints* wmh;
     if (!(wmh = XGetWMHints(g_display, this->window_))) {
-        return;
+        // just allocate new wm hints for the case the window
+        // did not have wm hints set before.
+        // here, we ignore what happens on insufficient memory
+        wmh = XAllocWMHints();
     }
-
     if (state) {
         wmh->flags |= XUrgencyHint;
     } else {


### PR DESCRIPTION
This fixes issue #586 where a client without wm hints (here, the
chromium window) is equipped with the urgency hint via ewmh, e.g. by:

    wmctrl -r Chromium -b add,demands_attention

In such a case, the urgency hint was not updated correctly, and the
tag_flags hook was not fired. This commit fixes both by creating a new
wm hint for clients lacking it instead of doing nothing. Also, a test
for this is added.