### PR TITLE
tests: Change Xvfb availability check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -540,9 +540,9 @@ def kill_all_existing_windows(show_warnings=True):
 
 
 @pytest.fixture()
-def hlwm_spawner(tmpdir):
+def hlwm_spawner(tmpdir, xvfb):
     """yield a function to spawn hlwm"""
-    assert os.environ['DISPLAY'] != ':0', 'Refusing to run tests on display that might be your actual X server (not Xvfb)'
+    assert xvfb is not None, 'Refusing to run tests in a non-Xvfb environment (possibly your actual X server?)'
 
     def spawn(args=[], display=None):
         if display is None:


### PR DESCRIPTION
With newer versions of PyVirtualDisplay, a display number of :0 can be
valid during tests, too. It does not necessarily mean that Xvfb is not
available.

As suggested by @The-Compiler use the xvfb fixture of pytest-xvfb and
check if it is valid. (You can trigger the assertion by passing
--no-xvfb while running the tests with tox for example).