### PR TITLE
Test feeding junk to commands

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,7 +204,11 @@ class HlwmBridge:
                     items.append(i[0:-1])
         # evaluate escape sequences:
         if evaluate_escapes:
-            items = [shlex.split(s)[0] for s in items]
+            old_items = items
+            items = []
+            for s in old_items:
+                unescaped = shlex.split(s)
+                items.append(unescaped[0] if len(unescaped) else '')
         return sorted(items)
 
     def list_children_via_attr(self, object_path):

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -245,7 +245,7 @@ def test_junk_args_dont_crash(hlwm, args_before, junk_arg):
             continue
         full_cmd = [cmd_name]
         for _ in range(0, args_before):
-            # find some arg apropriate for the current command
+            # find some arg appropriate for the current command
             completions = hlwm.unchecked_call(
                 ['complete', str(len(full_cmd))] + full_cmd).stdout.splitlines()
             completions.append('')

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -231,3 +231,24 @@ def test_posix_escape(hlwm):
     results = hlwm.complete(['use'], evaluate_escapes=True)
     print(results)
     assert sorted(['default'] + tags) == sorted(results)
+
+
+@pytest.mark.exclude_from_coverage(
+    reason='This test does not verify functionality but only whether \
+    passing junk to args does not crash herbstluftwm.')
+@pytest.mark.parametrize("args_before", [0, 1, 2])
+@pytest.mark.parametrize("junk_arg", ['junk', '234', ' '])
+def test_junk_args_dont_crash(hlwm, args_before, junk_arg):
+    commands = hlwm.call('list_commands').stdout.splitlines()
+    for cmd_name in commands:
+        if cmd_name in ['wmexec', 'quit']:
+            continue
+        full_cmd = [cmd_name]
+        for _ in range(0, args_before):
+            # find some arg apropriate for the current command
+            completions = hlwm.unchecked_call(
+                ['complete', str(len(full_cmd))] + full_cmd).stdout.splitlines()
+            completions.append('')
+            full_cmd.append(completions[0])
+        full_cmd.append(junk_arg)
+        hlwm.unchecked_call(full_cmd)


### PR DESCRIPTION
This adds a test case that tries to call commands with a junk argument.
Of course this should not affect the coverage, but I hope that with
this, we will find bugs in parser exception handling earlier (such as
pr #590).