### PR TITLE
herbstclient: Quiet more errors in case of --quiet

### DIFF
--- a/ipc-client/main.c
+++ b/ipc-client/main.c
@@ -112,7 +112,9 @@ int main_hook(int argc, char* argv[]) {
     }
     HCConnection* con = hc_connect_to_display(display);
     if (!hc_check_running(con)) {
-        fprintf(stderr, "Error: herbstluftwm is not running\n");
+        if (!g_quiet) {
+            fprintf(stderr, "Error: herbstluftwm is not running\n");
+        }
         hc_disconnect(con);
         XCloseDisplay(display);
         destroy_hook_regex();
@@ -245,11 +247,15 @@ int main(int argc, char* argv[]) {
         char* output;
         HCConnection* con = hc_connect();
         if (!con) {
-            fprintf(stderr, "Error: Cannot open display.\n");
+            if (!g_quiet) {
+                fprintf(stderr, "Error: Cannot open display.\n");
+            }
             return EXIT_FAILURE;
         }
         if (!hc_check_running(con)) {
-            fprintf(stderr, "Error: herbstluftwm is not running.\n");
+            if (!g_quiet) {
+                fprintf(stderr, "Error: herbstluftwm is not running.\n");
+            }
             hc_disconnect(con);
             return EXIT_FAILURE;
         }
@@ -257,7 +263,9 @@ int main(int argc, char* argv[]) {
                                    &output, &command_status);
         hc_disconnect(con);
         if (!suc) {
-            fprintf(stderr, "Error: Could not send command.\n");
+            if (!g_quiet) {
+                fprintf(stderr, "Error: Could not send command.\n");
+            }
             return EXIT_FAILURE;
         }
         FILE* file = stdout; // on success, output to stdout

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -18,7 +18,8 @@ def test_herbstclient_no_display(argument):
 
 @pytest.mark.parametrize('hlwm_mode', ['never started', 'sigterm', 'sigkill'])
 @pytest.mark.parametrize('hc_parameter', ['true', '--wait'])
-def test_herbstclient_recognizes_hlwm_not_running(hlwm_spawner, x11, hlwm_mode, hc_parameter):
+@pytest.mark.parametrize('hc_quiet', [True, False])
+def test_herbstclient_recognizes_hlwm_not_running(hlwm_spawner, x11, hlwm_mode, hc_parameter, hc_quiet):
     if hlwm_mode == 'never started':
         pass
     else:
@@ -46,11 +47,16 @@ def test_herbstclient_recognizes_hlwm_not_running(hlwm_spawner, x11, hlwm_mode, 
             assert False, 'assert that we have no typos above'
 
     # run herbstclient while no hlwm is running
+    if hc_quiet:
+        hc_parameter = f'--quiet {hc_parameter}'
     hc_command = [HC_PATH, hc_parameter]
     result = subprocess.run(hc_command, stderr=subprocess.PIPE, universal_newlines=True)
 
     assert result.returncode != 0
-    assert re.search(r'Error: herbstluftwm is not running', result.stderr)
+    if hc_quiet:
+        assert re.search(r'Error: herbstluftwm is not running', result.stderr) is None
+    else:
+        assert re.search(r'Error: herbstluftwm is not running', result.stderr)
 
 
 def test_herbstclient_invalid_regex():


### PR DESCRIPTION
Some error messages regarding display or herstluftwm availability would still be printed if -q was given.