### PR TITLE
Remove one DynAttribute_ constructor

### DIFF
--- a/src/attribute_.h
+++ b/src/attribute_.h
@@ -210,12 +210,6 @@ class DynAttribute_ : public Attribute {
 public:
     // each time a dynamic attribute is read, the getter_ is called in order to
     // get the actual value
-    DynAttribute_(const std::string &name, std::function<T()> getter)
-        : Attribute(name, false)
-        , getter_(getter)
-    {
-        hookable_ = false;
-    }
     DynAttribute_(Object* owner, const std::string &name, std::function<T()> getter)
         : Attribute(name, false)
         , getter_(getter)

--- a/src/indexingobject.h
+++ b/src/indexingobject.h
@@ -90,6 +90,10 @@ public:
     iterator_type begin() { return data.begin(); }
     iterator_type end() { return data.end(); }
 private:
+    unsigned long sizeUnsignedLong() {
+        return static_cast<unsigned long>(data.size());
+    }
+
     std::vector<T*> data;
 };
 

--- a/src/indexingobject.h
+++ b/src/indexingobject.h
@@ -15,8 +15,8 @@ template<typename T>
 class IndexingObject : public Object {
 public:
     IndexingObject()
-    : count("count", [this]() { return this->size(); })
-    { wireAttributes({ &count }); }
+    : count(this, "count", &IndexingObject<T>::size)
+    { }
     void addIndexed(T* newChild) {
         // the current array size is the index for the new child
         unsigned long index = data.size();

--- a/src/indexingobject.h
+++ b/src/indexingobject.h
@@ -15,7 +15,7 @@ template<typename T>
 class IndexingObject : public Object {
 public:
     IndexingObject()
-    : count(this, "count", &IndexingObject<T>::size)
+    : count(this, "count", &IndexingObject<T>::sizeUnsignedLong)
     { }
     void addIndexed(T* newChild) {
         // the current array size is the index for the new child


### PR DESCRIPTION
Using the 'Owner'-aware constructors of DynAttribute_ improve the
readability. The particular constructor removed by this commit was used
in only one place anyway.

This commit does not require new test cases, because there are a couple
of test cases for the attribute 'tags.count'.