### PR TITLE
Ignore EnterNotify events by grabs and decoration

### DIFF
--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -338,7 +338,14 @@ void XMainLoop::destroynotify(XUnmapEvent* event) {
 }
 
 void XMainLoop::enternotify(XCrossingEvent* ce) {
-    HSDebug("name is: EnterNotify, focus = %d\n", ce->focus);
+    HSDebug("EnterNotify, focus = %d, window = 0x%lx\n", ce->focus, ce->window);
+    if (ce->mode != NotifyNormal || ce->detail == NotifyInferior) {
+        // ignore an event if it is caused by (un-)grabbing the mouse or
+        // if the pointer moves from a window to its decoration.
+        // for 'ce->detail' see:
+        // https://tronche.com/gui/x/xlib/events/window-entry-exit/normal.html
+        return;
+    }
     if (!root_->mouse->mouse_is_dragging()
         && root_->settings()->focus_follows_mouse()
         && ce->focus == false) {


### PR DESCRIPTION
DWM ignores these events, too.