### PR TITLE
Add pgid (process group id) as rule condition

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ Current git version
   * Fix handling of delta -1 in 'focus_monitor' and 'cycle_monitor'
   * Fixed precision decimals in the layout tree (more reliable in- and output
     of fractions in frame splits)
+  * New rule condition 'pgid'
 
 Release 0.8.3 on 2020-06-06
 ---------------------------

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1174,6 +1174,10 @@ Valid 'properties' are:
     the client's process id (Warning: the pid is not available for every client.
     This only matches if the client sets _NET_WM_PID to the pid itself).
 
++pgid+::
+    this client's process group id. Since the pgid of a window is  is derived from
+    its +pid+ the same restrictions apply as above.
+
 +maxage+::
     matches if the age of the rule measured in seconds does not exceed 'value'.
     This condition only can be used with the +=+ operator. If maxage already is

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1175,7 +1175,7 @@ Valid 'properties' are:
     This only matches if the client sets _NET_WM_PID to the pid itself).
 
 +pgid+::
-    this client's process group id. Since the pgid of a window is  is derived from
+    this client's process group id. Since the pgid of a window is derived from
     its +pid+ the same restrictions apply as above.
 
 +maxage+::

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -44,6 +44,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , keyMask_(this,  "keymask", RegexStr::fromStr(""))
     , keysInactive_(this,  "keys_inactive", RegexStr::fromStr(""))
     , pid_(this,  "pid", -1)
+    , pgid_(this, "pgid", -1)
     , pseudotile_(this,  "pseudotile", false)
     , ewmhrequests_(this, "ewmhrequests", true)
     , ewmhnotify_(this, "ewmhnotify", true)
@@ -93,6 +94,7 @@ void Client::init_from_X() {
     last_size_ = float_size_;
 
     pid_ = Root::get()->X.windowPid(window_);
+    pgid_ = Root::get()->X.windowPgid(window_);
 
     update_title();
     update_wm_hints();

--- a/src/client.h
+++ b/src/client.h
@@ -63,6 +63,7 @@ public:
     Attribute_<RegexStr> keyMask_; // regex for key bindings that are active on this window
     Attribute_<RegexStr> keysInactive_; // regex for key bindings that are inactive on this window
     Attribute_<int>  pid_;
+    Attribute_<int>  pgid_;
     Attribute_<bool> pseudotile_; // only move client but don't resize (if possible)
     Attribute_<bool> ewmhrequests_; // accept ewmh-requests for this client
     Attribute_<bool> ewmhnotify_; // send ewmh-notifications for this client

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -19,6 +19,7 @@ const std::map<string, Condition::Matcher> Condition::matchers = {
     { "instance",       &Condition::matchesInstance          },
     { "title",          &Condition::matchesTitle             },
     { "pid",            &Condition::matchesPid               },
+    { "pgid",           &Condition::matchesPgid              },
     { "maxage",         &Condition::matchesMaxage            },
     { "windowtype",     &Condition::matchesWindowtype        },
     { "windowrole",     &Condition::matchesWindowrole        },
@@ -214,6 +215,19 @@ bool Condition::matchesPid(const Client* client) const {
     } else {
         char buf[1000]; // 1kb ought to be enough for every int
         sprintf(buf, "%d", client->pid_());
+        return matches(buf);
+    }
+}
+
+bool Condition::matchesPgid(const Client* client) const {
+    if (client->pgid_() < 0) {
+        return false;
+    }
+    if (value_type == CONDITION_VALUE_TYPE_INTEGER) {
+        return value_integer == client->pgid_;
+    } else {
+        char buf[1000]; // 1kb ought to be enough for every int
+        sprintf(buf, "%d", client->pgid_());
         return matches(buf);
     }
 }

--- a/src/rules.h
+++ b/src/rules.h
@@ -49,6 +49,7 @@ private:
     bool matchesInstance(const Client* client) const;
     bool matchesTitle(const Client* client) const;
     bool matchesPid(const Client* client) const;
+    bool matchesPgid(const Client* client) const;
     bool matchesMaxage(const Client* client) const;
     bool matchesWindowtype(const Client* client) const;
     bool matchesWindowrole(const Client* client) const;

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -6,6 +6,7 @@
 #include <X11/Xutil.h>
 #include <climits>
 #include <iostream>
+#include <unistd.h>
 
 #include "globals.h"
 
@@ -152,6 +153,15 @@ int XConnection::windowPid(Window window) {
     } else {
         return res.value()[0];
     }
+}
+
+//! The pgid of a window or -1 if the pid is not set
+int XConnection::windowPgid(Window window) {
+    auto pid = windowPid(window);
+    if (pid == -1) {
+        return -1;
+    }
+    return getpgid(pid);
 }
 
 //! wrapper around XGetClassHint returning the window's instance and class name

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -4,9 +4,9 @@
 #include <X11/Xlib.h>
 #include <X11/Xproto.h>
 #include <X11/Xutil.h>
+#include <unistd.h>
 #include <climits>
 #include <iostream>
-#include <unistd.h>
 
 #include "globals.h"
 

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -25,6 +25,7 @@ public:
     static const char* requestCodeToString(int requestCode);
     Rectangle windowSize(Window window);
     int windowPid(Window window);
+    int windowPgid(Window window);
     Atom atom(const char* atom_name);
     std::string atomName(Atom atomIdentifier);
     std::pair<std::string, std::string> getClassHint(Window win);

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -11,6 +11,7 @@ string_props = [
 
 numeric_props = [
     'pid',
+    'pgid',
     'maxage',
 ]
 


### PR DESCRIPTION
I use a slightly modified version of `exec_on_tag.sh` to start applications. This works mostly fine with the exception of a starter application forking into the actual application (e.g. eclipse, IntelliJ Idea, Microsoft Teams). For these cases `pgid` is a lot more usefull as it's the same for all applications. With an adjusted timeout and the `once` modifier removed from the rule this leads to the desired behavior of not only having the splash screen but also the actual application spawn on the tag where it was started.

I recon that getting the `pgid` is mostly not trivial but e.g. my small tool [getpgid](https://github.com/wilriker/getpgid) can be used for this purpose.