### PR TITLE
New constant string format specifier for sprintf

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ Current git version
     'floatplacement=center' for centering) or leaves the floating position as
     is ('floatplacement=none')
   * New rule condition 'pgid'
+  * New format specifier '%c' in the 'sprintf' command (useful in combination with 'foreach')
   * The 'new_attr' command now also accepts an initial value
   * React to a change of the 'floating_focused' attribute of the tag object
   * New frame index character 'p' for accessing the parent frame

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -831,17 +831,26 @@ substitute 'IDENTIFIER' 'ATTRIBUTE' 'COMMAND' ['ARGS' ...]::
           +
           Prints the title of the currently focused window.
 
-sprintf 'IDENTIFIER' 'FORMAT' ['ATTRIBUTES' ...] 'COMMAND' ['ARGS' ...]::
-    Replaces all exact occurrences of 'IDENTIFIER' in 'COMMAND' and its 'ARGS'
-    by the string specified by 'FORMAT'. Each +%s+ in 'FORMAT' stands for the
-    value of the next attribute in 'ATTRIBUTES', similar to the *printf*(1)
-    command. The replaced command with its arguments then is executed.
+sprintf 'IDENTIFIER' 'FORMAT' ['FORMATARG' ...] 'COMMAND' ['CMDARGS' ...]::
+    Replaces all exact occurrences of 'IDENTIFIER' in 'COMMAND' and its 'CMDARGS'
+    by the string specified by 'FORMAT'. The 'FORMAT' string may contain several
+    placeholders, similar to the *printf*(1) command:
+      - +%s+ inserts an attribute value whose path is given by the string value
+        of the next 'FORMATARG'
+      - +%c+ ("constant") inserts the next 'FORMATARG' without modification.
+      - +%%+ stands for a plain +%+
+
+ ::
+    The replaced command with its arguments then is executed.
     Examples:
 
         * +sprintf STR title=%s clients.focus.title echo STR+ +
           +
           Prints the title of the currently focused window prepended by
           +title=+.
+        * +sprintf X "%c %s tags" "there are" tags.count echo X+
+          +
+          Prints +there are N tags+ with +N+ replaced by the number of tags.
         * +sprintf X tag=%s tags.focus.name rule once X+ +
           +
           Moves the next client that appears to the tag that is currently
@@ -852,6 +861,12 @@ sprintf 'IDENTIFIER' 'FORMAT' ['ATTRIBUTES' ...] 'COMMAND' ['ARGS' ...]::
         * +sprintf l somelongstring echo l l l+ +
           +
           Prints +somelongstring+ three times, separated by spaces.
