### PR TITLE
Tests: Fix race condition in test_reload

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,6 +385,15 @@ class HlwmProcess:
             if not expect_sth or match_found():
                 break
 
+        # decode remaining bytes for the final match_found() check
+        if stderr_bytes != b'':
+            stderr += stderr_bytes.decode()
+            sys.stderr.write(stderr_bytes.decode())
+            sys.stderr.flush()
+        if stdout_bytes != b'':
+            stdout += stdout_bytes.decode()
+            sys.stdout.write(stdout_bytes.decode())
+            sys.stdout.flush()
         duration = (datetime.now() - started).total_seconds()
         if expect_sth and not match_found():
             assert False, f'Expected string not encountered within {duration:.1f} seconds'
@@ -394,6 +403,9 @@ class HlwmProcess:
         """
         Context manager for wrapping commands that are expected to result in
         certain output on hlwm's stdout (e.g., input events).
+
+        Warning: do not run call(...) within such a context, but only
+        unchecked_call(..., read_hlwm_output=False) instead
         """
         self.read_and_echo_output()
         yield
@@ -404,6 +416,9 @@ class HlwmProcess:
         """
         Context manager for wrapping commands that are expected to result in
         certain output on hlwm's stderr (e.g., input events).
+
+        Warning: do not run call(...) within such a context, but only
+        unchecked_call(..., read_hlwm_output=False) instead
         """
         self.read_and_echo_output()
         yield

--- a/tests/test_herbstluftwm.py
+++ b/tests/test_herbstluftwm.py
@@ -12,7 +12,12 @@ HLWM_PATH = os.path.join(BINDIR, 'herbstluftwm')
 
 def test_reload(hlwm_process, hlwm):
     with hlwm_process.wait_stdout_match('hlwm started'):
-        hlwm.call('reload')
+        # run the command, but read not hlwm's output in unchecked_call()
+        # but instead, let the current context manager read it!
+        proc = hlwm.unchecked_call('reload', read_hlwm_output=False)
+        assert not proc.stderr
+        assert not proc.stdout
+        assert proc.returncode == 0
 
 
 def test_herbstluftwm_already_running(hlwm):

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -1,4 +1,7 @@
 def test_spawn(hlwm, hlwm_process):
-    hlwm.call(['spawn', 'sh', '-c', 'echo >&2 spawnyboi'])
-
-    hlwm_process.wait_stderr_match('spawnyboi')
+    with hlwm_process.wait_stderr_match('spawnyboi'):
+        cmd = ['spawn', 'sh', '-c', 'echo >&2 spawnyboi']
+        proc = hlwm.unchecked_call(cmd, read_hlwm_output=False)
+        assert proc.returncode == 0
+        assert not proc.stderr
+        assert not proc.stdout


### PR DESCRIPTION
The issue was that the call() command processed the output of the
herbstluftwm process and so the context manager shutdown code could not
find the strings it was looking for.

There was essentially the same issue in test_spawn that never appeared
in the CI runs (i.e. "in the wild").

The present commit mainly fixes the race condition. While at it, I also
fixed a minor (maybe only theoretic) race condition in
read_and_echo_output() itself, where a line on stdout/stderr was lost if
it is not enclosed by a '\n' byte within the timeout.

This fixes #902.