### PR TITLE
X Properties with format 32 are arrays of long

### DIFF
--- a/ipc-client/ipc-client.c
+++ b/ipc-client/ipc-client.c
@@ -128,13 +128,14 @@ bool hc_send_command(HCConnection* con, int argc, char* argv[],
             output_received = true;
         }
         else if (!status_received && pe->atom == con->atom_status) {
-            int *value;
+            long* value;
             Atom type;
             int format;
             unsigned long items, bytes;
             if (Success != XGetWindowProperty(con->display, con->client_window,
                     XInternAtom(con->display, HERBST_IPC_STATUS_ATOM, False), 0, 1, False,
-                    XA_ATOM, &type, &format, &items, &bytes, (unsigned char**)&value)) {
+                    XA_ATOM, &type, &format, &items, &bytes, (unsigned char**)&value)
+                || format != 32) {
                     // if could not get window property
                 fprintf(stderr, "could not get WindowProperty \"%s\"\n",
                                 HERBST_IPC_STATUS_ATOM);
@@ -173,7 +174,7 @@ static int log_bad_window_error(Display* display, XErrorEvent* ev) {
 }
 
 static Window get_hook_window(Display* display) {
-    int *value; // list of ints
+    long* value;
     Atom type;
     int format;
     unsigned long items, bytes;
@@ -181,7 +182,7 @@ static Window get_hook_window(Display* display) {
         XInternAtom(display, HERBST_HOOK_WIN_ID_ATOM, False), 0, 1, False,
         XA_ATOM, &type, &format, &items, &bytes, (unsigned char**)&value);
     // only accept exactly one Window id
-    if (status != Success || items != 1) {
+    if (status != Success || items != 1 || format != 32) {
         return 0;
     }
     Window win = *value;

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -279,7 +279,7 @@ template<typename T> pair<Atom,vector<T>>
     Atom actual_type;
     int format;
     unsigned long bytes_left;
-    unsigned long* items_return;
+    long* items_return;
     unsigned long count;
     int status = XGetWindowProperty(display, window,
             property, 0, ULONG_MAX, False, AnyPropertyType,


### PR DESCRIPTION
The documentation for XGetWindowProperty[1] specifies that if the
format parameter is 32, then the data array must be an array of long.

The present commit fixes this both in the herbstluftwm and in the
herbstclient code.

[1] https://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html