### PR TITLE
Reset cursor position before every test case

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -875,6 +875,9 @@ def keyboard():
 @pytest.fixture()
 def mouse(hlwm_process, hlwm):
     class Mouse:
+        def __init__(self):
+            self.move_to(0, 0, wait=True)
+
         def move_into(self, win_id, x=1, y=1, wait=True):
             if wait:
                 with hlwm_process.wait_stderr_match('EnterNotify'):

--- a/tests/test_basic_events.py
+++ b/tests/test_basic_events.py
@@ -37,7 +37,8 @@ def test_focus_follows_mouse(hlwm, mouse, focus_follows_mouse, single_floating):
         hlwm.call('set_attr tags.focus.floating on')
     hlwm.call('set_attr tags.focus.floating on')
     hlwm.call(['set', 'focus_follows_mouse', hlwm.bool(focus_follows_mouse)])
-    c1, _ = hlwm.create_client(position=(0, 0))
+    mouse.move_to(0, 0)  # make sure that the cursor is not within any of the new windows
+    c1, _ = hlwm.create_client(position=(10, 0))
     c2, _ = hlwm.create_client(position=(300, 0))
     hlwm.call(f'jumpto {c2}')  # also raises c2
     assert hlwm.get_attr('clients.focus.winid') == c2
@@ -81,14 +82,8 @@ def test_focus_frame_by_mouse(hlwm, mouse, click, focus_follows_mouse):
         == hlwm.call('dump').stdout
 
 
-@pytest.mark.parametrize("click,focus_follows_mouse", [
-    (False, False),
-    (True, False),
-    (True, True)
-    #  FIXME: here, hlwm doesn't get an EnterNotify event in xvfb
-    # but it works in Xephyr.
-    # (False, True)
-])
+@pytest.mark.parametrize("click", [True, False])
+@pytest.mark.parametrize("focus_follows_mouse", [True, False])
 def test_focus_client_by_decoration(hlwm, mouse, x11, click, focus_follows_mouse):
     hlwm.call('attr theme.border_width 50')
     hlwm.call('attr theme.active.color red')
@@ -102,7 +97,7 @@ def test_focus_client_by_decoration(hlwm, mouse, x11, click, focus_follows_mouse
     # move mouse to the decoration:
     decwin = x11.get_decoration_window(x11.window(winids[1]))
     # here, xdotool hangs on the second invokation of this testcase
-    mouse.move_into(x11.winid_str(decwin), 10, 10, wait=False)
+    mouse.move_into(x11.winid_str(decwin), 10, 10)
     if click:
         mouse.click('1')
     expected_focus = 1 if focus_follows_mouse or click else 0

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -111,7 +111,7 @@ def test_drag_move(hlwm, x11, mouse, repeat):
     client, winid = x11.create_client()
     x, y = x11.get_absolute_top_left(client)
     # Just positioning the mouse pointer, no need to wait for hlwm
-    mouse.move_into(winid, wait=False)
+    mouse.move_into(winid, wait=True)
 
     hlwm.call(['drag', winid, 'move'])
     mouse.move_relative(12, 15)

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -110,7 +110,6 @@ def test_drag_move(hlwm, x11, mouse, repeat):
     hlwm.call('set_attr tags.focus.floating on')
     client, winid = x11.create_client()
     x, y = x11.get_absolute_top_left(client)
-    # Just positioning the mouse pointer, no need to wait for hlwm
     mouse.move_into(winid, wait=True)
 
     hlwm.call(['drag', winid, 'move'])


### PR DESCRIPTION
In the setup of the 'mouse' fixture, we reset the cursor to (0, 0). This
now fixes some issues where EnterNotify events were not produced
(because the cursor was already on the window).

In particular, we now support all parameter combinations in the test
case test_focus_client_by_decoration.