### PR TITLE
Add initial argument to new_attr command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@ Current git version
     clients ('floatplacement=center') or leaves the floating position as is
     ('floatplacement=none')
   * New rule condition 'pgid'
+  * The 'new_attr' command now also accepts an initial value
   * Bug fixes:
     - Fix wrong behaviour in 'cycle_layout' in the case where the current layout
       is not contained in the layout list passed to 'cycle_layout'.

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -807,10 +807,11 @@ set_attr 'ATTRIBUTE' 'NEWVALUE'::
     Assign 'NEWVALUE' to the specified 'ATTRIBUTE' as described in the
     <<OBJECTS,*OBJECTS section*>>.
 
-new_attr [*bool*|*color*|*int*|*string*|*uint*] 'PATH'::
+new_attr *bool*|*color*|*int*|*string*|*uint* 'PATH' ['VALUE']::
     Creates a new attribute with the name and in the object specified by 'PATH'.
     Its type is specified by the first argument. The attribute name has to begin
-    with +my_+.
+    with +my_+. If 'VALUE' is supplied, then it is written to the attribute (if
+    this fails the attribute still remains).
 
 remove_attr 'PATH'::
     Removes the user defined attribute 'PATH'.

--- a/tests/test_root_commands.py
+++ b/tests/test_root_commands.py
@@ -217,6 +217,20 @@ def test_new_attr_has_right_type(hlwm, attrtype):
     assert m.group(1)[0] == attrtype[0]
 
 
+def test_new_attr_initial_value(hlwm):
+    hlwm.call('new_attr string clients.my_foo bar')
+
+    assert hlwm.get_attr('clients.my_foo') == 'bar'
+
+
+def test_new_attr_initial_value_invalid(hlwm):
+    hlwm.call_xfail('new_attr int clients.my_foo bar') \
+        .expect_stderr('"bar" is an invalid value for clients.my_foo')
+
+    # the client still exists and the default value remains
+    assert hlwm.get_attr('clients.my_foo') == '0'
+
+
 def test_new_attr_complete(hlwm):
     assert 'bool' in hlwm.complete('new_attr')
     assert 'my_' in hlwm.complete('new_attr int', partial=True)


### PR DESCRIPTION
Equip the new_attr command with an optional argument that initializes
the value of the fresh attribute. While at it, I removed the square
brackets around the type argument, because it looks as if the type
parameter was optional (the type parameter is mandatory). Since it makes
the code easier, I'm also switching to the new ArgParse syntax.

In the man page, I'm not using the term 'initial value', because it is
not the initial value but the second value of the attribute (this can be
relevant in future hlwm versions as soon as it is possible for the user
to hook into the change events of attributes).