### PR TITLE
Test messages regarding the 'maxage' rule

### DIFF
--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -59,7 +59,7 @@ bool Rule::addCondition(string name, char op, const char* value, bool negated, O
             if (name == "maxage") {
                 cond.value_type = CONDITION_VALUE_TYPE_INTEGER;
                 if (1 != sscanf(value, "%d", &cond.value_integer)) {
-                    output << "rule: Can not integer from \"" << value << "\"\n";
+                    output << "rule: Cannot parse integer from \"" << value << "\"\n";
                     return false;
                 }
             } else {

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -107,6 +107,16 @@ def test_add_rule_with_unknown_condition(hlwm):
     call.expect_stderr('rule: Unknown argument "foo=bar"')
 
 
+def test_add_rule_maxage_condition_operator(hlwm):
+    call = hlwm.call_xfail('rule maxage~12')
+    call.expect_stderr('rule: Condition maxage only supports the = operator')
+
+
+def test_add_rule_maxage_condition_integer(hlwm):
+    call = hlwm.call_xfail('rule maxage=foo')
+    call.expect_stderr('rule: Cannot parse integer from "foo"')
+
+
 @pytest.mark.parametrize('method', ['-F', '--all'])
 def test_remove_all_rules(hlwm, method):
     hlwm.call('rule class=Foo tag=bar')


### PR DESCRIPTION
This adds two test cases for error messages related to the rule
consequence 'maxage'. Moreover, this replaces 'Can not' by 'Cannot' in
the message that needed to be fixed anyway.