### PR TITLE
Fix crash in smart placement on invisible tags

### DIFF
--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -139,6 +139,10 @@ void Decoration::resize_inner(Rectangle inner, const DecorationScheme& scheme) {
 }
 
 Rectangle Decoration::inner_to_outer(Rectangle rect) {
+    if (!last_scheme) {
+        // if the decoration was never drawn, we can't do anything reasonable
+        return rect;
+    }
     return last_scheme->inner_rect_to_outline(rect);
 }
 
@@ -294,6 +298,10 @@ unsigned int Decoration::get_client_color(Color color) {
 
 // draw a decoration to the client->dec.pixmap
 void Decoration::redrawPixmap() {
+    if (!last_scheme) {
+        // do nothing if we don't have a scheme.
+        return;
+    }
     const DecorationScheme& s = *last_scheme;
     auto dec = this;
     auto outer = last_outer_rect;

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -741,8 +741,12 @@ def test_floatplacement_smart_uses_all_corners(hlwm, x11):
 @pytest.mark.exclude_from_coverage(
     reason='This test does not verify functionality but only whether \
     creating lots of windows can be handled by the algorithm')
-def test_floatplacement_smart_create_many(hlwm, x11):
+@pytest.mark.parametrize('invisible_tag', [False, True])
+def test_floatplacement_smart_create_many(hlwm, x11, invisible_tag):
     hlwm.call('move_monitor "" 500x520')
+    if invisible_tag:
+        hlwm.call('add invisible_tag')
+        hlwm.call('rule tag=invisible_tag')
     hlwm.call('rule floatplacement=smart floating=on')
 
     # create many clients with different sizes
@@ -753,3 +757,15 @@ def test_floatplacement_smart_create_many(hlwm, x11):
 
     for i in range(0, 50):
         x11.create_client(geometry=index2geometry(i))
+
+
+def test_floatplacement_smart_invisible_windows(hlwm):
+    hlwm.call('add invisible')
+    hlwm.call('rule floatplacement=smart floating=on tag=invisible')
+
+    # create some floating clients on the invisible tag and check
+    # that it does not crash
+    hlwm.create_client()
+    hlwm.create_client()
+    hlwm.create_client()
+    hlwm.create_client()


### PR DESCRIPTION
If multiple floating clients are placed smartly on a tag, then the
'last_scheme' member of Decoration is used to compute the correct
geometry of a client. If this involves clients that have never been
shown, then the 'last_scheme' is not yet initialized.

This commit checks the 'last_scheme' pointer explicitly in
Decoration::inner_to_outer() and adds some test cases which reproduced
the crash earlier. Moreover, I've also added the check in
Decoration::redrawPixmap(), just to be on the safe side.

There is no entry in the NEWS section for this, because this bug was not
present in the last released version.