### PR TITLE
Fix cycle_layout for omitted layout names

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,7 +14,8 @@ Current git version
     ('floatplacement=none')
   * New rule condition 'pgid'
   * Bug fixes:
-    - Fix wrong behaviour in 'cycle_layout'
+    - Fix wrong behaviour in 'cycle_layout' in the case where the current layout
+      is not contained in the layout list passed to 'cycle_layout'.
 
 Release 0.8.3 on 2020-06-06
 ---------------------------

--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ Current git version
     clients ('floatplacement=center') or leaves the floating position as is
     ('floatplacement=none')
   * New rule condition 'pgid'
+  * Bug fixes:
+    - Fix wrong behaviour in 'cycle_layout'
 
 Release 0.8.3 on 2020-06-06
 ---------------------------

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -726,7 +726,12 @@ int FrameTree::cycleLayoutCommand(Input input, Output output) {
         string curname = Converter<LayoutAlgorithm>::str(cur_frame->getLayout());
         size_t count = input.end() - input.begin();
         auto curposition = std::find(input.begin(), input.end(), curname);
-        size_t idx = MOD((curposition - input.begin()) + delta, count);
+        size_t idx = 0;  // take the from the list per default
+        if (curposition != input.end()) {
+            // if the current layout name is in the list, take the next one
+            // (respective to the delta)
+            idx = MOD((curposition - input.begin()) + delta, count);
+        }
         try {
             layout_index = (int)Converter<LayoutAlgorithm>::parse(*(input.begin() + idx));
         } catch (const std::exception& e) {

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -726,7 +726,7 @@ int FrameTree::cycleLayoutCommand(Input input, Output output) {
         string curname = Converter<LayoutAlgorithm>::str(cur_frame->getLayout());
         size_t count = input.end() - input.begin();
         auto curposition = std::find(input.begin(), input.end(), curname);
-        size_t idx = 0;  // take the from the list per default
+        size_t idx = 0;  // take the first in the list per default
         if (curposition != input.end()) {
             // if the current layout name is in the list, take the next one
             // (respective to the delta)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -828,7 +828,7 @@ def test_cycle_layout_name_not_in_list(hlwm, delta):
     # if the current name is not contained in the custom list
     # of layouts, then the first entry in the custom list
     # has to be picked
-    hlwm.call('cycle_layout {} max grid'.format(delta))
+    hlwm.call(f'cycle_layout {delta} max grid')
 
     assert current_layout_name(hlwm) == 'max'
 
@@ -837,16 +837,17 @@ def test_cycle_layout_name_not_in_list(hlwm, delta):
 def test_cycle_layout_name_in_the_list(hlwm, delta):
     hlwm.call('set_layout vertical')
     layouts = ['vertical', 'max', 'grid']
-    # here, we omit 'horizontal' to verify that we never reach
-    # the 'horizontal' layout
-    command = ['cycle_layout', delta] + layouts
+    # here, 'layouts' does not contain 'horizontal'. By this, we
+    # implicitly verify that we never reach the 'horizontal' layout
+    # since the 'expected_layouts' list also does not contain 'horizontal'
+    cycle_layout_cmd = ['cycle_layout', delta] + layouts
     # expected list of layouts after calling
-    # this command multiple times:
+    # 'cycle_layout_cmd' multiple times:
     if delta == '+1':
         expected_layouts = layouts[1:] + layouts
     elif delta == '-1':
         expected_layouts = reversed(layouts + layouts)
 
     for expected in expected_layouts:
-        hlwm.call(command)
+        hlwm.call(cycle_layout_cmd)
         assert current_layout_name(hlwm) == expected

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -813,3 +813,40 @@ def test_resize_clamp_argument_bigger(hlwm):
     hlwm.call(['load', layout.format('0.2')])
     hlwm.call('resize left 0.15')
     assert hlwm.call('dump').stdout == layout.format('0.1')
+
+
+def current_layout_name(hlwm):
+    proc = hlwm.call(['dump', '', '@'])
+    m = re.match(r'^\([^ ]* ([^:]*):.*\)$', proc.stdout)
+    return m.group(1)
+
+
+@pytest.mark.parametrize("delta", ['-1', '+1'])
+def test_cycle_layout_name_not_in_list(hlwm, delta):
+    hlwm.call('set_layout vertical')
+
+    # if the current name is not contained in the custom list
+    # of layouts, then the first entry in the custom list
+    # has to be picked
+    hlwm.call('cycle_layout {} max grid'.format(delta))
+
+    assert current_layout_name(hlwm) == 'max'
+
+
+@pytest.mark.parametrize("delta", ['-1', '+1'])
+def test_cycle_layout_name_in_the_list(hlwm, delta):
+    hlwm.call('set_layout vertical')
+    layouts = ['vertical', 'max', 'grid']
+    # here, we omit 'horizontal' to verify that we never reach
+    # the 'horizontal' layout
+    command = ['cycle_layout', delta] + layouts
+    # expected list of layouts after calling
+    # this command multiple times:
+    if delta == '+1':
+        expected_layouts = layouts[1:] + layouts
+    elif delta == '-1':
+        expected_layouts = reversed(layouts + layouts)
+
+    for expected in expected_layouts:
+        hlwm.call(command)
+        assert current_layout_name(hlwm) == expected


### PR DESCRIPTION
If a custom list of layouts is specified for cycle_layout and the
current layout is not part of this list, then cycle_layout has to pick
the first layout in the list according to the docs. The present commit
re-establishes this behaviour and adds test cases for it.