### PR TITLE
New attribute urgent_count for tags

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ Current git version
   * Fix handling of delta -1 in 'focus_monitor' and 'cycle_monitor'
   * Fixed precision decimals in the layout tree (more reliable in- and output
     of fractions in frame splits)
+  * New attribute 'urgent_count' for tags, counting the number of urgent clients on a tag
   * New rule consequence 'floatplacement' that updates the placement of floating
     clients ('floatplacement=center') or leaves the floating position as is
     ('floatplacement=none')

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1446,6 +1446,7 @@ listed as follows:
  i - index                , index of this tag
  i - frame_count          , number of frames
  i - client_count         , number of clients on this tag
+ i - urgent_count         , number of urgent clients on this tag
  i - curframe_windex      , index of the focused client in the select frame
  i - curframe_wcount      , number of clients in the selected frame
 |===========================

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -33,6 +33,7 @@ HSTag::HSTag(string name_, TagManager* tags, Settings* settings)
         [tags](string newName) { return tags->isValidTagName(newName); })
     , frame_count(this, "frame_count", &HSTag::computeFrameCount)
     , client_count(this, "client_count", &HSTag::computeClientCount)
+    , urgent_count(this, "urgent_count", &HSTag::countUrgentClients)
     , curframe_windex(this, "curframe_windex",
         [this] () { return frame->focusedFrame()->getSelection(); } )
     , curframe_wcount(this, "curframe_wcount",
@@ -416,6 +417,17 @@ int HSTag::computeFrameCount() {
     frame->root_->fmap([](FrameSplit*) {},
                 [&count](FrameLeaf*) { count++; },
                 0);
+    return count;
+}
+
+int HSTag::countUrgentClients()
+{
+    int count = 0;
+    foreachClient([&](Client* client) {
+        if (client->urgent_()) {
+            count++;
+        }
+    });
     return count;
 }
 

--- a/src/tag.h
+++ b/src/tag.h
@@ -35,6 +35,7 @@ public:
     Attribute_<std::string>  name;   // name of this tag
     DynAttribute_<int> frame_count;
     DynAttribute_<int> client_count;
+    DynAttribute_<int> urgent_count; //! The number of urgent clients
     DynAttribute_<int> curframe_windex;
     DynAttribute_<int> curframe_wcount;
     int             flags;
@@ -76,6 +77,8 @@ private:
     int computeClientCount();
     //! get the number of clients on this tag
     int computeFrameCount();
+    //! get the number of urgent clients on this tag
+    int countUrgentClients();
     Settings* settings_;
 };
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -204,3 +204,12 @@ def test_close_or_remove_client(hlwm):
     hlwm.call('close_or_remove')
     # remove the frame
     assert int(hlwm.get_attr('tags.focus.frame_count')) == 1
+
+
+def test_urgent_count(hlwm, x11):
+    # create 5 urgent clients
+    for i in range(0, 5):
+        x11.create_client(urgent=True)
+
+    # since one of them gets focused, 4 urgent clients remain
+    assert int(hlwm.get_attr('tags.focus.urgent_count')) == 4


### PR DESCRIPTION
This implements feature request #949 in a slightly generalized way.
Though only a boolean was requested, I think having the number of urgent
windows is more future-proof, and one can always transform it into a
'boolean' by running

    compare tags.focus.urgent_count gt 0

and checking its exit code.