### PR TITLE
Don't drop later EnterNotify during enternotify()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 herbstluftwm NEWS -- History of user-visible changes
 ----------------------------------------------------
 
+Current git version
+-------------------
+
+  * Bug fixes:
+    - Fix race condition in focus_follows_mouse handling
+
 Release 0.8.2 on 2020-05-04
 ---------------------------
 

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -49,7 +49,7 @@ Monitor::Monitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, 
     , mouse { 0, 0 }
     , rect(rect_)
     , settings(settings_)
-    //, monman(monman_)
+    , monman(monman_)
 {
     for (auto i : {&pad_up, &pad_left, &pad_right, &pad_down}) {
         i->setWriteable();
@@ -261,7 +261,7 @@ void Monitor::applyLayout() {
 
     // remove all enternotify-events from the event queue that were
     // generated while arranging the clients on this monitor
-    drop_enternotify_events();
+    monman->dropEnterNotifyEvents.emit();
 }
 
 Monitor* find_monitor_by_name(const char* name) {
@@ -472,8 +472,6 @@ int monitor_set_tag(Monitor* monitor, HSTag* tag) {
             monitor->restack();
             other->applyLayout();
             monitor->applyLayout();
-            // discard enternotify-events
-            drop_enternotify_events();
             monitor_update_focus_objects();
             Ewmh::get().updateCurrentDesktop();
             emit_tag_changed(other->tag, other->index());
@@ -504,7 +502,7 @@ int monitor_set_tag(Monitor* monitor, HSTag* tag) {
     old_tag->setVisible(false);
     // focus window just has been shown
     // discard enternotify-events
-    drop_enternotify_events();
+    g_monitors->dropEnterNotifyEvents.emit();
     monitor_update_focus_objects();
     Ewmh::get().updateCurrentDesktop();
     emit_tag_changed(tag, g_monitors->cur_monitor);
@@ -655,7 +653,7 @@ void monitor_focus_by_index(unsigned new_selection) {
         // discard all mouse events caused by this pointer movage from the
         // event queue, so the focus really stays in the last focused window on
         // this monitor and doesn't jump to the window hovered by the mouse
-        drop_enternotify_events();
+        g_monitors->dropEnterNotifyEvents.emit();
     }
     // update objects
     monitor_update_focus_objects();
@@ -720,14 +718,6 @@ void all_monitors_replace_previous_tag(HSTag *old, HSTag *newmon) {
         if (m->tag_previous == old) {
             m->tag_previous = newmon;
         }
-    }
-}
-
-void drop_enternotify_events() {
-    XEvent ev;
-    XSync(g_display, False);
-    while (XCheckMaskEvent(g_display, EnterWindowMask, &ev)) {
-        ;
     }
 }
 

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -59,7 +59,7 @@ private:
     std::string getTagString();
     std::string setTagString(std::string new_tag);
     Settings* settings;
-    //MonitorManager* monman;
+    MonitorManager* monman;
 };
 
 // adds a new monitor to the monitors list and returns a pointer to it
@@ -81,8 +81,6 @@ int monitor_set_previous_tag_command(Output output);
 void all_monitors_apply_layout();
 void ensure_monitors_are_available();
 void all_monitors_replace_previous_tag(HSTag* old, HSTag* newmon);
-
-void drop_enternotify_events();
 
 void monitor_update_focus_objects();
 

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -386,7 +386,7 @@ int MonitorManager::addMonitor(Input input, Output output)
     monitor->applyLayout();
     tag->setVisible(true);
     emit_tag_changed(tag, g_monitors->size() - 1);
-    drop_enternotify_events();
+    dropEnterNotifyEvents.emit();
 
     return HERBST_EXIT_SUCCESS;
 }

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -9,6 +9,7 @@
 #include "link.h"
 #include "monitor.h"
 #include "plainstack.h"
+#include "signal.h"
 
 extern MonitorManager* g_monitors;
 
@@ -82,6 +83,13 @@ public:
     Rectangle interpretGlobalGeometry(Rectangle globalGeometry);
 
     int cur_monitor;
+
+    /**
+     * @brief this signal is emitted whenever the mouse cursor have
+     * entered another window although the user has not moved the cursor
+     * manually. In this case the respective events have to be ignored.
+     */
+    Signal dropEnterNotifyEvents;
 
 private:
     std::function<int(Input, Output)> byFirstArg(MonitorCommand cmd);

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -68,6 +68,9 @@ XMainLoop::XMainLoop(XConnection& X, Root* root)
     handlerTable_[ MotionNotify      ] = EH(&XMainLoop::motionnotify);
     handlerTable_[ PropertyNotify    ] = EH(&XMainLoop::propertynotify);
     handlerTable_[ UnmapNotify       ] = EH(&XMainLoop::unmapnotify);
+
+    root_->monitors->dropEnterNotifyEvents
+            .connect(this, &XMainLoop::dropEnterNotifyEvents);
 }
 
 //! scan for windows and add them to the list of managed clients
@@ -173,6 +176,21 @@ void XMainLoop::run() {
 
 void XMainLoop::quit() {
     aboutToQuit_ = true;
+}
+
+void XMainLoop::dropEnterNotifyEvents()
+{
+    if (duringEnterNotify_) {
+        // during a enternotify(), no artificial enter notify events
+        // can be created. Moreover, on quick mouse movements, an enter notify
+        // might be followed by further enter notify events, which
+        // must not be dropped.
+        return;
+    }
+    XEvent ev;
+    XSync(X_.display(), False);
+    while (XCheckMaskEvent(X_.display(), EnterWindowMask, &ev)) {
+    }
 }
 
 /* ----------------------------- */
@@ -346,6 +364,8 @@ void XMainLoop::enternotify(XCrossingEvent* ce) {
         // https://tronche.com/gui/x/xlib/events/window-entry-exit/normal.html
         return;
     }
+    // Warning: we have to set this to false again!
+    duringEnterNotify_ = true;
     if (!root_->mouse->mouse_is_dragging()
         && root_->settings()->focus_follows_mouse()
         && ce->focus == false) {
@@ -375,6 +395,7 @@ void XMainLoop::enternotify(XCrossingEvent* ce) {
             }
         }
     }
+    duringEnterNotify_ = false;
 }
 
 void XMainLoop::expose(XEvent* event) {

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -3,6 +3,8 @@
 #include <X11/X.h>
 #include <X11/Xlib.h>
 
+#include "x11-types.h"
+
 class Root;
 class XConnection;
 
@@ -14,6 +16,8 @@ public:
     //! quit the main loop as soon as possible
     void quit();
     using EventHandler = void (XMainLoop::*)(XEvent*);
+
+    void dropEnterNotifyEvents();
 private:
     // members
     XConnection& X_;
@@ -38,4 +42,6 @@ private:
     void maprequest(XMapRequestEvent* mapreq);
     void propertynotify(XPropertyEvent* event);
     void unmapnotify(XUnmapEvent* event);
+
+    bool duringEnterNotify_ = false; //! whether we are in enternotify()
 };


