### PR TITLE
tox: Require some fixed package versions for deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,8 @@ skipsdist = true
 commands = {envpython} -m pytest {posargs}
 deps =
     ewmh
-    pytest-xvfb
+    pytest-xvfb == 1.2.0
+    PyVirtualDisplay < 1.0 # pytest-xvfb <= 1.2.0 breaks with versions >= 1.0
     pytest-xdist
     python-xlib
 
@@ -30,7 +31,7 @@ passenv = PWD LSAN_OPTIONS
 
 [testenv:flake8]
 deps =
-    flake8
+    flake8 == 3.7.9 # TODO: Update to latest version and fix new warnings
 commands = flake8 .
 
 [flake8]


### PR DESCRIPTION
pytest-xvfb and PyVirtualDisplay need specific versions to work
together. Also the new flake8 version requires some fixes as it
introduces new warnings (e.g. it warns about f-strings without
parameters).