### PR TITLE
Replace 'can not' by 'cannot'

### DIFF
--- a/src/argparse.h
+++ b/src/argparse.h
@@ -8,7 +8,7 @@
 
 /**
  * @brief The InputConvert class is a convenience wrapper around Input::operator>> and
- * Converter<X>::parse(). If an argument can not be parsed, a meaningful error message
+ * Converter<X>::parse(). If an argument cannot be parsed, a meaningful error message
  * is printed to the output stream.
  */
 class ArgParse

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -405,7 +405,7 @@ void execute_autostart_file() {
         execl(path.c_str(), path.c_str(), nullptr);
 
         const char* global_autostart = HERBSTLUFT_GLOBAL_AUTOSTART;
-        HSDebug("Can not execute %s, falling back to %s\n", path.c_str(), global_autostart);
+        HSDebug("Cannot execute %s, falling back to %s\n", path.c_str(), global_autostart);
         execl(global_autostart, global_autostart, nullptr);
 
         fprintf(stderr, "herbstluftwm: execvp \"%s\"", global_autostart);

--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -138,12 +138,12 @@ int MouseManager::dragCommand(Input input, Output output)
         return HERBST_INVALID_ARGUMENT;
     }
     if (monitors_->byTag(client->tag()) == nullptr) {
-        output << input.command() << ": can not drag invisible client \"" << winid << "\"" << endl;
+        output << input.command() << ": cannot drag invisible client \"" << winid << "\"" << endl;
         return HERBST_INVALID_ARGUMENT;
     }
     string errorMsg = (this ->* action)(client, input.toVector());
     if (!errorMsg.empty()) {
-        output << input.command() << ": can not drag: " << errorMsg << "\n";
+        output << input.command() << ": cannot drag: " << errorMsg << "\n";
         return HERBST_UNKNOWN_ERROR;
     }
     return 0;

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -444,7 +444,7 @@ template <typename T> int parse_and_compare(string a, string b, Output o) {
         try {
             vals.push_back(Converter<T>::parse(x));
         } catch(std::exception& e) {
-            o << "can not parse \"" << x << "\" to "
+            o << "cannot parse \"" << x << "\" to "
               << typeid(T).name() << ": " << e.what() << endl;
             return (int) HERBST_INVALID_ARGUMENT;
         }

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -74,7 +74,7 @@ bool Rule::addCondition(string name, char op, const char* value, bool negated, O
             try {
                 cond.value_reg_exp = std::regex(value, std::regex::extended);
             } catch(std::regex_error& err) {
-                output << "rule: Can not parse value \"" << value
+                output << "rule: Cannot parse value \"" << value
                         << "\" from condition \"" << name
                         << "\": \"" << err.what() << "\"\n";
                 return false;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -413,7 +413,7 @@ void HSTag::onGlobalFloatingChange(bool newState)
 void HSTag::fixFocusIndex()
 {
    static_assert(std::is_same<decltype(floating_clients_focus_), size_t>::value,
-                 "we assume that index can not be negative.");
+                 "we assume that index cannot be negative.");
    if (floating_clients_focus_ >= floating_clients_.size()) {
        if (floating_clients_.empty()) {
            floating_clients_focus_  = 0;

--- a/src/x11-utils.cpp
+++ b/src/x11-utils.cpp
@@ -72,7 +72,7 @@ Point2D get_cursor_position() {
     unsigned int mask;
     if (True != XQueryPointer(g_display, g_root, &win, &child,
                               &point.x, &point.y, &wx,&wy, &mask)) {
-        HSWarning("Can not query cursor coordinates via XQueryPointer\n");
+        HSWarning("Cannot query cursor coordinates via XQueryPointer\n");
         point.x = 0;
         point.y = 0;
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,7 @@ class HlwmBridge:
         partial. If not in 'partial' mode, trailing spaces are stripped.
 
         Set 'evaluate_escapes' if the escape sequences of completion items
-        should be evaluated. If this is set, one can not distinguish between
+        should be evaluated. If this is set, one cannot distinguish between
         partial and full completion results anymore.
         """
         args = self._parse_command(cmd)

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -148,7 +148,7 @@ def test_drag_invisible_client(hlwm):
     hlwm.call('move t')
     # where he'll never be known
     hlwm.call_xfail(['drag', kid, 'resize']) \
-        .expect_stderr('can not drag invisible client')
+        .expect_stderr('cannot drag invisible client')
     # inward he's grown :-)
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -205,7 +205,7 @@ def test_monitor_consequence(hlwm, monitor_spec):
 def test_invalid_regex_in_condition(hlwm):
     call = hlwm.call_xfail('rule class~[b-a]')
 
-    assert call.stderr == 'rule: Can not parse value "[b-a]" from condition "class": "Invalid range in bracket expression."\n'
+    assert call.stderr == 'rule: Cannot parse value "[b-a]" from condition "class": "Invalid range in bracket expression."\n'
 
 
 def test_printlabel_flag(hlwm):


### PR DESCRIPTION
There is a subtle difference between the two phrases, and in all
instances in hlwm, 'cannot' is more appropriate.