### PR TITLE
Frame index 'p' for accessing parent frame

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,7 @@ Current git version
   * New rule condition 'pgid'
   * The 'new_attr' command now also accepts an initial value
   * React to a change of the 'floating_focused' attribute of the tag object
+  * New frame index character 'p' for accessing the parent frame
   * Bug fixes:
     - Fix wrong behaviour in 'cycle_layout' in the case where the current layout
       is not contained in the layout list passed to 'cycle_layout'.

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -106,24 +106,27 @@ FRAME INDEX
 -----------
 The exact position of a frame in the layout tree may be described by its
 *index* which is just a string of characters. The lookup algorithm starts at
-the root frame and selects one of its two subtrees according to the each
-character in the index.
-
-The characters are interpreted as follows:
+the root frame and interprets the *index* string character by character as
+follows:
 
     * +0+: select the first subtree
     * +1+: select the second subtree
     * +.+: select the subtree having the focus
     * +/+: select the subtree not having the focus
+    * +@+: select the frame having the focus. In contrast to +.+, this passes
+      multiple layers all down to the focused leaf of the frame tree.
+    * +p+: select the parent tree
     * +e+: finds a suitable empty frame: if the focused frame is not empty, this
       selects the closest frame that is empty (in any subtree)
 
-Thus an empty string refers to the root frame, and "00" refers to the first
-subtree of the first subtree of the root frame. Similarly "1e" refers to the
-first empty frame in the second subtree.
+For example:
 
-As a special case, the string "@" always refers to the currently focused
-frame.
+    * An empty string refers to the root frame
+    * +00+ refers to the first subtree of the first subtree of the root frame.
+    * +1e+ refers to the first empty frame in the second subtree.
+    * +/@+ refers to the focused frame within the unfocused "half" of the frame
+      tree
+    * +@p/+ refers to the sibling of the focused frame
 
 TAGS
 ----

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -76,16 +76,27 @@ void FrameTree::dump(shared_ptr<Frame> frame, Output output)
  */
 shared_ptr<Frame> FrameTree::lookup(const string& path) {
     shared_ptr<Frame> node = root_;
-    // the string "@" is a special case
-    if (path == "@") {
-        return focusedFrame();
-    }
     for (char c : path) {
         if (c == 'e') {
             shared_ptr<FrameLeaf> emptyFrame = findEmptyFrameNearFocus(node);
             if (emptyFrame) {
                 // go to the empty node if we had found some
                 node = emptyFrame;
+            }
+            continue;
+        }
+        if (c == '@') {
+            node = focusedFrame(node);
+            continue;
+        }
+        if (c == 'p') {
+            auto parent = node->parent_;
+            // only change the 'node' if 'parent' is set.
+            // if 'parent' is not set, then 'node' is already
+            // the root node; in this case we stay at the
+            // root.
+            if (parent.lock()) {
+                node = parent.lock();
             }
             continue;
         }

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -181,15 +181,31 @@ def test_dump_frame_index(hlwm):
     layout = {}
     layout['00'] = "(clients vertical:0)"
     layout['01'] = "(clients grid:0)"
-    layout['0'] = '(split vertical:0.7:0 {} {})'.format(
+    layout['0'] = '(split vertical:0.7:1 {} {})'.format(
         layout['00'], layout['01'])
     layout['1'] = '(clients horizontal:0)'
     layout[''] = '(split horizontal:0.65:0 {} {})'.format(
         layout['0'], layout['1'])
     hlwm.call(['load', layout['']])
 
+    # also test more specific frame indices:
+    frame_index_aliases = [
+        ('@', '01'),
+        ('@p', '0'),
+        ('@p/', '00'),
+        ('@p/', '00'),
+        ('@pp', ''),
+        ('@ppp', ''),  # going up too much does not exceed the root
+        ('..', '01'),
+        ('...', '01'),
+        ('./', '00'),
+    ]
+    for complicated, normalized in frame_index_aliases:
+        layout[complicated] = layout[normalized]
+
+    # test all the frame tree portions in the dict 'layout':
     tag = hlwm.get_attr('tags.focus.name')
-    for index in ["", "0", "1", "00", "01"]:
+    for index in layout.keys():
         assert hlwm.call(['dump', tag, index]).stdout == layout[index]
 
 


### PR DESCRIPTION
This extends the frame index possibilities by a new character 'p' that
goes back to the parent frame. In order to avoid a mess with 'special
cases' in the frame index section in the man page, I have reorganized it
a bit improving readability.

There is no real way to test frame indices on their own, but I'm using
the 'dump' command which accepts a frame index parameter, in order to
verify that 'dump' prints the correct subtree.

This implements a feature request raised in the discussion of #906 by
elvisjauld.