### PR TITLE
Remove unused command interface methods

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -292,28 +292,6 @@ void Commands::complete(Completion& completion) {
     }
 }
 
-
-// Old C-ish interface to commands:
-
-int call_command(int argc, char** argv, Output output) {
-    if (argc < 1) {
-        return HERBST_COMMAND_NOT_FOUND;
-    }
-
-    string cmd(argv[0]);
-    vector<string> args;
-    for (int i = 1; i < argc; i++) {
-        args.push_back(argv[i]);
-    }
-
-    return Commands::call(Input(cmd, args), output);
-}
-
-int call_command_no_output(int argc, char** argv) {
-    std::ostringstream output;
-    return call_command(argc, argv, output);
-}
-
 int list_commands(Output output)
 {
     for (auto cmd : *Commands::get()) {

--- a/src/command.h
+++ b/src/command.h
@@ -141,15 +141,6 @@ namespace Commands {
     std::shared_ptr<const CommandTable> get();
 }
 
-// Mark the following two functions as obsolete to make it easier to detect and
-// fix call-sites gradually.
-
-int call_command(int argc, char** argv, Output output)
-   /* __attribute__((deprecated("Old C interface, use CommandTable"))) */;
-
-int call_command_no_output(int argc, char** argv)
-   /* __attribute__((deprecated("Old C interface, use CommandTable"))) */;
-
 // commands
 int list_commands(Output output);
 int complete_command(int argc, char** argv, Output output);


### PR DESCRIPTION
They do not seem to be used anymore.