+        * +substitute X tags.count sprintf Y "number=%c" X echo Y+ +
+          +
+          has the same output as +
+          +sprintf Y "number=%s" tags.count echo Y+ +
+          +
+          (Note how the +%c+ changes to +%s+)
 
 mktemp [*bool*|*int*|*string*|*uint*] 'IDENTIFIER' 'COMMAND' ['ARGS' ...]::
     Creates a temporary attribute with the given type and replaces all

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -239,7 +239,7 @@ int RootCommands::sprintf_cmd(Input input, Output output)
     for (const auto& blob : format) {
         if (blob.literal_) {
             replacedString += blob.data_;
-        } else if (blob.data_ == "c"){
+        } else if (blob.data_ == "c") {
             // a constant string argument
             string constString;
             if (!(input >> constString)) {
@@ -279,7 +279,7 @@ void RootCommands::sprintf_complete(Completion& complete)
             complete.invalidArguments();
             return;
         }
-        int	indexOfNextArgument = 2;
+        int indexOfNextArgument = 2;
         for (const auto& b : fs) {
             if (b.literal_ == true) {
                 continue;

--- a/src/rootcommands.cpp
+++ b/src/rootcommands.cpp
@@ -202,6 +202,8 @@ RootCommands::FormatString RootCommands::parseFormatString(const string &format)
                     blobs.push_back({true, "%"});
                 } else if (format_type == 's') {
                     blobs.push_back({false, "s"});
+                } else if (format_type == 'c') {
+                    blobs.push_back({false, "c"});
                 } else {
                     stringstream msg;
                     msg << "invalid format type %"
@@ -237,6 +239,14 @@ int RootCommands::sprintf_cmd(Input input, Output output)
     for (const auto& blob : format) {
         if (blob.literal_) {
             replacedString += blob.data_;
+        } else if (blob.data_ == "c"){
+            // a constant string argument
+            string constString;
+            if (!(input >> constString)) {
+                return HERBST_NEED_MORE_ARGS;
+            }
+            // just copy the plain string to the output
+            replacedString += constString;
         } else {
             // we reached %s
             string path;
@@ -262,22 +272,30 @@ void RootCommands::sprintf_complete(Completion& complete)
     } else if (complete == 1) {
         // no completion for format string
     } else {
-        complete.full(complete[0]); // complete string replacement
-        int placeholderCount = 0;
+        FormatString fs;
         try {
-            FormatString fs = parseFormatString(complete[1]);
-            for (const auto& b : fs) {
-                if (b.literal_ == false) {
-                    placeholderCount++;
-                }
-            }
+            fs = parseFormatString(complete[1]);
         }  catch (const std::invalid_argument&) {
             complete.invalidArguments();
+            return;
         }
-        if (complete < 2 + placeholderCount) {
-            completeAttributePath(complete);
-        } else {
-            complete.completeCommands(2 + placeholderCount);
+        int	indexOfNextArgument = 2;
+        for (const auto& b : fs) {
+            if (b.literal_ == true) {
+                continue;
+            }
+            if (complete == indexOfNextArgument) {
+                if (b.data_ == "s") {
+                    completeAttributePath(complete);
+                } else if (b.data_ == "c") {
+                    // no completion for constant strings
+                }
+            }
+            indexOfNextArgument++;
+        }
+        if (complete >= indexOfNextArgument) {
+            complete.full(complete[0]); // complete string replacement
+            complete.completeCommands(indexOfNextArgument);
         }
     }
 }

--- a/tests/test_root_commands.py
+++ b/tests/test_root_commands.py
@@ -96,6 +96,25 @@ def test_sprintf(hlwm):
     assert call.stdout == expected_output
 
 
+def test_sprintf_s_vs_c(hlwm):
+    p1 = hlwm.call('substitute X tags.count sprintf Y "number=%c" X echo Y')
+    p2 = hlwm.call('sprintf Y "number=%s" tags.count echo Y')
+    assert p1.stdout == p2.stdout
+
+
+def test_sprintf_c_placeholder(hlwm):
+    proc = hlwm.call('sprintf X "%c %s tags" "there are" tags.count echo X')
+    assert proc.stdout == "there are 1 tags\n"
+
+
+def test_sprintf_nested(hlwm):
+    cmd = 'substitute A tags.count'
+    cmd += ' sprintf B "%c%c" A A'
+    cmd += ' sprintf C "%c%c" B B'
+    cmd += ' sprintf D "%c%c" C C echo D'
+    assert hlwm.call(cmd).stdout == '11111111\n'
+
+
 def test_sprintf_too_few_attributes__command_treated_as_attribute(hlwm):
     call = hlwm.call_xfail('sprintf X %s/%s tags.count echo X')
 
@@ -122,7 +141,13 @@ def test_sprintf_double_percentage_escapes(hlwm):
 
 def test_sprintf_completion_1_placeholder(hlwm):
     assert hlwm.complete('sprintf T %s', partial=True) \
-        == sorted(['T '] + hlwm.complete('get_attr', partial=True))
+        == sorted(hlwm.complete('get_attr', partial=True))
+
+
+def test_sprintf_completion_s_after_c_placeholder(hlwm):
+    assert hlwm.complete('sprintf T %c%s', partial=True) == []
+    assert hlwm.complete('sprintf T %c%s myconst', partial=True) \
+        == sorted(hlwm.complete('get_attr', partial=True))
 
 
 def test_sprintf_completion_0_placeholders(hlwm):


### PR DESCRIPTION
This introduces a new format specifier '%c' in the sprintf format
strings. Of course it never makes sense to manually write something like

    hc sprintf S '%c.name' 'tags.0'

but it makes sense in combination with the other commands that replace
certain identifiers in commands, especially in combination with the foreach
command.

This change required an update in the completion code for the 'sprintf'
command, and while at it, I fixed a minor bug in the completion. The bug
was that completing the command

   hc sprintf S '%s'

erroneously yielded S.