### PR DESCRIPTION
This fixes a race condition, reported in #908.

In general, Monitor::applyLayout() possibly drops future EnterNotify
events in the X11 event queue that might have been artifically triggered
because the new tiling on a monitor might have moved a window to the
cursor.

During the handling of an EnterNotify event, no such artificial enter
notify events can be created, because only the focus is changed, so
there is not necessity to drop those. Moreover, on quick mouse
movements, multiple enter notify events can be created if the cursor
traverses over multiple windows. In this case, we must not drop these
later EnterNotify events.

(These events can be triggered while hlwm is already processing the
first EnterNotify event, so it is not enough to skip to the newest
EnterNotify event in the enternotify() event handler).

To accomplish this restriction, the dropEnterNotifyEvents() function is
moved to XMainLoop where we keep track of whether we are in
enternotify(). On a positive side, we get rid of calling an X function
in monitor.cpp.

There are two new test cases:

  - The first test case verifies that after resizing, non-welcome
    EnterNotify events are dropped.
  - The second one checks that for a number of EnterNotify events, the
    last one survives. Unfortunately, I did not manage to establish a
    test case that fails before the present commit. (But I think this is
    better than nothing because it still tests something)

In order to test this manually, do the following:

  - herbstclient set focus_follows_mouse on
  - herbstclient set frame_border_width 20
  - put two clients in separate frames side by side
  - move the mouse cursor quickly between the two clients.
  - before the present commit, the focus isn't updated reliably, but
    with this commit, it is. (Instead of switching between git commits
    one can also simply deactivate the 'return' in
    XMainLoop::dropEnterNotifyEvents())