### PR TITLE
Add the 'foreach' command for object iteration

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ Current git version
   * When an application fails to focus itself (because
     focus_stealing_prevention is active), then the window is marked as urgent.
   * New optional argument for the 'split' command for splitting non-leaf frames
+  * New command 'foreach' for iterating over objects
   * New attribute 'urgent_count' for tags, counting the number of urgent clients on a tag
   * New rule consequence 'floatplacement' that updates the placement of floating
     clients ('floatplacement=smart' for little overlap,

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -831,6 +831,29 @@ substitute 'IDENTIFIER' 'ATTRIBUTE' 'COMMAND' ['ARGS' ...]::
           +
           Prints the title of the currently focused window.
 
+
+foreach 'IDENTIFIER' 'OBJECT' 'COMMAND' ['ARGS' ...]::
+    For each child of the given 'OBJECT' the 'COMMAND' is called with its
+    'ARGS', where the 'IDENTIFIER' is replaced by the path of the child. The
+    exit code is the exit code of the command executed last. Examples:
+
+        * +foreach T tags.by-name. echo T+ +
+          +
+          Prints:
+
+             theme.tiling.active
+             theme.tiling.normal
+             theme.tiling.urgent
+
+        * Note that +foreach+ only iterates over children, but not over
+          attributes, so +foreach S settings echo S+ prints nothing, since the
+          settings object has only attributes but no child objects.
+
+        * +foreach C clients. echo C+ prints the object paths of all clients,
+          but the focused client twice, because it is mentioned in +clients.+
+          twice: by window id and as +clients.focus+.
+
+
 sprintf 'IDENTIFIER' 'FORMAT' ['ATTRIBUTES' ...] 'COMMAND' ['ARGS' ...]::
     Replaces all exact occurrences of 'IDENTIFIER' in 'COMMAND' and its 'ARGS'
     by the string specified by 'FORMAT'. Each +%s+ in 'FORMAT' stands for the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,6 +196,8 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                             &RootCommands::print_object_tree_complete} },
         {"substitute",     { root_commands, &RootCommands::substitute_cmd,
                                             &RootCommands::substitute_complete} },
+        {"foreach",        { root_commands, &RootCommands::foreachCmd,
+                                            &RootCommands::foreachComplete} },
         {"sprintf",        { root_commands, &RootCommands::sprintf_cmd,
                                             &RootCommands::sprintf_complete} },
         {"new_attr",       { root_commands, &RootCommands::new_attr_cmd,

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -180,6 +180,56 @@ void RootCommands::substitute_complete(Completion& complete)
     }
 }
 
