### PR TITLE
codecov: Remove -y flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
                 focal sh -c '
                     /hlwm/ci/build.py --build-dir=/hlwm/build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=/.ccache --compile --run-tests
                 '
-              - bash <(curl -s https://codecov.io/bash) -y .codecov.yml -f coverage.info
+              - bash <(curl -s https://codecov.io/bash) -f coverage.info
 
         - name: "Build with Clang, run linters and static analyzers"
           env: TRAVIS_CACHE_ID=focal-linter


### PR DESCRIPTION
The flag is deprecated:

DeprecationWarning: The -y flag is no longer supported by Codecov.
  codecov.yml must be located underneath the root, dev/, or .github/
  directorie