### PR TITLE
Fix crash while parsing empty decimal

### DIFF
--- a/src/fixprecdec.cpp
+++ b/src/fixprecdec.cpp
@@ -16,6 +16,9 @@ template<>
 FixPrecDec Converter<FixPrecDec>::parse(const string& source)
 {
     vector<string> parts = ArgList::split(source, '.');
+    if (parts.size() == 0) {
+        throw std::invalid_argument("Decimal is empty");
+    }
     if (parts.size() > 2) {
         throw std::invalid_argument("A decimal must have at most one \'.\'");
     }

--- a/src/fixprecdec.cpp
+++ b/src/fixprecdec.cpp
@@ -16,7 +16,7 @@ template<>
 FixPrecDec Converter<FixPrecDec>::parse(const string& source)
 {
     vector<string> parts = ArgList::split(source, '.');
-    if (parts.size() == 0) {
+    if (parts.empty()) {
         throw std::invalid_argument("Decimal is empty");
     }
     if (parts.size() > 2) {

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -805,7 +805,7 @@ def test_split_invalid_argument(hlwm):
         ('b', "stoi"),
         ('-.3', "stoi"),
         ('+.8', "stoi"),
-        ('', "stoi"),
+        ('', "Decimal is empty"),
     ]
     for d, msg in wrongDecimal:
         hlwm.call_xfail(['split', 'top', d]) \

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -805,7 +805,7 @@ def test_split_invalid_argument(hlwm):
         ('b', "stoi"),
         ('-.3', "stoi"),
         ('+.8', "stoi"),
-        ('\"\"', "stoi"),
+        ('', "stoi"),
     ]
     for d, msg in wrongDecimal:
         hlwm.call_xfail(['split', 'top', d]) \

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -805,6 +805,7 @@ def test_split_invalid_argument(hlwm):
         ('b', "stoi"),
         ('-.3', "stoi"),
         ('+.8', "stoi"),
+        ('\"\"', "stoi"),
     ]
     for d, msg in wrongDecimal:
         hlwm.call_xfail(['split', 'top', d]) \


### PR DESCRIPTION
An empty decimal would result in a crash
while trying to dereference parts[0] in fixdecprec.cpp.