### PR TITLE
mergify: Use pull request title+body as commit msg

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,3 +9,4 @@ pull_request_rules:
           merge:
               method: squash
               strict: smart
+              commit_message: title+body


### PR DESCRIPTION
This uses a new mergify feature where the commit message of a PR is
taking from the opening comment of a PR (which can be edited during the
review of the PR itself). Moreover, this avoids non-sensical comments in
the commit messages like ('Fix typo', 'Fix whitespace', ...).