### PR TITLE
Add 'index' attribute to frame objects

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -32,7 +32,8 @@ using std::weak_ptr;
  * you can either specify a frame or a tag as its parent
  */
 Frame::Frame(HSTag* tag, Settings* settings, weak_ptr<FrameSplit> parent)
-    : tag_(tag)
+    : frameIndexAttr_(this, "index", &Frame::frameIndex)
+    , tag_(tag)
     , settings_(settings)
     , parent_(parent)
 {}
@@ -159,6 +160,19 @@ shared_ptr<FrameSplit> FrameSplit::thisSplit() {
 
 shared_ptr<FrameLeaf> Frame::getGloballyFocusedFrame() {
     return get_current_monitor()->tag->frame->focusedFrame();
+}
+
+std::string Frame::frameIndex() const
+{
+    auto p = parent_.lock();
+    if (p) {
+        string parent_index = p->frameIndex();
+        bool first_child = p->firstChild() == shared_from_this();
+        return parent_index + (first_child ? "0" : "1");
+    } else {
+        // this is the root
+        return "";
+    }
 }
 
 TilingResult FrameLeaf::layoutLinear(Rectangle rect, bool vertical) {

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -162,7 +162,7 @@ shared_ptr<FrameLeaf> Frame::getGloballyFocusedFrame() {
     return get_current_monitor()->tag->frame->focusedFrame();
 }
 
-std::string Frame::frameIndex() const
+string Frame::frameIndex() const
 {
     auto p = parent_.lock();
     if (p) {

--- a/src/layout.h
+++ b/src/layout.h
@@ -80,6 +80,8 @@ public:
     friend class FrameSplit;
     friend class FrameTree;
     friend class HSTag; // for HSTag::foreachClient()
+    DynAttribute_<std::string> frameIndexAttr_;
+    std::string frameIndex() const;
 public: // soon will be protected:
     virtual std::shared_ptr<FrameSplit> isSplit() { return std::shared_ptr<FrameSplit>(); };
     virtual std::shared_ptr<FrameLeaf> isLeaf() { return std::shared_ptr<FrameLeaf>(); };

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -970,5 +970,5 @@ def test_frame_index_attribute(hlwm):
         hlwm.call(['split', 'auto', '0.5', index])
 
         # after each splitting operation, check that
-        # the frame_index attribute is correct:
+        # the frame's index attribute is correct:
         verify_frame_tree('tags.focus.tiling.root', '')

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -952,3 +952,23 @@ def test_split_something_in_between(hlwm, splitmode, context):
 
     expected_layout = outer_layer.format(context.format(inner_layer))
     assert hlwm.call('dump').stdout == expected_layout
+
+
+def test_frame_index_attribute(hlwm):
+    # split the frames with the following indices
+    split_index = [
+        '', '0', '00', '1', '11', '111'
+    ]
+
+    def verify_frame_tree(object_path, index_prefix):
+        assert hlwm.get_attr(f'{object_path}.index') == index_prefix
+        if '0' in hlwm.list_children(object_path):
+            verify_frame_tree(f'{object_path}.0', f'{index_prefix}0')
+            verify_frame_tree(f'{object_path}.1', f'{index_prefix}1')
+
+    for index in split_index:
+        hlwm.call(['split', 'auto', '0.5', index])
+
+        # after each splitting operation, check that
+        # the frame_index attribute is correct:
+        verify_frame_tree('tags.focus.tiling.root', '')


### PR DESCRIPTION
This equips the frame objects with a dynamic attribute 'index'
containing the frame's frame index. Since there is no documentation for
frame objects yet, there is no documentation for the 'index' attribute
here.

This feature has been requested by @bew during the discussion of #906.