### PR TITLE
Add timeout for each test case

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,3 +42,6 @@ ignore =
 [pytest]
 markers =
     exclude_from_coverage: Some tests are not relevant for the coverage report
+# get python stacktrace when a test takes more than 'faulthandler_timeout' secs
+# https://docs.pytest.org/en/latest/reference.html#confval-faulthandler_timeout
+faulthandler_timeout = 240


### PR DESCRIPTION
Maybe this helps us to find out more about the strange freezes between
test cases (#954).