### PR TITLE
Explicitly state addtional pytest runtime deps

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -29,12 +29,20 @@ herbstluftwm (Alt-Shift-q or run herbstclient quit) to end testing.
 Running tests
 -------------
 
-Tests are run using pytest[1] and tox[2]. With tox and Xvfb[3] installed, you
-can run the following from the build directory:
+Tests are run using pytest[1] and tox[2]. In addition to tox,
+you'll have to install additional dependencies, in order to successfully
+run the complete test suite:
+
+  - xvfb[3]
+  - xdotool
+  - xsetroot
+  - xterm
+
+With everything installed, you can run the following from the build directory:
 
     tox -c ..  -- -v --maxfail=1
 
-If you run arch linux, it may be necessary to add -e py38 to the tox parameters
+If you run Arch Linux, it may be necessary to add -e py38 to the tox parameters
 (that is, before the --). If you have an old version of tox installed, it may be
 necessary to pass ../tox.ini instead of .. to the -c parameter.
 


### PR DESCRIPTION
In order to successfully run the whole suite, you need things like
xdotool and xsetroot.