### PR TITLE
Unpin pytest-xvfb / PyVirtualDisplay

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,8 @@ skipsdist = true
 commands = {envpython} -m pytest {posargs}
 deps =
     ewmh
-    pytest-xvfb == 1.2.0
-    PyVirtualDisplay < 1.0 # pytest-xvfb <= 1.2.0 breaks with versions >= 1.0
+    pytest-xvfb
+    PyVirtualDisplay
     pytest-xdist
     python-xlib
 


### PR DESCRIPTION
PyVirtualDisplay v2.0.0 is out now, which is compatible with the newest PyVirtualDisplay again.