### PR TITLE
Create Xvfb manually in the test cases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -509,35 +509,6 @@ def hc_idle(hlwm):
     hc.shutdown()
 
 
-def kill_all_existing_windows(show_warnings=True):
-    xlsclients = subprocess.run(['xlsclients', '-l'],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                check=False)
-    print(xlsclients.stderr.decode(), file=sys.stderr, end='')
-    if re.search('unable to open display', xlsclients.stderr.decode()):
-        # if the display is already closed since there are no clients left,
-        # then that's fine for us
-        return
-    else:
-        # otherwise, assert successfull termination
-        assert xlsclients.returncode == 0
-    clients = []
-    for line in xlsclients.stdout.decode().splitlines():
-        m = re.match(r'Window (0x[0-9a-fA-F]*):', line)
-        if m:
-            clients.append(m.group(1))
-    if clients and show_warnings:
-        warnings.warn(UserWarning("There are still some clients "
-                                  "from previous tests."))
-    for c in clients:
-        if show_warnings:
-            warnings.warn(UserWarning("Killing " + c))
-        # send close and kill ungently
-        subprocess.run(['xdotool', 'windowclose', c])
-        subprocess.run(['xdotool', 'windowkill', c])
-
-
 @pytest.fixture()
 def hlwm_spawner(tmpdir):
     """yield a function to spawn hlwm"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -577,12 +577,10 @@ def xvfb():
 def hlwm_process(hlwm_spawner, xvfb):
     """Set up hlwm and also check that it shuts down gently afterwards"""
     hlwm_proc = hlwm_spawner(['--no-tag-import'], display=xvfb.display)
-    # kill_all_existing_windows(show_warnings=True)
 
     yield hlwm_proc
 
     hlwm_proc.shutdown()
-    # kill_all_existing_windows(show_warnings=False)
 
 
 @pytest.fixture(params=[0])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ import time
 import types
 
 import pytest
-import warnings
 
 
 BINDIR = os.path.join(os.path.abspath(os.environ['PWD']))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -845,6 +845,7 @@ class MultiscreenDisplay:
             if len(chunk) < 1 or chunk == b'\n':
                 break
         os.close(pipe_read)
+        os.close(pipe_write)
         self.display = ':' + display_bytes.decode().rstrip()
         print(server + " is using the display \"{}\"".format(self.display))
 

--- a/tests/test_herbstluftwm.py
+++ b/tests/test_herbstluftwm.py
@@ -41,10 +41,10 @@ def test_herbstluftwm_default_autostart(hlwm):
 
 
 @pytest.mark.parametrize("method", ['home', 'xdg', 'shortopt', 'longopt'])
-def test_autostart_path(tmpdir, method):
+def test_autostart_path(tmpdir, method, xvfb):
     # herbstluftwm environment:
     env = {
-        'DISPLAY': os.environ['DISPLAY'],
+        'DISPLAY': xvfb.display,
     }
     args = []  # extra command line args
     if method == 'home':
@@ -74,10 +74,10 @@ def test_autostart_path(tmpdir, method):
     hlwm_proc.shutdown()
 
 
-def test_no_autostart():
+def test_no_autostart(xvfb):
     # no HOME, no XDG_CONFIG_HOME
     env = {
-        'DISPLAY': os.environ['DISPLAY'],
+        'DISPLAY': xvfb.display,
     }
     hlwm_proc = HlwmProcess('', env, [])
     hlwm_proc.read_and_echo_output(until_stderr='Will not run autostart file.')

--- a/tests/test_monitor_detection.py
+++ b/tests/test_monitor_detection.py
@@ -8,7 +8,7 @@ from conftest import MultiscreenDisplay
     [(500, 450), (200, 600), (200, 600)],
 ])
 @pytest.mark.parametrize('server_type', ['Xvfb', 'Xephyr'])
-def test_detect_monitors_xinerama(hlwm_spawner, server_type, screens):
+def test_detect_monitors_xinerama(hlwm_spawner, server_type, screens, xvfb):
     args = ['+extension', 'XINERAMA']
     args += ['-extension', 'RANDR']
     with MultiscreenDisplay(screens=screens, extra_args=args) as xserver:

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,6 @@ skipsdist = true
 commands = {envpython} -m pytest {posargs}
 deps =
     ewmh
-    pytest-xvfb
-    PyVirtualDisplay
     pytest-xdist
     python-xlib
 


### PR DESCRIPTION
This introduces a new fixture 'xvfb' that creates an Xvfb instance
whose scope is only the test case and not the entire test session. The
python code for this has already been written in the MultiscreenDisplay
class.

Having the Xvfb scope only within the testcase gets rid of the necessity
to kill existing/remaining windows at the beginning and the end of the
testcase run.

Moreover, I am passing -noreset to Xvfb, and so the X properties are not
reset when the last client window closes, hence we don't need this
x11_connection fixture hack anymore.