### PR TITLE
Use fixed precision decimals for frame fractions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ Current git version
   * When an application fails to focus itself (because
     focus_stealing_prevention is actve), then the window is marked as urgent.
   * Fix handling of delta -1 in 'focus_monitor' and 'cycle_monitor'
+  * Fixed precision decimals in the layout tree (more reliable in- and output
+    of fractions in frame splits)
 
 Release 0.8.3 on 2020-06-06
 ---------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(herbstluftwm PRIVATE
     desktopwindow.h desktopwindow.cpp
     entity.cpp entity.h
     ewmh.cpp ewmh.h
+    fixprecdec.cpp fixprecdec.h
     floating.cpp floating.h
     framedata.h framedata.cpp
     framedecoration.cpp framedecoration.h

--- a/src/fixprecdec.cpp
+++ b/src/fixprecdec.cpp
@@ -52,7 +52,7 @@ string Converter<FixPrecDec>::str(FixPrecDec payload)
     return payload.str();
 }
 
-std::string FixPrecDec::str() const
+string FixPrecDec::str() const
 {
     int v = value_;
     stringstream fmt;

--- a/src/fixprecdec.cpp
+++ b/src/fixprecdec.cpp
@@ -1,0 +1,81 @@
+#include "fixprecdec.h"
+
+#include <cctype>
+#include <exception>
+#include <string>
+#include <sstream>
+#include <vector>
+
+using std::string;
+using std::stringstream;
+using std::vector;
+
+const int FixPrecDec::unit_ = 10000;
+
+template<>
+FixPrecDec Converter<FixPrecDec>::parse(const string& source)
+{
+    vector<string> parts = ArgList::split(source, '.');
+    if (parts.size() > 2) {
+        throw std::invalid_argument("A decimal must have at most one \'.\'");
+    }
+    if (parts[0].size() == 0) {
+        throw std::invalid_argument("There must be at least oen digit before \'.\'");
+    }
+    // check the signum from the string, because the signum may get lost if
+    // parts[0] is "-0"
+    int signum = (parts[0][0] == '-') ? -1 : 1;
+    int value = Converter<int>::parse(parts[0]) * FixPrecDec::unit_;
+    if (parts.size() == 1) {
+        // no decimal separator, so nothing more to parse
+        return FixPrecDec::raw(value);
+    }
+    int remaining_unit = FixPrecDec::unit_;
+    for (char ch : parts[1]) {
+        if (!isdigit(ch)) {
+            throw std::invalid_argument("After \'.\' only digits may follow");
+        }
+        remaining_unit /= 10;
+        // we can add digits after the decimal separator, but we need
+        // to subtract if the entire number is negative
+        value += signum * (ch - '0') * remaining_unit;
+        if (remaining_unit == 0) {
+            break;
+        }
+    }
+    return FixPrecDec::raw(value);
+}
+
+template<>
+string Converter<FixPrecDec>::str(FixPrecDec payload)
+{
+    int v = payload.value_;
+    stringstream fmt;
+    if (v < 0) {
+        fmt << "-";
+        v *= -1;
+    }
+    // from now on, we can act as if the value is positive (this makes modulo easier)
+    fmt << (v / payload.unit_);
+    v %= payload.unit_;
+    if (v != 0) {
+        fmt << ".";
+        int remaining_unit = payload.unit_;
+        while (v != 0) {
+            remaining_unit /= 10;
+            fmt << (v / remaining_unit);
+            v %= remaining_unit;
+        }
+    }
+    return fmt.str();
+}
+
+bool FixPrecDec::operator<(double other)
+{
+    return value_ < other * unit_;
+}
+
+bool FixPrecDec::operator>(double other)
+{
+    return value_ > other * unit_;
+}

--- a/src/fixprecdec.cpp
+++ b/src/fixprecdec.cpp
@@ -2,8 +2,8 @@
 
 #include <cctype>
 #include <exception>
-#include <string>
 #include <sstream>
+#include <string>
 #include <vector>
 
 using std::string;

--- a/src/fixprecdec.cpp
+++ b/src/fixprecdec.cpp
@@ -19,8 +19,8 @@ FixPrecDec Converter<FixPrecDec>::parse(const string& source)
     if (parts.size() > 2) {
         throw std::invalid_argument("A decimal must have at most one \'.\'");
     }
-    if (parts[0].size() == 0) {
-        throw std::invalid_argument("There must be at least oen digit before \'.\'");
+    if (parts[0].empty()) {
+        throw std::invalid_argument("There must be at least one digit before \'.\'");
     }
     // check the signum from the string, because the signum may get lost if
     // parts[0] is "-0"

--- a/src/fixprecdec.cpp
+++ b/src/fixprecdec.cpp
@@ -49,18 +49,23 @@ FixPrecDec Converter<FixPrecDec>::parse(const string& source)
 template<>
 string Converter<FixPrecDec>::str(FixPrecDec payload)
 {
-    int v = payload.value_;
+    return payload.str();
+}
+
+std::string FixPrecDec::str() const
+{
+    int v = value_;
     stringstream fmt;
     if (v < 0) {
         fmt << "-";
         v *= -1;
     }
     // from now on, we can act as if the value is positive (this makes modulo easier)
-    fmt << (v / payload.unit_);
-    v %= payload.unit_;
+    fmt << (v / unit_);
+    v %= unit_;
     if (v != 0) {
         fmt << ".";
-        int remaining_unit = payload.unit_;
+        int remaining_unit = unit_;
         while (v != 0) {
             remaining_unit /= 10;
             fmt << (v / remaining_unit);
@@ -78,4 +83,15 @@ bool FixPrecDec::operator<(double other)
 bool FixPrecDec::operator>(double other)
 {
     return value_ > other * unit_;
+}
+
+/**
+ * @brief Construct a FixPrecDec that roughly is the given fraction
+ * @param nominator
+ * @param denominator
+ * @return
+ */
+FixPrecDec FixPrecDec::approxFrac(int nominator, int denominator)
+{
+    return unit_ * nominator / denominator;
 }

--- a/src/fixprecdec.h
+++ b/src/fixprecdec.h
@@ -12,8 +12,20 @@ class FixPrecDec
 public:
     int value_;
     static const int unit_; //! the number one encoded as a FixPrecDec
+
+    std::string str() const;
+
     bool operator<(double other);
     bool operator>(double other);
+
+    bool operator<(FixPrecDec other) {
+        return value_ < other.value_;
+    }
+
+    bool operator>(FixPrecDec other) {
+        return value_ > other.value_;
+    }
+
     static FixPrecDec fromInteger(int integer) {
         return integer * unit_;
     }
@@ -28,6 +40,7 @@ public:
         return value_ / divisor;
     }
     static FixPrecDec raw(int value) { return value; }
+    static FixPrecDec approxFrac(int nominator, int denominator);
 private:
     FixPrecDec(int value) : value_(value) {}
 };

--- a/src/fixprecdec.h
+++ b/src/fixprecdec.h
@@ -1,0 +1,39 @@
+#ifndef FIXPRECDEC_H
+#define FIXPRECDEC_H
+
+#include "types.h"
+
+/**
+ * @brief A class for fixed precision decimals encoded in the type int.
+ * The unit is globally fixed to FixPrecDec::unit_;
+ */
+class FixPrecDec
+{
+public:
+    int value_;
+    static const int unit_; //! the number one encoded as a FixPrecDec
+    bool operator<(double other);
+    bool operator>(double other);
+    static FixPrecDec fromInteger(int integer) {
+        return integer * unit_;
+    }
+
+    FixPrecDec operator+(FixPrecDec other) {
+        return value_ + other.value_;
+    }
+    FixPrecDec operator-(FixPrecDec other) {
+        return value_ - other.value_;
+    }
+    FixPrecDec operator/(int divisor) {
+        return value_ / divisor;
+    }
+    static FixPrecDec raw(int value) { return value; }
+private:
+    FixPrecDec(int value) : value_(value) {}
+};
+
+template<> FixPrecDec Converter<FixPrecDec>::parse(const std::string& source);
+template<> std::string Converter<FixPrecDec>::str(FixPrecDec payload);
+
+
+#endif // FIXPRECDEC_H

--- a/src/framedata.h
+++ b/src/framedata.h
@@ -16,9 +16,8 @@
 #include <memory>
 #include <vector>
 
+#include "fixprecdec.h"
 #include "types.h"
-
-#define FRACTION_UNIT 10000
 
 class Client;
 
@@ -59,8 +58,6 @@ protected:
 
     /*!
      * Size of first child relative to whole size.
-     * For example, a value of FRACTION_UNIT means full size
-     * and FRACTION_UNIT/2 means 50%.
      */
-    int fraction_ = 0;
+    FixPrecDec fraction_ = FixPrecDec::fromInteger(0);
 };

--- a/src/frameparser.cpp
+++ b/src/frameparser.cpp
@@ -4,8 +4,8 @@
 #include <sstream>
 
 #include "arglist.h"
-#include "globals.h"
 #include "fixprecdec.h"
+#include "globals.h"
 #include "hlwmcommon.h"
 #include "root.h"
 #include "x11-types.h"

--- a/src/frameparser.cpp
+++ b/src/frameparser.cpp
@@ -5,6 +5,7 @@
 
 #include "arglist.h"
 #include "globals.h"
+#include "fixprecdec.h"
 #include "hlwmcommon.h"
 #include "root.h"
 #include "x11-types.h"
@@ -117,18 +118,18 @@ shared_ptr<RawFrameNode> FrameParser::buildTree() {
         }
         try {
             node->align_ = Converter<SplitAlign>::parse(alignName);
-            double fraction = std::stod(fractionStr);
+            FixPrecDec fraction = Converter<FixPrecDec>::parse(fractionStr);
             if (fraction < FRAME_MIN_FRACTION
-                || fraction > 1 - FRAME_MIN_FRACTION)
+                || fraction > (1 - FRAME_MIN_FRACTION))
             {
                 stringstream message;
                 message << "Fraction must be between "
                         <<  FRAME_MIN_FRACTION << " and "
                         << (1 - FRAME_MIN_FRACTION)
-                        << " but actually is " << fraction;
+                        << " but actually is " << Converter<FixPrecDec>::str(fraction);
                 throw std::invalid_argument(message.str());
             }
-            node->fraction_ = fraction * FRACTION_UNIT;
+            node->fraction_ = fraction;
             node->selection_ = std::stoi(selectionStr);
             if (node->selection_ != 0 && node->selection_ != 1) {
                 throw std::invalid_argument("selection must be 0 or 1");

--- a/src/frameparser.cpp
+++ b/src/frameparser.cpp
@@ -120,12 +120,12 @@ shared_ptr<RawFrameNode> FrameParser::buildTree() {
             node->align_ = Converter<SplitAlign>::parse(alignName);
             FixPrecDec fraction = Converter<FixPrecDec>::parse(fractionStr);
             if (fraction < FRAME_MIN_FRACTION
-                || fraction > (1 - FRAME_MIN_FRACTION))
+                || fraction > (FixPrecDec::fromInteger(1) - FRAME_MIN_FRACTION))
             {
                 stringstream message;
                 message << "Fraction must be between "
-                        <<  FRAME_MIN_FRACTION << " and "
-                        << (1 - FRAME_MIN_FRACTION)
+                        <<  FRAME_MIN_FRACTION.str() << " and "
+                        << (FixPrecDec::fromInteger(1) - FRAME_MIN_FRACTION).str()
                         << " but actually is " << Converter<FixPrecDec>::str(fraction);
                 throw std::invalid_argument(message.str());
             }

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -825,7 +825,13 @@ int FrameTree::splitCommand(Input input, Output output)
         return HERBST_NEED_MORE_ARGS;
     }
     bool userDefinedFraction = input >> strFraction;
-    FixPrecDec fraction = Converter<FixPrecDec>::parse(strFraction);
+    FixPrecDec fraction = FixPrecDec::fromInteger(0);
+    try {
+        fraction = Converter<FixPrecDec>::parse(strFraction);
+    }  catch (const std::exception& e) {
+        output << "invalid argument: " << e.what() << endl;
+        return HERBST_INVALID_ARGUMENT;
+    }
     fraction = FrameSplit::clampFraction(fraction);
     auto frame = focusedFrame();
     int lh = frame->lastRect().height;

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -7,6 +7,7 @@
 
 #include "client.h"
 #include "completion.h"
+#include "fixprecdec.h"
 #include "framedata.h"
 #include "frameparser.h"
 #include "ipc-protocol.h"
@@ -56,7 +57,7 @@ void FrameTree::dump(shared_ptr<Frame> frame, Output output)
             << "(split "
             << Converter<SplitAlign>::str(s->align_)
             << ":"
-            << ((double)s->fraction_) / (double)FRACTION_UNIT
+            << Converter<FixPrecDec>::str(s->fraction_)
             << ":"
             << s->selection_
             << " ";
@@ -210,7 +211,7 @@ int FrameTree::rotateCommand() {
                     s->align_ = SplitAlign::vertical;
                     s->selection_ = s->selection_ ? 0 : 1;
                     swap(s->a_, s->b_);
-                    s->fraction_ = FRACTION_UNIT - s->fraction_;
+                    s->fraction_ = FixPrecDec::fromInteger(1) - s->fraction_;
                     break;
             }
         };
@@ -261,7 +262,8 @@ shared_ptr<TreeInterface> FrameTree::treeInterface(
         size_t childCount() override { return 2; };
         void appendCaption(Output output) override {
             output << " " << Converter<SplitAlign>::str(s_->align_)
-                   << " " << (s_->fraction_ * 100 / FRACTION_UNIT) << "%"
+                   << " " << (s_->fraction_.value_ * 100 / s_->fraction_.unit_)
+                   << "%"
                    << " selection=" << s_->selection_;
         }
     private:
@@ -372,14 +374,13 @@ bool FrameTree::contains(shared_ptr<Frame> frame) const
 
 //! resize the borders of the focused client in the specific direction by 'delta'
 //! returns whether the focused frame has a border in the specified direction.
-bool FrameTree::resizeFrame(double delta_double, Direction direction)
+bool FrameTree::resizeFrame(FixPrecDec delta, Direction direction)
 {
-    int delta = int(FRACTION_UNIT * delta_double);
     // if direction is left or up we have to flip delta
     // because e.g. resize up by 0.1 actually means:
     // reduce fraction by 0.1, i.e. delta = -0.1
     if (direction == Direction::Left || direction == Direction::Up) {
-        delta *= -1;
+        delta.value_ = delta.value_ * -1;
     }
 
     shared_ptr<Frame> neighbour = focusedFrame()->neighbour(direction);
@@ -819,13 +820,13 @@ vector<SplitMode> SplitMode::modes(SplitAlign align_explode, SplitAlign align_au
 int FrameTree::splitCommand(Input input, Output output)
 {
     // usage: split t|b|l|r|h|v FRACTION
-    string splitType, strFraction;
+    string splitType, strFraction = "0.5";
     if (!(input >> splitType )) {
         return HERBST_NEED_MORE_ARGS;
     }
     bool userDefinedFraction = input >> strFraction;
-    double fractionFloat = userDefinedFraction ? atof(strFraction.c_str()) : 0.5;
-    int fraction = FrameSplit::clampFraction(FRACTION_UNIT * fractionFloat);
+    FixPrecDec fraction = Converter<FixPrecDec>::parse(strFraction);
+    fraction = FrameSplit::clampFraction(fraction);
     auto frame = focusedFrame();
     int lh = frame->lastRect().height;
     int lw = frame->lastRect().width;
@@ -860,7 +861,7 @@ int FrameTree::splitCommand(Input input, Output output)
         if ((layout == LayoutAlgorithm::horizontal
             || layout == LayoutAlgorithm::vertical)
             && !userDefinedFraction && count1 > 1) {
-            fraction = (nc1 * FRACTION_UNIT) / count1;
+            fraction.value_ = (nc1 * fraction.unit_) / count1;
         }
     }
     // move second half of the window buf to second frame

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 
+#include "fixprecdec.h"
 #include "types.h"
 
 class Client;
@@ -49,7 +50,7 @@ public:
         End,
     };
 
-    bool resizeFrame(double delta, Direction dir);
+    bool resizeFrame(FixPrecDec delta, Direction dir);
 
     // Commands
     int cycleSelectionCommand(Input input, Output output);

--- a/src/globals.h
+++ b/src/globals.h
@@ -12,7 +12,7 @@
 #define WINDOW_MIN_WIDTH 32
 
 // minimum relative fraction of split frames
-#define FRAME_MIN_FRACTION 0.1
+#define FRAME_MIN_FRACTION FixPrecDec::approxFrac(1, 10) // 0.1
 
 #define HERBST_MAX_TREE_HEIGHT 3
 

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -519,10 +519,14 @@ void FrameSplit::setFraction(FixPrecDec fraction)
 
 FixPrecDec FrameSplit::clampFraction(FixPrecDec fraction)
 {
-    fraction.value_
-            = CLAMP(fraction.value_,
-                    fraction.unit_ * (0.0 + FRAME_MIN_FRACTION),
-                    fraction.unit_ * (1.0 - FRAME_MIN_FRACTION));
+    auto minFrac = FRAME_MIN_FRACTION;
+    auto maxFrac = FixPrecDec::fromInteger(1) - minFrac;
+    if (fraction < minFrac) {
+        return minFrac;
+    }
+    if (fraction > maxFrac) {
+        return maxFrac;
+    }
     return fraction;
 }
 

--- a/src/layout.h
+++ b/src/layout.h
@@ -114,7 +114,7 @@ public:
 
     Client* focusedClient() override;
 
-    bool split(SplitAlign alignment, int fraction, size_t childrenLeaving = 0);
+    bool split(SplitAlign alignment, FixPrecDec fraction, size_t childrenLeaving = 0);
     LayoutAlgorithm getLayout() { return layout; }
     void setLayout(LayoutAlgorithm l) { layout = l; }
     int getSelection() { return selection; }
@@ -143,7 +143,7 @@ private:
 
 class FrameSplit : public Frame, public FrameDataSplit<Frame> {
 public:
-    FrameSplit(HSTag* tag, Settings* settings, std::weak_ptr<FrameSplit> parent, int fraction_, SplitAlign align_,
+    FrameSplit(HSTag* tag, Settings* settings, std::weak_ptr<FrameSplit> parent, FixPrecDec fraction_, SplitAlign align_,
                  std::shared_ptr<Frame> a_, std::shared_ptr<Frame> b_);
     ~FrameSplit() override;
     // inherited:
@@ -164,10 +164,10 @@ public:
     std::shared_ptr<Frame> secondChild() { return b_; }
     std::shared_ptr<Frame> selectedChild() { return selection_ ? b_ : a_; }
     void swapChildren();
-    void adjustFraction(int delta);
-    void setFraction(int fraction);
-    int getFraction() const { return fraction_; }
-    static int clampFraction(int fraction);
+    void adjustFraction(FixPrecDec delta);
+    void setFraction(FixPrecDec fraction);
+    FixPrecDec getFraction() const { return fraction_; }
+    static FixPrecDec clampFraction(FixPrecDec fraction);
     std::shared_ptr<FrameSplit> thisSplit();
     std::shared_ptr<FrameSplit> isSplit() override { return thisSplit(); }
     SplitAlign getAlign() { return align_; }

--- a/src/mousedraghandler.cpp
+++ b/src/mousedraghandler.cpp
@@ -290,15 +290,15 @@ void MouseResizeFrame::handle_motion_event(Point2D newCursorPos)
     }
 
     auto deltaVec = newCursorPos - buttonDragStart_;
-    double delta;
+    int delta;
     if (df->getAlign() == SplitAlign::vertical) {
         delta = deltaVec.y;
     } else {
         delta = deltaVec.x;
     }
     // translate delta from 'pixels' to 'FRACTION_UNIT'
-    delta = (delta * FRACTION_UNIT) / dragDistanceUnit_;
-    df->setFraction(dragStartFraction_ + (int)delta);
+    delta = (delta * dragStartFraction_.unit_) / dragDistanceUnit_;
+    df->setFraction(dragStartFraction_ + FixPrecDec::raw(delta));
     dragMonitor_->applyLayout();
 }
 

--- a/src/mousedraghandler.h
+++ b/src/mousedraghandler.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <memory>
 
+#include "fixprecdec.h"
 #include "x11-types.h"
 
 class Client;
@@ -90,7 +91,7 @@ private:
     MonitorManager*  monitors_;
     Point2D          buttonDragStart_ = {};
     std::weak_ptr<FrameSplit> dragFrame_; //! the frame whose split is adjusted
-    int              dragStartFraction_; //! initial fraction
+    FixPrecDec       dragStartFraction_ = FixPrecDec::fromInteger(0); //! initial fraction
     int              dragDistanceUnit_; //! 100% split ratio in pixels
     HSTag*           dragTag_; //! the tag containing the dragFrame
     Monitor*         dragMonitor_ = nullptr; //! the monitor with the dragFrame

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -357,9 +357,13 @@ int HSTag::resizeCommand(Input input, Output output)
     if (!(input >> dir_str)) {
         return HERBST_NEED_MORE_ARGS;
     }
+    string delta_str = "0.02";
+    input >> delta_str; // try reading
     Direction direction;
+    FixPrecDec delta = FixPrecDec::fromInteger(0);
     try {
         direction = Converter<Direction>::parse(dir_str);
+        delta = Converter<FixPrecDec>::parse(delta_str);
     } catch (const std::exception& e) {
         output << input.command() << ": " << e.what() << "\n";
         return HERBST_INVALID_ARGUMENT;
@@ -371,9 +375,6 @@ int HSTag::resizeCommand(Input input, Output output)
             return HERBST_FORBIDDEN;
         }
     } else {
-        string delta_str = "0.02";
-        input >> delta_str; // try reading
-        FixPrecDec delta = Converter<FixPrecDec>::parse(delta_str);
         if (!frame->resizeFrame(delta, direction)) {
             output << input.command() << ": No neighbour found\n";
             return HERBST_FORBIDDEN;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -371,12 +371,10 @@ int HSTag::resizeCommand(Input input, Output output)
             return HERBST_FORBIDDEN;
         }
     } else {
-        double delta_double = 0.02;
-        string delta_str;
-        if (input >> delta_str) {
-            delta_double = atof(delta_str.c_str());
-        }
-        if (!frame->resizeFrame(delta_double, direction)) {
+        string delta_str = "0.02";
+        input >> delta_str; // try reading
+        FixPrecDec delta = Converter<FixPrecDec>::parse(delta_str);
+        if (!frame->resizeFrame(delta, direction)) {
             output << input.command() << ": No neighbour found\n";
             return HERBST_FORBIDDEN;
         }

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -2,6 +2,7 @@ import pytest
 import re
 import math
 import textwrap
+from decimal import Decimal
 
 
 @pytest.mark.parametrize("running_clients_num", [0, 1, 2])
@@ -545,8 +546,8 @@ def test_resize_flat_split(hlwm, splittype, dir_work, dir_dummy):
         assert new_layout[0:len(layout_prefix)] == layout_prefix
         assert new_layout[-len(layout_suffix):] == layout_suffix
         new_fraction_str = new_layout[len(layout_prefix):-len(layout_suffix)]
-        expected_fraction = float(0.4 + signum * 0.1)
-        assert math.isclose(float(new_fraction_str), expected_fraction, abs_tol=0.001)
+        expected_fraction = Decimal('0.4') + Decimal(signum) * Decimal('0.1')
+        assert new_fraction_str == str(expected_fraction)
 
     for d in dir_dummy:
         hlwm.call(['load', layout_format.format('0.4')])
@@ -589,15 +590,17 @@ def test_resize_nested_split(hlwm):
     for d, signum in [('left', -1), ('right', 1)]:
         hlwm.call(['load', layout])  # reset layout
         hlwm.call(['resize', d, '+0.05'])
-        fraction = float(hlwm.call('dump').stdout.split(':')[1])
-        assert math.isclose(fraction, 0.2 + signum * 0.05, abs_tol=0.001)
+        fraction = hlwm.call('dump').stdout.split(':')[1]
+        expected = Decimal('0.2') + signum * Decimal('0.05')
+        assert fraction == str(expected)
 
     # resize the nested split
     for d, signum in [('up', -1), ('down', 1)]:
         hlwm.call(['load', layout])  # reset layout
         hlwm.call(['resize', d, '+0.05'])
-        fraction = float(hlwm.call('dump').stdout.split(':')[3])
-        assert math.isclose(fraction, 0.3 + signum * 0.05, abs_tol=0.001)
+        fraction = hlwm.call('dump').stdout.split(':')[3]
+        expected = Decimal('0.3') + signum * Decimal('0.05')
+        assert fraction == str(expected)
 
 
 @pytest.mark.parametrize('layout', [

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -747,11 +747,11 @@ def test_split_invalid_argument(hlwm):
         ('0.+8', "After '.' only digits"),
         ('0.-8', "After '.' only digits"),
         ('0..0', "A decimal must have at most one '.'"),
-        ('.3',   "There must be at least one digit"),
-        ('.',    "There must be at least one digit"),
-        ('b',    "stoi"),
-        ('-.3',  "stoi"),
-        ('+.8',  "stoi"),
+        ('.3', "There must be at least one digit"),
+        ('.', "There must be at least one digit"),
+        ('b', "stoi"),
+        ('-.3', "stoi"),
+        ('+.8', "stoi"),
     ]
     for d, msg in wrongDecimal:
         hlwm.call_xfail(['split', 'top', d]) \

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -741,11 +741,17 @@ def test_tree_style_utf8(hlwm):
 
 
 def test_split_invalid_argument(hlwm):
+    # this also tests all exceptions in Converter<FixPrecDec>::parse()
     wrongDecimal = [
         ('0.0f', "After '.' only digits"),
+        ('0.+8', "After '.' only digits"),
+        ('0.-8', "After '.' only digits"),
+        ('0..0', "A decimal must have at most one '.'"),
         ('.3',   "There must be at least one digit"),
         ('.',    "There must be at least one digit"),
         ('b',    "stoi"),
+        ('-.3',  "stoi"),
+        ('+.8',  "stoi"),
     ]
     for d, msg in wrongDecimal:
         hlwm.call_xfail(['split', 'top', d]) \

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -349,7 +349,7 @@ def test_cycle_frame_traverses_all(hlwm, running_clients, num_splits, delta):
 
 def test_cycle_frame_invalid_delta(hlwm):
     hlwm.call_xfail(['cycle_frame', 'df8']) \
-        .expect_stderr('invalid argument')
+        .expect_stderr('invalid argument: stoi')
     hlwm.call_xfail(['cycle_frame', '-230984209340']) \
         .expect_stderr('out of range')
 
@@ -742,11 +742,14 @@ def test_tree_style_utf8(hlwm):
 
 def test_split_invalid_argument(hlwm):
     wrongDecimal = [
-        '0.0f', '.3', '.', 'b',
+        ('0.0f', "After '.' only digits"),
+        ('.3',   "There must be at least one digit"),
+        ('.',    "There must be at least one digit"),
+        ('b',    "stoi"),
     ]
-    for d in wrongDecimal:
+    for d, msg in wrongDecimal:
         hlwm.call_xfail(['split', 'top', d]) \
-            .expect_stderr('invalid argument')
+            .expect_stderr('invalid argument: ' + msg)
 
 
 def test_split_clamp_argument_smaller(hlwm):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -135,3 +135,34 @@ def test_load_brings_windows(hlwm, running_clients, running_clients_num, num_bri
 def test_load_invalid_tag(hlwm):
     hlwm.call_xfail(['load', 'invalidtagname', '(clients vertical:0)']) \
         .expect_stderr(r'Tag.*not found')
+
+
+def test_fraction_precision(hlwm):
+    values = [
+        '0.4', '0.305', '0.8987',
+        '0.5', '0.4001'
+    ]
+    layout_format = '(split horizontal:{}:0 (clients max:0) (clients max:0))'
+    for v in values:
+        layout = layout_format.format(v)
+        hlwm.call(['load', layout])
+        assert hlwm.call('dump').stdout == layout
+
+
+def test_fraction_precision_outside_range(hlwm):
+    # here, we test the decimal i/o for values that are outside
+    # of the allowed frame-split-ratio. This test only makes sense
+    # because we know that in FrameParser::buildTree(), the already
+    # parsed decimal is used for the error message
+    values = [
+        '0.098',
+        '-0.098',
+        '-0.5',
+        '12.43',
+        '-110.01',
+    ]
+    layout_format = '(split horizontal:{}:0 (clients max:0) (clients max:0))'
+    for v in values:
+        layout = layout_format.format(v)
+        hlwm.call_xfail(['load', layout]) \
+            .expect_stderr('but actually is ' + v)


### PR DESCRIPTION
We introduce a new class FixPrecDec that encapsulates in- and output of
fixed precision decimal numbers, and we use them for reading and
printing the fractions in the frame layout tree.

This solves #936.