### PR TITLE
Fix modulo computation for negative numbers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ Current git version
 
   * When an application fails to focus itself (because
     focus_stealing_prevention is actve), then the window is marked as urgent.
+  * Fix handling of delta -1 in 'focus_monitor' and 'cycle_monitor'
 
 Release 0.8.3 on 2020-06-06
 ---------------------------

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -724,9 +724,7 @@ int FrameTree::cycleLayoutCommand(Input input, Output output) {
         string curname = Converter<LayoutAlgorithm>::str(cur_frame->getLayout());
         size_t count = input.end() - input.begin();
         auto curposition = std::find(input.begin(), input.end(), curname);
-        size_t idx = (curposition - input.begin()) + delta;
-        idx += count;
-        idx %= count;
+        size_t idx = MOD((curposition - input.begin()) + delta, count);
         try {
             layout_index = (int)Converter<LayoutAlgorithm>::parse(*(input.begin() + idx));
         } catch (const std::exception& e) {
@@ -735,10 +733,7 @@ int FrameTree::cycleLayoutCommand(Input input, Output output) {
         }
     } else {
         /* cycle through the default list of layouts */
-        layout_index = (int)cur_frame->getLayout() + delta;
-        layout_index %= layoutAlgorithmCount();
-        layout_index += layoutAlgorithmCount();
-        layout_index %= layoutAlgorithmCount();
+        layout_index = MOD((int)cur_frame->getLayout() + delta, layoutAlgorithmCount());
     }
     cur_frame->setLayout((LayoutAlgorithm)layout_index);
     get_current_monitor()->applyLayout();

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -591,12 +591,8 @@ int monitor_cycle_command(int argc, char** argv) {
         delta = atoi(argv[1]);
     }
     int new_selection = g_monitors->cur_monitor + delta; // signed for delta calculations
-    // fix range of index
-    new_selection %= count;
-    new_selection += count;
-    new_selection %= count;
     // really change selection
-    monitor_focus_by_index((unsigned)new_selection);
+    monitor_focus_by_index((unsigned)MOD(new_selection, count));
     return 0;
 }
 

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -100,10 +100,7 @@ int MonitorManager::string_to_monitor_index(string str) {
         if (isdigit(str[1])) {
             // relative monitor index
             int idx = cur_monitor + atoi(str.c_str());
-            idx %= size();
-            idx += size();
-            idx %= size();
-            return idx;
+            return MOD(idx, size());
         } else if (str[0] == '-') {
             try {
                 auto dir = Converter<Direction>::parse(str.substr(1));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -36,6 +36,12 @@ time_t get_monotonic_timestamp() {
 }
 
 int MOD(int x, int n) {
+    // for the tests of this, see tests of cycle_monitor in test_monitor.py
+    if (n > 0) {
+        while (x < 0) {
+            x += n;
+        }
+    }
     return (((x % n) + n) % n);
 }
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -319,3 +319,22 @@ def test_list_padding(hlwm):
 def test_list_padding_invalid_monitor(hlwm):
     hlwm.call_xfail('list_padding 23') \
         .expect_stderr('Monitor.*not found')
+
+
+@pytest.mark.parametrize("mon_num,focus_idx", [
+    (num, focus) for num in [1, 2, 3, 4, 5] for focus in [0, num - 1]])
+@pytest.mark.parametrize("delta", ['-1', '+1'])
+@pytest.mark.parametrize("command", ['cycle_monitor', 'focus_monitor'])
+def test_cycle_monitor(hlwm, mon_num, focus_idx, delta, command):
+    """the present test also tests the MOD() function in utility.h"""
+    for i in range(1, mon_num):
+        hlwm.call('add tag' + str(i))
+        hlwm.call('add_monitor 800x600+' + str(i*10))
+    hlwm.call(['focus_monitor', str(focus_idx)])
+    assert hlwm.get_attr('monitors.focus.index') == str(focus_idx)
+    assert hlwm.get_attr('monitors.count') == str(mon_num)
+
+    hlwm.call([command, delta])
+
+    new_index = (focus_idx + int(delta) + mon_num) % mon_num
+    assert hlwm.get_attr('monitors.focus.index') == str(new_index)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -329,7 +329,7 @@ def test_cycle_monitor(hlwm, mon_num, focus_idx, delta, command):
     """the present test also tests the MOD() function in utility.h"""
     for i in range(1, mon_num):
         hlwm.call('add tag' + str(i))
-        hlwm.call('add_monitor 800x600+' + str(i*10))
+        hlwm.call('add_monitor 800x600+' + str(i * 10))
     hlwm.call(['focus_monitor', str(focus_idx)])
     assert hlwm.get_attr('monitors.focus.index') == str(focus_idx)
     assert hlwm.get_attr('monitors.count') == str(mon_num)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -326,7 +326,7 @@ def test_list_padding_invalid_monitor(hlwm):
 @pytest.mark.parametrize("delta", ['-1', '+1'])
 @pytest.mark.parametrize("command", ['cycle_monitor', 'focus_monitor'])
 def test_cycle_monitor(hlwm, mon_num, focus_idx, delta, command):
-    """the present test also tests the MOD() function in utility.h"""
+    """the present test also tests the MOD() function in utility.cpp"""
     for i in range(1, mon_num):
         hlwm.call('add tag' + str(i))
         hlwm.call('add_monitor 800x600+' + str(i * 10))


### PR DESCRIPTION
The fear of having an integer overflow caused the modulo implementation to
be wrong for negative numbers in various places of the source code. Of
course, -1 modulo 3 should be 2, and the present commit fixes this
accordingly in the MOD() utility function which is now used everywhere.