### PR TITLE
Document that some settings are aliases to theme.

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -982,23 +982,35 @@ raise_on_click (Boolean)::
 
 window_border_width (Integer)::
     Border width of a window.
+    *Warning:* This only exists for compatibility reasons; it is only an alias for
+    the attribute +theme.border_width+.
 
 window_border_inner_width (Integer)::
     The width of the inner border of a window. Must be less than
     window_border_width, since it does not add to the window border width but is
     a part of it.
+    *Warning:* This only exists for compatibility reasons; it is only an alias for
+    the attribute +theme.inner_width+.
 
 window_border_active_color (String/Color)::
     Border color of a focused window.
+    *Warning:* This only exists for compatibility reasons; it is only an alias for
+    the attribute +theme.active.color+.
 
 window_border_normal_color (String/Color)::
     Border color of an unfocused window.
+    *Warning:* This only exists for compatibility reasons; it is only an alias for
+    the attribute +theme.normal.color+.
 
 window_border_urgent_color (String/Color)::
     Border color of an unfocused but urgent window.
+    *Warning:* This only exists for compatibility reasons; it is only an alias for
+    the attribute +theme.urgent.color+.
 
 window_border_inner_color (String/Color)::
     Color of the inner border of a window.
+    *Warning:* This only exists for compatibility reasons; it is only an alias for
+    the attribute +theme.inner_color+.
 
 always_show_frame (Boolean)::
     If set, all frames are displayed. If unset, only frames with focus or with


### PR DESCRIPTION
I find a big 'Warning' sign like for 'list_keybindings' too much in the
present case, hence only the inline warning.