### PR TITLE
Set .desktop file Type to Application

### DIFF
--- a/share/herbstluftwm.desktop
+++ b/share/herbstluftwm.desktop
@@ -3,4 +3,4 @@ Encoding=UTF-8
 Name=herbstluftwm
 Comment=Manual tiling window manager
 Exec=herbstluftwm
-Type=XSession
+Type=Application


### PR DESCRIPTION
XSession doesn't seem to be a valid type, the spec seems to only mention
Link, Application and Directory. See also
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850690

Also, on my system all other .desktop files in /usr/share/xsessions/
declare themselves to be Type=Application.