+int RootCommands::foreachCmd(Input input, Output output)
+{
+    string ident, pathString;
+    if (!(input >> ident >> pathString)) {
+        return HERBST_NEED_MORE_ARGS;
+    }
+    // remove trailing dots to avoid parsing issues:
+    while (!pathString.empty() && pathString.back() == OBJECT_PATH_SEPARATOR) {
+        // while the last character is a dot, erase it:
+        pathString.erase(pathString.size() - 1);
+    }
+    Path path { pathString, OBJECT_PATH_SEPARATOR };
+    Object* object = root.child(path, output);
+    if (!object) {
+        return HERBST_INVALID_ARGUMENT;
+    }
+
+    // collect the paths of all children of this object
+    vector<string> childPaths;
+    // collect the children's name first to ensure that
+    // object->childrens() is not changed by the commands we are
+    // calling.
+    if (!pathString.empty()) {
+        pathString += OBJECT_PATH_SEPARATOR;
+    }
+    for (const auto& entry : object->children()) {
+        childPaths.push_back(pathString + entry.first);
+    }
+    int  lastStatusCode = 0;
+    for (const auto& child : childPaths) {
+        Input carryover = input.fromHere();
+        carryover.replace(ident, child);
+        lastStatusCode = Commands::call(carryover, output);
+    }
+    return lastStatusCode;
+}
+
+void RootCommands::foreachComplete(Completion& complete)
+{
+    if (complete == 0) {
+        // no completion for the identifier
+    } else if (complete == 1) {
+        completeObjectPath(complete);
+    } else {
+        // later, complete the identifier
+        complete.full(complete[0]);
+        complete.completeCommands(2);
+    }
+}
+
 //! parse a format string or throw an exception
 RootCommands::FormatString RootCommands::parseFormatString(const string &format)
 {

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -199,8 +199,8 @@ int RootCommands::foreachCmd(Input input, Output output)
 
     // collect the paths of all children of this object
     vector<string> childPaths;
-    // collect the children's name first to ensure that
-    // object->childrens() is not changed by the commands we are
+    // collect the children's names first to ensure that
+    // object->children() is not changed by the commands we are
     // calling.
     if (!pathString.empty()) {
         pathString += OBJECT_PATH_SEPARATOR;

--- a/src/rootcommands.h
+++ b/src/rootcommands.h
@@ -42,6 +42,8 @@ public:
 
     int substitute_cmd(Input input, Output output);
     void substitute_complete(Completion& complete);
+    int foreachCmd(Input input, Output output);
+    void foreachComplete(Completion& complete);
     int sprintf_cmd(Input input, Output output);
     void sprintf_complete(Completion& complete);
     int new_attr_cmd(Input input, Output output);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -13,11 +13,11 @@ Input &Input::operator>>(string &val)
 Input Input::fromHere()
 {
     string cmd;
-    if (!(*this >> cmd)) {
+    if (empty()) {
         return {{}, {}};
     }
 
-    return Input(cmd, toVector());
+    return Input(*(begin()), Container(begin() + 1, end()));
 }
 
 void Input::replace(const string &from, const string &to)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -220,9 +220,16 @@ def test_remove_attr(hlwm):
     hlwm.call_xfail('get_attr ' + attr_path)
 
 
-def test_substitute(hlwm):
+@pytest.mark.parametrize('command_prefix', [
+    ['substitute', 'ARG', 'tags.count'],
+    ['foreach', 'ARG', 'clients']
+])
+def test_metacommand(hlwm, command_prefix):
+    """test the completion of a command that accepts another
+    command as the parameter
+    """
     cmdlist = hlwm.call('list_commands').stdout.splitlines()
-    assert hlwm.complete(['substitute', 'ARG', 'tags.count']) \
+    assert hlwm.complete(command_prefix) \
         == sorted(['ARG'] + cmdlist)
 
 

--- a/tests/test_root_commands.py
+++ b/tests/test_root_commands.py
@@ -606,3 +606,11 @@ def test_foreach_object_completion(hlwm):
     assert 'tags.by-name.' in completions
     # attributes are not completed
     assert 'tags.count' not in completions
+
+
+def test_foreach_identfier_completion(hlwm):
+    # the identfier isn't completed in the object parameter
+    assert 'X ' not in hlwm.complete(['foreach', 'X', ], partial=True)
+    # but the identfier is completed in the command parameter
+    assert 'X ' in hlwm.complete(['foreach', 'X', 'tags.'], partial=True)
+    assert 'X ' in hlwm.complete(['foreach', 'X', 'tags.', 'echo'], partial=True)

--- a/tests/test_root_commands.py
+++ b/tests/test_root_commands.py
@@ -598,3 +598,11 @@ def test_foreach_exit_code_no_iteration(hlwm):
 def test_foreach_invalid_object(hlwm):
     hlwm.call_xfail('foreach C clients.foobar quit') \
         .expect_stderr('"clients." has no child named "foobar"')
+
+
+def test_foreach_object_completion(hlwm):
+    completions = hlwm.complete(['foreach', 'X', 'tags.'], position=2, partial=True)
+    # objects are completed
+    assert 'tags.by-name.' in completions
+    # attributes are not completed
+    assert 'tags.count' not in completions


### PR DESCRIPTION
The foreach command iterates over all children of a given object. With
this, it becomes easy to iterate over all clients, tags, monitors. It's
probably only a first version of the 'foreach' because often one needs
to filter the children in a certain way (e.g. 'tags' has more children
than tags because there is something like tags.focus and tags.by-name).

This implements #26.