### PR TITLE
Generate json documentation on the object tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ doc: $(BUILDDIR)
 tar: doc
 	git archive --prefix=herbstluftwm-$(VERSION)/ -o $(TARFILE) HEAD
 	tar --transform="flags=r;s,$(BUILDDIR),herbstluftwm-$(VERSION),"  --owner=0 --group=0 \
-		-uvf $(TARFILE) $(BUILDDIR)/doc/*.html $(BUILDDIR)/doc/*.[1-9]
+		-uvf $(TARFILE) $(BUILDDIR)/doc/*.{html,json} $(BUILDDIR)/doc/*.[1-9]
 	gzip $(TARFILE)
 	gpg --detach-sign $(TARFILE).gz

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -48,6 +48,8 @@ function(gen_html sourcefile)
     install(FILES ${dst} DESTINATION ${DOCDIR})
 endfunction()
 
+gen_json_doc(hlwm-doc)
+
 if (WITH_DOCUMENTATION)
     find_program(ASCIIDOC_A2X NAMES a2x DOC "Path to AsciiDoc a2x command")
     find_program(ASCIIDOC NAMES asciidoc DOC "Path to AsciiDoc command")
@@ -59,7 +61,6 @@ if (WITH_DOCUMENTATION)
     gen_html(herbstclient)
     gen_html(herbstluftwm)
     gen_html(herbstluftwm-tutorial)
-    gen_json_doc(hlwm-doc)
 endif()
 
 # vim: et:ts=4:sw=4

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,5 +1,17 @@
 option(WITH_DOCUMENTATION "Build with documentation" ON)
 
+function(gen_json_doc destfile)
+    set(dst "${CMAKE_CURRENT_BINARY_DIR}/${destfile}.json")
+    AUX_SOURCE_DIRECTORY("${CMAKE_CURRENT_SOURCE_DIR}/../src" CPPSRC)
+    add_custom_target("doc_json" ALL DEPENDS ${dst})
+    add_custom_command(
+        OUTPUT ${dst}
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py" --sourcedir "${CMAKE_CURRENT_SOURCE_DIR}/../src" --json > ${dst}
+        DEPENDS ${CPPSRC} "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py"
+        )
+    install(FILES ${dst} DESTINATION ${DOCDIR})
+endfunction()
+
 function(gen_manpage sourcefile man_nr)
     set(src_orig "${CMAKE_CURRENT_SOURCE_DIR}/${sourcefile}.txt")
     set(src "${CMAKE_CURRENT_BINARY_DIR}/${sourcefile}.txt")
@@ -47,6 +59,7 @@ if (WITH_DOCUMENTATION)
     gen_html(herbstclient)
     gen_html(herbstluftwm)
     gen_html(herbstluftwm-tutorial)
+    gen_json_doc(hlwm-doc)
 endif()
 
 # vim: et:ts=4:sw=4

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -454,13 +454,31 @@ class ObjectInformation:
         # 1. collect all subclasses of 'Object'
         superclasses = self.superclasses_transitive()
         result = []
+
+        # 2. create a helper dict mapping classes to its members
+        cls2members = {}
+        for (cls, _), member in self.member2info.items():
+            if cls not in cls2members:
+                cls2members[cls] = []
+            cls2members[cls].append(member)
+
+        # 3. create the json-object with all object/attribute info
         for clsname, supers in superclasses.items():
             if 'Object' not in supers:
                 continue
             attributes = []
+            for cls in [clsname] + supers:
+                for member in cls2members.get(cls, []):
+                    if isinstance(member, ObjectInformation.AttributeInformation):
+                        attributes.append({
+                            'cpp_name': member.cpp_name,
+                            'type': str(member.type),
+                            'default_value': member.default_value,
+                            'class': member.attribute_class,
+                        })
             result.append({
                 'classname': clsname,
-                #'attributes': attributes,
+                'attributes': attributes,
             })
         return result
 

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -15,7 +15,7 @@ def findfiles(sourcedir, regex_object):
     for root, dirs, files in os.walk(sourcedir):
         for file in files:
             if regex_object.match(file):
-                 yield os.path.join(root, file)
+                yield os.path.join(root, file)
 
 
 def extract_file_tokens(filepath):
@@ -237,7 +237,6 @@ class TokenStream:
                 text += "\n'{}'".format(msg)
             raise Exception(text)
 
-
     def discard_until(self, *args):
         """
         discard tokens until try_match(*args) succeeds (returning True)
@@ -275,6 +274,8 @@ def build_token_tree_list(token_stream):
 
 
 class ClassName:
+    """a class name with additional information of the surrounding namespace
+    and template arguments"""
     def __init__(self, name, type_modifier=[], namespace=[], template_args=[]):
         self.type_modifier = type_modifier  # something like 'unsigned'
         self.namespace = namespace
@@ -306,9 +307,8 @@ class ClassName:
         return self.__str__()
 
 
-
-
 class ObjectInformation:
+    """This gathers all kinds of information about hlwm's object tree"""
     class AttributeInformation:
         def __init__(self, cpp_name):
             self.cpp_name = cpp_name

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -295,10 +295,10 @@ class ObjectInformation:
             if self.attribute_class == 'Attribute_':
                 #print("args = {}".format(','.join(args)))
                 if len(args) == 2:
-                    self.cpp_name = args[0]
+                    self.user_name = args[0]
                     self.default_value = args[1]
                 elif len(args) >= 3:
-                    self.cpp_name = args[1]
+                    self.user_name = args[1]
                     self.default_value = args[2]
 
     def __init__(self):

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -74,9 +74,10 @@ def pretty_print_token_list(tokens, indent='  '):
 
 
 class TokenGroup:
-    """A list of TokenTrees is a list whose elements are either:
-        - plain strings (something like a 'class' token)
-        - a token group enclosed by ( ), [ ], or { } tokens
+    """
+    A TokenGroup represents a list of tokens that are enclosed by ( ), [ ], or { }.
+    A 'list of tokens' is actually a list whose elements are strings or
+    TokenGroup objects.
     """
     def __init__(self):
         """this should not be called directly"""

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -345,8 +345,6 @@ class ObjectInformation:
                     self.set_user_name(args[1])
                     self.set_default_value(args[2])
             if self.attribute_class == 'DynAttribute_':
-                #if self.cpp_name == 'count':
-                print("args : {}".format('|'.join([str(s) for s in args])))
                 if len(args) == 2:
                     self.set_user_name(args[0])
                 elif len(args) >= 3 and args[0] == 'this':

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -449,7 +449,7 @@ class ObjectInformation:
             if clsname in target_dict:
                 # nothing to do
                 return
-            bases = [str(b) for b in self.base_classes.get(clsname, [])]
+            bases = [b.name for b in self.base_classes.get(clsname, [])]
             target_dict[clsname] = bases
             for b in bases:
                 bounded_depth_first_search(b, target_dict)
@@ -582,6 +582,7 @@ class TokTreeInfoExtrator:
         def semicolon_or_block_callback(t):
             return t == ';' or TokenTree.IsTokenGroup(t, opening_token='{')
         semicolon_or_block = TokenStream.PatternArg(callback=semicolon_or_block_callback)
+        arg = TokenStream.PatternArg()
         while not stream.empty():
             if stream.try_match(pub_priv_prot_re, ':'):
                 continue
@@ -619,6 +620,13 @@ class TokTreeInfoExtrator:
                 link = self.objInfo.child_info(classname, cpp_name)
                 link.child_class = link_.value
                 link.type = link_type
+                stream.discard_until(semicolon_or_block)
+            elif stream.try_match('ByName', arg):
+                link = self.objInfo.child_info(classname, arg.value)
+                link.child_class = 'ByName'
+                link.user_name = 'by-name'
+                link.type = ClassName('ByName')
+                stream.discard_until(semicolon_or_block)
             else:
                 stream.discard_until(semicolon_or_block)
 

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -147,6 +147,12 @@ class TokenStream:
         #print("tokundo", file=sys.stderr)
         self.pos -= 1
 
+    def try_match(self, *args):
+        """if the next tokens match the list in the *args
+        then pop them from the stream, else do nothing
+        """
+        pass
+
 
 def build_token_tree_list(token_stream):
     """return a list of TokenTree objects"""
@@ -181,28 +187,28 @@ class ObjectInformation:
 
     def print(self):
         for k, v in self.base_classes.items():
-            print("{} has the base classes: {}".format(k, ' '.join(v)))
+            print("{} has the base classes: \'{}\'".format(k, '\' \''.join(v)))
 
 
-def extract_doc_info(tokentreenodes, objInfo):
+def extract_doc_info(tokens, objInfo):
     """extract object information from a list of TokenTree objects
     and save the data in the ObjectInformation object passed"""
     pub_priv_prot = ['public', 'private', 'protected']
-    stream = TokenStream(tokentreenodes)
+    stream = TokenStream([t for t in tokens if t.strip() != ''])
     while not stream.empty():
         token = stream.pop()
         #print("token = {}".format(token))
-        if token.literate == 'class':
-            classname = stream.pop("expecting class name after 'class'").literate
+        if token == 'class':
+            classname = stream.pop("expecting class name after 'class'")
             nexttoken = stream.pop("expecting something after 'class {}'"
                                   .format(classname))
-            if nexttoken.literate == ':':
+            if nexttoken == ':':
                 nexttoken = stream.pop("expecting base classes")
-                while nexttoken.literate not in [None, ';']:
-                    if nexttoken.literate not in pub_priv_prot:
-                        objInfo.base_class(classname, nexttoken.literate)
+                while nexttoken not in [None, ';', '{']:
+                    if nexttoken not in pub_priv_prot:
+                        objInfo.base_class(classname, nexttoken)
                     nexttoken = stream.pop("expecting base classes")
-            if nexttoken.literate == ';':
+            if nexttoken == ';':
                 # only a forward declaration
                 continue
 
@@ -245,8 +251,8 @@ def main():
         for f in files():
             print("parsing file {}".format(f))
             toks = extract_file_tokens(f)
-            toktree = list(build_token_tree_list(TokenStream(list(toks))))
-            extract_doc_info(toktree, objInfo)
+            #toktree = list(build_token_tree_list(TokenStream(list(toks))))
+            extract_doc_info(list(toks), objInfo)
         objInfo.print()
 
 

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+import re
+
+
+def findfiles(sourcedir, regex_object):
+    """find all files in the given 'sourcedir' whose
+    filename matches 'regex_object'
+    """
+    for root, dirs, files in os.walk(sourcedir):
+        for file in files:
+            if regex_object.match(file):
+                 yield os.path.join(root, file)
+
+
+def extract_file_tokens(filepath):
+    # in the following, it's important to use
+    # non-capturing groups (?: .... )
+    token_types = [
+        '//[^\n]*\n',  # single-line comment
+        '/\*(?:[^\*]*|\**[^/*])*\*/',  # multiline comment
+        '[a-zA-Z_][a-zA-Z0-9_]*',  # identifiers
+        '\'(?:\\\'|[^\']*)\'',
+        "\"(?:\\\"|[^\"]*)\"",
+        "[-+<>/*]",  # operators
+        "[\(\),;:{}\?|~]",
+        '[\t ][\t ]*',
+        '\n',
+    ]
+    entire_regex = ['(?:{})'.format(t) for t in token_types]
+    entire_regex = re.compile('(' + '|'.join(entire_regex) + ')')
+    with open(filepath, 'r') as fh:
+        for t in entire_regex.split(fh.read()):
+            if t is not None and t.strip(' \t') != '':
+                yield t
+
+
+def pretty_print_token_list(tokens, indent='  '):
+    """print all the tokens and auto-indent based on { }"""
+    number_nested_braces = 0
+    first_in_line = True
+    line_number = 1
+    for tok in tokens:
+        if tok == '}':
+            number_nested_braces -= 1
+        linecontent = tok.rstrip('\n')
+        if linecontent != '':
+            if first_in_line:
+                print('{:4}: '.format(line_number) + number_nested_braces * indent, end='')
+            print(' \'{}\''.format(linecontent), end='')
+        for ch in tok:
+            if ch == '\n':
+                line_number += 1
+        if tok.endswith('\n'):
+            print('')
+            first_in_line = True
+        else:
+            first_in_line = False
+        if tok == '{':
+            number_nested_braces += 1
+    print()
+
+
+class TokenTree:
+    """a TokenTree is one of the following:
+        - a literate token
+        - a token group that is enclosed by ( ), [ ], or { } tokens
+    """
+    def __init__(self):
+        """this should not be called directly"""
+        # literate token:
+        self.literate = None
+        # token group
+        self.opening_token = None
+        self.enclosed_tokens = []  # list of TokenTree objects
+        self.closing_token = None
+        pass
+
+    @staticmethod
+    def LiterateToken(tok):
+        tt = TokenTree()
+        tt.literate = tok
+        return tt
+
+    @staticmethod
+    def TokenGroup(opening, enclosed, closing):
+        tt = TokenTree()
+        tt.opening_token = opening
+        tt.enclosed_tokens = enclosed
+        tt.closing_token = closing
+        return tt
+
+    def PrettyPrintList(tokentree_list, curindent=''):
+        for t in tokentree_list:
+            if t.literate is not None:
+                if t.literate.strip() == '':
+                    continue
+                print(curindent + t.literate)
+            else:
+                print(curindent + t.opening_token)
+                TokenTree.PrettyPrintList(t.enclosed_tokens, curindent=curindent + '  ')
+                print(curindent + t.closing_token)
+
+
+class TokenStream:
+    def __init__(self, tokens):
+        self.tokens = tokens
+        self.pos = 0
+
+    def empty(self):
+        return self.pos >= len(self.tokens)
+
+    def pop(self):
+        t =  self.tokens[self.pos]
+        self.pos += 1
+        #print("yielding token '{}'".format(t))
+        return t
+
+    def undo_pop(self):
+        """undo the last pop operation"""
+        self.pos -= 1
+
+
+def build_token_tree_list(token_stream):
+    """return a list of TokenTree objects"""
+    while not token_stream.empty():
+        t = token_stream.pop()
+        if t in [')', '}', ']']:
+            token_stream.undo_pop()
+            break
+        elif t in ['(', '{', ']']:
+            nested = list(build_token_tree_list(token_stream))
+            closing = token_stream.pop()
+            #assert closing in [')', '}', ']']
+            yield TokenTree.TokenGroup(t, nested, closing)
+        else:
+            yield TokenTree.LiterateToken(t)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='extract hlwm doc from the source code')
+    parser.add_argument('--sourcedir', default='./src/',
+                        help='directory containing the source files')
+    parser.add_argument('--fileregex', default='.*\.(h|cpp)$',
+                        help='consider files whose name matches this regex')
+    parser.add_argument('--tokenize-single-file',
+                        help='tokenize a particular file and then exit')
+    parser.add_argument('--tokentree-single-file',
+                        help='print the token tree of a particular file and then exit')
+    args = parser.parse_args()
+    files = findfiles(args.sourcedir, re.compile(args.fileregex))
+
+    if args.tokenize_single_file is not None:
+        tokens = extract_file_tokens(args.tokenize_single_file)
+        pretty_print_token_list(tokens)
+        return 0
+
+    if args.tokentree_single_file is not None:
+        tokens = extract_file_tokens(args.tokentree_single_file)
+        stream = TokenStream(list(tokens))
+        tt_list = list(build_token_tree_list(stream))
+        if not stream.empty():
+            print('Warning: unmatched [ ], ( ), { }', file=sys.stderr)
+            print("Remaining tokens are:", file=sys.stderr)
+            while not stream.empty():
+                print("token: {}".format(stream.pop()), file=sys.stderr)
+        TokenTree.PrettyPrintList(tt_list)
+        return 0
+
+EXITCODE = main()
+if EXITCODE is not None:
+    sys.exit(EXITCODE)

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -496,7 +496,7 @@ class ObjectInformation:
     def json_object(self):
         # 1. collect all subclasses of 'Object'
         superclasses = self.superclasses_transitive()
-        result = []
+        result = {}
 
         # 2. create a helper dict mapping classes to its members
         cls2members = {}
@@ -509,30 +509,35 @@ class ObjectInformation:
         for clsname, supers in superclasses.items():
             if 'Object' not in supers:
                 continue
-            attributes = []
-            children = []
+            attributes = {}
+            children = {}
             for cls in [clsname] + supers:
                 for member in cls2members.get(cls, []):
                     if isinstance(member, ObjectInformation.AttributeInformation):
-                        attributes.append({
+                        # assert uniqueness:
+                        assert member.user_name not in attributes
+                        attributes[member.user_name] = {
                             'name': member.user_name,
                             'cpp_name': member.cpp_name,
                             'type': member.type.to_user_type_name(),
                             'default_value': member.default_value,
                             'class': member.attribute_class,
-                        })
+                        }
                     if isinstance(member, ObjectInformation.ChildInformation):
-                        children.append({
+                        # assert uniqueness:
+                        assert member.user_name not in children
+                        children[member.user_name] = {
                             'name': member.user_name,
                             'cpp_name': member.cpp_name,
                             'type': member.type.to_user_type_name(),
                             'class': member.child_class,
-                        })
-            result.append({
+                        }
+            assert clsname not in result  # assert uniqueness
+            result[clsname] = {
                 'classname': clsname,
                 'children': children,
                 'attributes': attributes,
-            })
+            }
         return {'objects': result}  # only generate object doc so far
 
 

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -720,7 +720,7 @@ def main():
     if args.objects or args.json:
         objInfo = ObjectInformation()
         for f in files():
-            print("parsing file {}".format(f), file=sys.stderr)
+            # print("parsing file {}".format(f), file=sys.stderr)
             toks = [t for t in extract_file_tokens(f) if t.strip() != '']
             toktree = list(build_token_tree_list(TokenStream(toks)))
             extractor = TokTreeInfoExtrator(objInfo)

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -700,7 +700,8 @@ def main():
     args = parser.parse_args()
 
     # only evaluated if needed:
-    files = lambda: findfiles(args.sourcedir, re.compile(args.fileregex))
+    def files():
+        return findfiles(args.sourcedir, re.compile(args.fileregex))
 
     if args.tokenize_single_file is not None:
         tokens = extract_file_tokens(args.tokenize_single_file)

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -20,14 +20,15 @@ def extract_file_tokens(filepath):
     # in the following, it's important to use
     # non-capturing groups (?: .... )
     token_types = [
-        '#[a-zA-Z][^\n]*\n',  # preprocessor
+        '#[a-zA-Z](?:[^\n]|\\\n)*\n',  # preprocessor
         '//[^\n]*\n',  # single-line comment
         '/\*(?:[^\*]*|\**[^/*])*\*/',  # multiline comment
         '[a-zA-Z_][a-zA-Z0-9_]*',  # identifiers
+        '[0-9][0-9\.a-z]*', # numbers
         '\'(?:\\\'|[^\']*)\'',
         "\"(?:\\\"|[^\"]*)\"",
         "[-+<>/*]",  # operators
-        "[\(\),;:{}\?|~]",
+        r'[\(\),;:{}\[\]\?&|~]',
         '[\t ][\t ]*',
         '\n',
     ]
@@ -107,6 +108,7 @@ class TokenTree:
 
 
 class TokenStream:
+    """a stream of objects"""
     def __init__(self, tokens):
         self.tokens = tokens
         self.pos = 0
@@ -114,32 +116,82 @@ class TokenStream:
     def empty(self):
         return self.pos >= len(self.tokens)
 
-    def pop(self):
-        t =  self.tokens[self.pos]
+    def pop(self, error_message="expected another token"):
+        """pop a token from the stream. If the stream is empty
+        already, raise an exception instead
+        """
+        if self.pos >= len(self.tokens):
+            fullmsg = "Unexpected end of token stream: {}"
+            fullmsg = fullmsg.format(error_message)
+            raise Exception(fullmsg)
+        tok = self.tokens[self.pos]
+        print("tok {}".format(tok), file=sys.stderr)
         self.pos += 1
-        #print("yielding token '{}'".format(t))
-        return t
+        # print("yielding token '{}'".format(t))
+        return tok
 
     def undo_pop(self):
         """undo the last pop operation"""
+        print("tokundo", file=sys.stderr)
         self.pos -= 1
 
 
 def build_token_tree_list(token_stream):
     """return a list of TokenTree objects"""
+    matching = [
+        ('(', ')'),
+        ('{', '}'),
+        ('[', ']'),
+    ]
     while not token_stream.empty():
         t = token_stream.pop()
-        if t in [')', '}', ']']:
+        if t in [m[1] for m in matching]:  # closing scope
             token_stream.undo_pop()
             break
-        elif t in ['(', '{', '[']:
+        elif t in [m[0] for m in matching]:  # opening scope
             nested = list(build_token_tree_list(token_stream))
             closing = token_stream.pop()
-            #assert closing in [')', '}', ']']
+            if (t, closing) not in matching:
+                raise Exception("'{}' is closed by '{}'".format(t, closing))
             yield TokenTree.TokenGroup(t, nested, closing)
         else:
             yield TokenTree.LiterateToken(t)
 
+
+class ObjectInformation:
+    def __init__(self):
+        self.base_classes = {}  # mapping class names to base clases
+
+    def base_class(self, subclass, baseclass):
+        if subclass not in self.base_classes:
+            self.base_classes[subclass] = []
+        self.base_classes[subclass].append(baseclass)
+
+    def print(self):
+        for k, v in self.base_classes.items():
+            print("{} has the base classes: {}".format(k, ' '.join(v)))
+
+
+def extract_doc_info(tokentreenodes, objInfo):
+    """extract object information from a list of TokenTree objects
+    and save the data in the ObjectInformation object passed"""
+    pub_priv_prot = ['public', 'private', 'protected']
+    stream = TokenStream(tokentreenodes)
+    while not stream.empty():
+        token = stream.pop()
+        if token.literate == 'class':
+            classname = stream.pop("expecting class name after 'class'").literate
+            nexttoken = stream.pop("expecting something after 'class {}'"
+                                  .format(classname))
+            if nexttoken.literate == ':':
+                nexttoken = stream.pop("expecting base classes")
+                while nexttoken.literate not in [None, ';']:
+                    if nexttoken.literate not in pub_priv_prot:
+                        objInfo.base_class(classname, nexttoken.literate)
+                    nexttoken = stream.pop("expecting base classes")
+            if nexttoken.literate == ';':
+                # only a forward declaration
+                continue
 
 def main():
     parser = argparse.ArgumentParser(description='extract hlwm doc from the source code')
@@ -151,8 +203,12 @@ def main():
                         help='tokenize a particular file and then exit')
     parser.add_argument('--tokentree-single-file',
                         help='print the token tree of a particular file and then exit')
+    parser.add_argument('--objects', action='store_const', default=False, const=True,
+                        help='extract object information')
     args = parser.parse_args()
-    files = findfiles(args.sourcedir, re.compile(args.fileregex))
+
+    # only evaluated if needed:
+    files = lambda: findfiles(args.sourcedir, re.compile(args.fileregex))
 
     if args.tokenize_single_file is not None:
         tokens = extract_file_tokens(args.tokenize_single_file)
@@ -170,6 +226,16 @@ def main():
                 print("token: {}".format(stream.pop()), file=sys.stderr)
         TokenTree.PrettyPrintList(tt_list)
         return 0
+
+    if args.objects is not None:
+        objInfo = ObjectInformation()
+        for f in files():
+            print("parsing file {}".format(f))
+            toks = extract_file_tokens(f)
+            toktree = list(build_token_tree_list(TokenStream(list(toks))))
+            extract_doc_info(toktree, objInfo)
+        objInfo.print()
+
 
 EXITCODE = main()
 if EXITCODE is not None:

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -41,7 +41,7 @@ def extract_file_tokens(filepath):
     ]
     entire_regex = ['(?:{})'.format(t) for t in token_types]
     entire_regex = re.compile('(' + '|'.join(entire_regex) + ')')
-    with open(filepath, 'r') as fh:
+    with open(filepath, 'r', encoding='utf8') as fh:
         for t in entire_regex.split(fh.read().replace('\r', '') + '\n'):
             if t is not None and t.strip(' \t') != '':
                 yield t

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -20,6 +20,7 @@ def extract_file_tokens(filepath):
     # in the following, it's important to use
     # non-capturing groups (?: .... )
     token_types = [
+        '#[a-zA-Z][^\n]*\n',  # preprocessor
         '//[^\n]*\n',  # single-line comment
         '/\*(?:[^\*]*|\**[^/*])*\*/',  # multiline comment
         '[a-zA-Z_][a-zA-Z0-9_]*',  # identifiers
@@ -131,7 +132,7 @@ def build_token_tree_list(token_stream):
         if t in [')', '}', ']']:
             token_stream.undo_pop()
             break
-        elif t in ['(', '{', ']']:
+        elif t in ['(', '{', '[']:
             nested = list(build_token_tree_list(token_stream))
             closing = token_stream.pop()
             #assert closing in [')', '}', ']']

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -300,6 +300,8 @@ class ClassName:
             return 'uint'
         if self.name == 'RegexStr':
             return 'regex'
+        if self.name == 'FixPrecDec':
+            return 'decimal'
         return self.__str__()
 
 

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -20,7 +20,7 @@ def extract_file_tokens(filepath):
     # in the following, it's important to use
     # non-capturing groups (?: .... )
     token_types = [
-        '#[a-zA-Z](?:[^\n]|\\\n)*\n',  # preprocessor
+        '#[a-zA-Z ](?:[^\n]|\\\n)*\n',  # preprocessor
         '//[^\n]*\n',  # single-line comment
         '/\*(?:[^\*]*|\**[^/*])*\*/',  # multiline comment
         '[a-zA-Z_][a-zA-Z0-9_]*',  # identifiers
@@ -125,14 +125,14 @@ class TokenStream:
             fullmsg = fullmsg.format(error_message)
             raise Exception(fullmsg)
         tok = self.tokens[self.pos]
-        print("tok {}".format(tok), file=sys.stderr)
+        #print("tok {}".format(tok), file=sys.stderr)
         self.pos += 1
         # print("yielding token '{}'".format(t))
         return tok
 
     def undo_pop(self):
         """undo the last pop operation"""
-        print("tokundo", file=sys.stderr)
+        #print("tokundo", file=sys.stderr)
         self.pos -= 1
 
 

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -388,7 +388,13 @@ class ObjectInformation:
             self.constructor_args = None
 
         def add_constructor_args(self, args):
-            pass
+            if len(args) >= 4:
+                cpp_token = args[3]
+                if cpp_token == 'TMP_OBJECT_PATH':
+                    cpp_token = 'tmp'
+                if cpp_token[0:1] == '"':
+                    cpp_token = cpp_token[1:-1]
+                self.user_name = cpp_token
 
     def __init__(self):
         self.base_classes = {}  # mapping class names to base clases

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -322,7 +322,7 @@ class ObjectInformation:
             # split 'args' by the ',' tokens
             new_args = []
             current_chunk = []
-            for a in args + [',']:  # simulate the end by an artifical ','
+            for a in args + [',']:  # simulate the end by an artificial ','
                 if str(a) == ',':
                     if len(current_chunk) == 1:
                         # if there was one token before the ',' (or end)
@@ -366,7 +366,7 @@ class ObjectInformation:
 
         def set_default_value(self, cpp_token):
             if TokenGroup.IsTokenGroup(cpp_token):
-                # drop surrounding '{' ... '}' if its an initalizer list
+                # drop surrounding '{' ... '}' if its an initializer list
                 cpp_token = cpp_token.enclosed_tokens[0]
             if cpp_token[0:1] == ['-']:
                 # this is most probably a signed number
@@ -400,9 +400,9 @@ class ObjectInformation:
                 self.user_name = cpp_token
 
     def __init__(self):
-        self.base_classes = {}  # mapping class names to base clases
+        self.base_classes = {}  # mapping class names to base classes
         self.member2info = {}  # mapping (classname,member) to ChildInformation or AttributeInformation
-        self.member2init = {}  # mapping (classname,member) to its initalizer list
+        self.member2init = {}  # mapping (classname,member) to its initializer list
 
     def base_class(self, subclass, baseclass):
         if subclass not in self.base_classes:
@@ -548,7 +548,7 @@ class TokTreeInfoExtrator:
     ObjectInformation object.
 
     The actual extraction is done in the main()
-    function which has to be called separatedly
+    function which has to be called separately
     """
 
     def __init__(self, objInfo):
@@ -614,7 +614,7 @@ class TokTreeInfoExtrator:
                 attr.type = attr_type
                 attr.attribute_class = attribute_.value
                 if stream.try_match('='):
-                    # static initializiation:
+                    # static initialization:
                     t = stream.pop()
                     assert TokenGroup.IsTokenGroup(t)
                     attr.add_constructor_args(t.enclosed_tokens)

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -301,6 +301,7 @@ class ObjectInformation:
             self.constructor_args = None  # the arguments to the constructor
 
         def add_constructor_args(self, args):
+            # Here, we should probably cut the ',' separated list into pieces
             args = [a for a in args if str(a) != ',']
             self.constructor_args = args
             if self.attribute_class is None:
@@ -309,6 +310,12 @@ class ObjectInformation:
                 if len(args) == 2:
                     self.user_name = args[0]
                     self.default_value = args[1]
+                elif len(args) >= 3:
+                    self.user_name = args[1]
+                    self.default_value = args[2]
+            if self.attribute_class == 'DynAttribute_':
+                if len(args) == 3 and args[0] == 'this':
+                    self.user_name = args[1]
                 elif len(args) >= 3:
                     self.user_name = args[1]
                     self.default_value = args[2]

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -29,9 +29,9 @@ def extract_file_tokens(filepath):
         # \ right before the last \n
         "#(?:[^Z\n]|\\\\\n)*[^\\\\]\n",  # preprocessor
         '//[^\n]*\n',  # single-line comment
-        '/\*(?:[^\*]*|\**[^/*])*\*/',  # multiline comment
+        r'/\*(?:[^\*]*|\**[^/*])*\*/',  # multiline comment
         '[a-zA-Z_][a-zA-Z0-9_]*',  # identifiers
-        '[0-9][0-9\.a-z]*', # numbers
+        r'[0-9][0-9\.a-z]*',  # numbers
         '\'(?:\\\'|[^\']*)\'',
         "\"(?:\\\"|[^\"]*)\"",
         "[-+<>/*]",  # operators
@@ -588,14 +588,16 @@ class TokTreeInfoExtrator:
         attribute_ = TokenStream.PatternArg(re=attr_cls_re)
         link_ = TokenStream.PatternArg(re=re.compile('^(Link_|Child_)$'))
         parameters = TokenStream.PatternArg(callback=lambda t: TokenGroup.IsTokenGroup(t, opening_token='('))
+
         def semicolon_or_block_callback(t):
             return t == ';' or TokenGroup.IsTokenGroup(t, opening_token='{')
+
         semicolon_or_block = TokenStream.PatternArg(callback=semicolon_or_block_callback)
         arg = TokenStream.PatternArg()
         while not stream.empty():
             if stream.try_match(pub_priv_prot_re, ':'):
                 continue
-            if stream.try_match(re.compile('^(//|/\*)')):
+            if stream.try_match(re.compile(r'^(//|/\*)')):
                 # skip comments
                 continue
             # whenever we reach this point, this is a new
@@ -693,7 +695,7 @@ def main():
     parser = argparse.ArgumentParser(description='extract hlwm doc from the source code')
     parser.add_argument('--sourcedir', default='./src/',
                         help='directory containing the source files')
-    parser.add_argument('--fileregex', default='.*\.(h|cpp)$',
+    parser.add_argument('--fileregex', default=r'.*\.(h|cpp)$',
                         help='consider files whose name matches this regex')
     parser.add_argument('--tokenize-single-file',
                         help='tokenize a particular file and then exit')

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -301,8 +301,24 @@ class ObjectInformation:
             self.constructor_args = None  # the arguments to the constructor
 
         def add_constructor_args(self, args):
-            # Here, we should probably cut the ',' separated list into pieces
-            args = [a for a in args if str(a) != ',']
+            # split 'args' by the ',' tokens
+            new_args = []
+            current_chunk = []
+            for a in args + [',']:  # simulate the end by an artifical ','
+                if str(a) == ',':
+                    if len(current_chunk) == 1:
+                        # if there was one token before the ',' (or end)
+                        # then only put this token into the 'new_args'
+                        new_args.append(current_chunk[0])
+                    else:
+                        # if there were multiple or no tokens, then
+                        # retain the list
+                        new_args.append(current_chunk)
+                    current_chunk = []
+                else:
+                    current_chunk.append(a)
+
+            args = new_args  # also update 'args' for shorter notation later
             self.constructor_args = args
             if self.attribute_class is None:
                 return
@@ -314,11 +330,15 @@ class ObjectInformation:
                     self.user_name = args[1]
                     self.default_value = args[2]
             if self.attribute_class == 'DynAttribute_':
-                if len(args) == 3 and args[0] == 'this':
+                if len(args) == 2:
+                    self.user_name = args[0]
+                elif len(args) >= 3 and args[0] == 'this':
                     self.user_name = args[1]
-                elif len(args) >= 3:
-                    self.user_name = args[1]
-                    self.default_value = args[2]
+                elif len(args) >= 3 and args[0] != 'this':
+                    self.user_name = args[0]
+            if self.attribute_class == 'AttributeProxy_':
+                self.user_name = args[0]
+                self.default_value = args[1]
 
     def __init__(self):
         self.base_classes = {}  # mapping class names to base clases

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -234,17 +234,17 @@ class ClassName:
     @staticmethod
     def stream_pop_class_name(stream):
         namespace = []
+        if stream.try_match(':', ':'):
+            # absolute namespace, e.g. ::std::exception.
+            namespace.append('')
         name = stream.pop('expected class name')
         tmpl_args = []
         arg = TokenStream.PatternArg()
         while stream.try_match(':', ':', arg):
             namespace.append(name)
             name = arg.value
-        #if name == 'enable_shared_from_this':
-        #    print("Next token is: {}".format(stream.tokens[stream.pos]))
         if stream.try_match('<'):
             tok = stream.pop('expected template argument')
-            #print("next token is: {}".format(tok))
             tmpl_args.append(tok)
             while stream.try_match(','):
                 tmpl_args.append(stream.pop('expected template argument'))

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -345,6 +345,9 @@ class ObjectInformation:
             if TokenTree.IsTokenGroup(cpp_token):
                 # drop surrounding '{' ... '}' if its an initalizer list
                 cpp_token = cpp_token.enclosed_tokens[0]
+            if cpp_token[0:1] == ['-']:
+                # this is most probably a signed number
+                cpp_token = ''.join(cpp_token)
             if cpp_token[0:4] == ['RegexStr', ':', ':', 'fromStr']:
                 # assume that the next token in the list 'cpp_token' is a
                 # token group
@@ -472,6 +475,9 @@ class TokTreeInfoExtrator:
         attribute_ = TokenStream.PatternArg(re=attr_cls_re)
         while not stream.empty():
             if stream.try_match(pub_priv_prot_re, ':'):
+                continue
+            if stream.try_match(re.compile('^(//|/\*)')):
+                # skip comments
                 continue
             # whenever we reach this point, this is a new
             # member variable or member function definition

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -244,7 +244,7 @@ class TokenStream:
         """
         while not self.empty():
             # terminate if the args match to the upcoming tokens
-            if self.try_match(';'):
+            if self.try_match(*args):
                 return True
             # otherwise, discard the next token:
             self.pop()
@@ -548,6 +548,9 @@ class TokTreeInfoExtrator:
         stream = TokenStream(toktreelist)
         attr_cls_re = re.compile('^(Dyn|)Attribute(Proxy|)_$')
         attribute_ = TokenStream.PatternArg(re=attr_cls_re)
+        def semicolon_or_block_callback(t):
+            return t == ';' or TokenTree.IsTokenGroup(t, opening_token='{')
+        semicolon_or_block = TokenStream.PatternArg(callback=semicolon_or_block_callback)
         while not stream.empty():
             if stream.try_match(pub_priv_prot_re, ':'):
                 continue
@@ -577,9 +580,9 @@ class TokTreeInfoExtrator:
                     pass
                 else:
                     # some other definition (e.g. a function)
-                    stream.discard_until(';')
+                    stream.discard_until(semicolon_or_block)
             else:
-                stream.discard_until(';')
+                stream.discard_until(semicolon_or_block)
 
     def main(self, toktreelist):
         """extract object information from a list of TokenTree objects

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -500,7 +500,7 @@ class ObjectInformation:
                 'classname': clsname,
                 'attributes': attributes,
             })
-        return result
+        return {'objects': result}  # only generate object doc so far
 
 
 class TokTreeInfoExtrator:
@@ -658,7 +658,7 @@ def main():
     if args.objects or args.json:
         objInfo = ObjectInformation()
         for f in files():
-            print("parsing file {}".format(f))
+            print("parsing file {}".format(f), file=sys.stderr)
             toks = [t for t in extract_file_tokens(f) if t.strip() != '']
             toktree = list(build_token_tree_list(TokenStream(toks)))
             extractor = TokTreeInfoExtrator(objInfo)

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -23,6 +23,23 @@ def create_frame_split(hlwm):
     return 'tags.0.tiling.root'
 
 
+def types_and_shorthands():
+    """a mapping from type names in the json doc to their
+    one letter short hands in the output of 'attr'
+    """
+    return {
+        'int': 'i',
+        'uint': 'u',
+        'bool': 'b',
+        'decimal': 'd',
+        'color': 'c',
+        'string': 's',
+        'regex': 'r',
+        'SplitAlign': 'n',
+        'LayoutAlgorithm': 'n',
+    }
+
+
 @pytest.mark.parametrize('clsname,object_path', [
     ('ByName', 'monitors.by-name'),
     ('Client', create_client),
@@ -64,10 +81,16 @@ def test_attributes(hlwm, clsname, object_path, json_doc):
         # a string
         object_path = object_path(hlwm)
 
-    # 1. test that all documented attributes actually exist
+    # 1. test that all documented attributes actually exist and that it has
+    # the right type
+    attr_output = hlwm.call(['attr', object_path]).stdout.splitlines()
+    attr_output = [l.split(' ') for l in attr_output if '=' in l]
+    attrname2shorttype = dict([(l[4], l[1]) for l in attr_output])
+    fulltype2shorttype = types_and_shorthands()
     for attr in object_doc['attributes']:
         print("checking attribute {}::{}".format(clsname, attr['cpp_name']))
         hlwm.get_attr('{}.{}'.format(object_path, attr['name']).lstrip('.'))
+        assert fulltype2shorttype[attr['type']] == attrname2shorttype[attr['name']]
 
     # collect all attributes and children
     attributes = dict([(a['name'], a) for a in object_doc['attributes']])

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -27,7 +27,7 @@ def create_frame_split(hlwm):
     ('ByName', 'monitors.by-name'),
     ('Client', create_client),
     ('ClientManager', 'clients'),
-    # ('DecTriple', 'theme.tiling'),
+    ('DecTriple', 'theme.tiling'),
     ('DecorationScheme', 'theme.tiling.urgent'),
     ('FrameLeaf', 'tags.0.tiling.root'),
     ('FrameSplit', create_frame_split),
@@ -37,12 +37,20 @@ def create_frame_split(hlwm):
     ('Root', ''),
     ('Settings', 'settings'),
     ('TagManager', 'tags'),
-    # ('Theme', 'theme'),
+    ('Theme', 'theme'),
 ])
 def test_attributes(hlwm, clsname, object_path, json_doc):
     # if a path matches the following re, then it's OK if it
     # is not mentioned explicitly in the docs
-    undocumented_path_re = re.compile(r'^((tags|monitors)\.[0-9]+|tags\.by-name\..*)[\. ]*$')
+    undocumented_paths = '|'.join([
+        r'tags\.[0-9]+',
+        r'monitors\.[0-9]+',
+        r'tags\.by-name\.default',
+        # the theme children do not yet use the Child_<...> pattern
+        r'theme\.(|.*\.)(active|normal|urgent)',
+        r'theme\.(fullscreen|tiling|floating|minimal)',
+    ])
+    undocumented_path_re = re.compile(r'^({})[\. ]*$'.format(undocumented_paths))
 
     object_doc = None
     for obj in json_doc['objects']:

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -1,0 +1,56 @@
+import json
+import pytest
+import conftest
+import os
+
+@pytest.fixture()
+def json_doc():
+    json_filepath = os.path.join(conftest.BINDIR, 'doc/hlwm-doc.json')
+    with open(json_filepath, 'r') as fh:
+        doc = json.loads(fh.read())
+    return doc
+
+def create_client(hlwm):
+    winid, _ = hlwm.create_client()
+    return f'clients.{winid}'
+
+def create_frame_split(hlwm):
+    hlwm.call('split explode')
+    return 'tags.0.tiling.root'
+
+@pytest.mark.parametrize('clsname,object_path',[
+    ('ByName', 'monitors.by-name'),
+    ('Client', create_client),
+    ('ClientManager', 'clients'),
+    ('DecTriple', 'theme.tiling'),
+    ('DecorationScheme', 'theme.tiling.urgent'),
+    ('FrameLeaf', 'tags.0.tiling.root'),
+    ('FrameSplit', create_frame_split),
+    ('HSTag', 'tags.0'),
+    ('Monitor', 'monitors.0'),
+    ('MonitorManager', 'monitors'),
+    ('Root', ''),
+    ('Settings', 'settings'),
+    ('TagManager', 'tags'),
+    ('Theme', 'theme'),
+])
+def test_attributes(hlwm, clsname, object_path, json_doc):
+    object_doc = None
+    for obj in json_doc['objects']:
+        if obj['classname'] == clsname:
+            object_doc = obj
+            break
+    assert object_doc is not None
+
+    if not isinstance(object_path, str):
+        # if it's not a string directly, it's a function returning
+        # a string
+        object_path = object_path(hlwm)
+
+    # 1. test that all documented attributes actually exist
+    for attr in object_doc['attributes']:
+        print("checking attribute {}::{}".format(clsname, attr['cpp_name']))
+        hlwm.get_attr('{}.{}'.format(object_path,attr['name']).lstrip('.'))
+
+
+

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -2,6 +2,8 @@ import json
 import pytest
 import conftest
 import os
+import re
+
 
 @pytest.fixture()
 def json_doc():
@@ -10,19 +12,22 @@ def json_doc():
         doc = json.loads(fh.read())
     return doc
 
+
 def create_client(hlwm):
     winid, _ = hlwm.create_client()
     return f'clients.{winid}'
+
 
 def create_frame_split(hlwm):
     hlwm.call('split explode')
     return 'tags.0.tiling.root'
 
-@pytest.mark.parametrize('clsname,object_path',[
+
+@pytest.mark.parametrize('clsname,object_path', [
     ('ByName', 'monitors.by-name'),
     ('Client', create_client),
     ('ClientManager', 'clients'),
-    ('DecTriple', 'theme.tiling'),
+    # ('DecTriple', 'theme.tiling'),
     ('DecorationScheme', 'theme.tiling.urgent'),
     ('FrameLeaf', 'tags.0.tiling.root'),
     ('FrameSplit', create_frame_split),
@@ -32,9 +37,13 @@ def create_frame_split(hlwm):
     ('Root', ''),
     ('Settings', 'settings'),
     ('TagManager', 'tags'),
-    ('Theme', 'theme'),
+    # ('Theme', 'theme'),
 ])
 def test_attributes(hlwm, clsname, object_path, json_doc):
+    # if a path matches the following re, then it's OK if it
+    # is not mentioned explicitly in the docs
+    undocumented_path_re = re.compile(r'^((tags|monitors)\.[0-9]+|tags\.by-name\..*)[\. ]*$')
+
     object_doc = None
     for obj in json_doc['objects']:
         if obj['classname'] == clsname:
@@ -50,7 +59,21 @@ def test_attributes(hlwm, clsname, object_path, json_doc):
     # 1. test that all documented attributes actually exist
     for attr in object_doc['attributes']:
         print("checking attribute {}::{}".format(clsname, attr['cpp_name']))
-        hlwm.get_attr('{}.{}'.format(object_path,attr['name']).lstrip('.'))
+        hlwm.get_attr('{}.{}'.format(object_path, attr['name']).lstrip('.'))
 
+    # collect all attributes and children
+    attributes = dict([(a['name'], a) for a in object_doc['attributes']])
+    children = dict([(c['name'], c) for c in object_doc['children']])
 
-
+    # 2. test that all children/attributes are documented
+    object_path_dot = object_path + '.' if object_path != '' else ''
+    entries = hlwm.complete(['get_attr', object_path_dot], position=1, partial=True)
+    for full_entry_path in entries:
+        if undocumented_path_re.match(full_entry_path):
+            continue
+        assert full_entry_path[0:len(object_path_dot)] == object_path_dot
+        entry = full_entry_path[len(object_path_dot):]
+        if entry[-1] == '.':
+            assert entry[0:-1] in children
+        else:
+            assert entry[0:-1] in attributes

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -84,8 +84,8 @@ def test_attributes(hlwm, clsname, object_path, json_doc):
     # 1. test that all documented attributes actually exist and that it has
     # the right type
     attr_output = hlwm.call(['attr', object_path]).stdout.splitlines()
-    attr_output = [l.split(' ') for l in attr_output if '=' in l]
-    attrname2shorttype = dict([(l[4], l[1]) for l in attr_output])
+    attr_output = [line.split(' ') for line in attr_output if '=' in line]
+    attrname2shorttype = dict([(line[4], line[1]) for line in attr_output])
     fulltype2shorttype = types_and_shorthands()
     for attr in object_doc['attributes']:
         print("checking attribute {}::{}".format(clsname, attr['cpp_name']))

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -32,8 +32,8 @@ def create_frame_split(hlwm):
     return 'tags.0.tiling.root'
 
 
-# map every c++ class to a function accepting an hlwm fixture and returning
-# the path to an example object of the C++ class
+# map every c++ class name to a function ("constructor") accepting an hlwm
+# fixture and returning the path to an example object of the C++ class
 classname2examplepath = [
     ('ByName', lambda _: 'monitors.by-name'),
     ('Client', create_client),
@@ -50,6 +50,14 @@ classname2examplepath = [
     ('TagManager', lambda _: 'tags'),
     ('Theme', lambda _: 'theme'),
 ]
+
+
+@pytest.mark.parametrize('clsname,object_path', classname2examplepath)
+def test_documented_attributes_exist(hlwm, clsname, object_path, json_doc):
+    object_path = object_path(hlwm)
+    for _, attr in json_doc['objects'][clsname]['attributes'].items():
+        print("checking attribute {}::{}".format(clsname, attr['cpp_name']))
+        hlwm.get_attr('{}.{}'.format(object_path, attr['name']).lstrip('.'))
 
 
 def types_and_shorthands():
@@ -70,20 +78,26 @@ def types_and_shorthands():
 
 
 @pytest.mark.parametrize('clsname,object_path', classname2examplepath)
-def test_documented_attributes_exist(hlwm, clsname, object_path, json_doc):
+def test_documented_attribute_type(hlwm, clsname, object_path, json_doc):
     object_path = object_path(hlwm)
     attr_output = hlwm.call(['attr', object_path]).stdout.splitlines()
     attr_output = [line.split(' ') for line in attr_output if '=' in line]
-    attrname2shorttype = dict([(line[4], line[1]) for line in attr_output])
+    attrname2shorttype = {line[4]: line[1] for line in attr_output}
     fulltype2shorttype = types_and_shorthands()
     for _, attr in json_doc['objects'][clsname]['attributes'].items():
-        print("checking attribute {}::{}".format(clsname, attr['cpp_name']))
-        hlwm.get_attr('{}.{}'.format(object_path, attr['name']).lstrip('.'))
         assert fulltype2shorttype[attr['type']] == attrname2shorttype[attr['name']]
 
 
 @pytest.mark.parametrize('clsname,object_path', classname2examplepath)
-def test_attributes(hlwm, clsname, object_path, json_doc):
+def test_documented_children_exist(hlwm, clsname, object_path, json_doc):
+    object_path = object_path(hlwm)
+    object_path_dot = object_path + '.' if object_path != '' else ''
+    for _, child in json_doc['objects'][clsname]['children'].items():
+        hlwm.call(['object_tree', object_path_dot + child['name']])
+
+
+@pytest.mark.parametrize('clsname,object_path', classname2examplepath)
+def test_attributes_and_children_are_documented(hlwm, clsname, object_path, json_doc):
     # if a path matches the following re, then it's OK if it
     # is not mentioned explicitly in the docs
     undocumented_paths = '|'.join([
@@ -91,40 +105,15 @@ def test_attributes(hlwm, clsname, object_path, json_doc):
         r'clients\.0x[0-9a-f]+',
         r'monitors\.[0-9]+',
         r'tags\.by-name\.default',
-        # the theme children do not yet use the Child_<...> pattern
+        # TODO: the theme children do not yet use the Child_<...> pattern
         r'theme\.(|.*\.)(active|normal|urgent)',
         r'theme\.(fullscreen|tiling|floating|minimal)',
     ])
     undocumented_path_re = re.compile(r'^({})[\. ]*$'.format(undocumented_paths))
 
-    object_doc = json_doc['objects'][clsname]
-
-    if not isinstance(object_path, str):
-        # if it's not a string directly, it's a function returning
-        # a string
-        object_path = object_path(hlwm)
-
-    # 1. test that all documented attributes actually exist and that
-    # they have the right type
-    attr_output = hlwm.call(['attr', object_path]).stdout.splitlines()
-    attr_output = [line.split(' ') for line in attr_output if '=' in line]
-    attrname2shorttype = dict([(line[4], line[1]) for line in attr_output])
-    fulltype2shorttype = types_and_shorthands()
-    for _, attr in object_doc['attributes'].items():
-        print("checking attribute {}::{}".format(clsname, attr['cpp_name']))
-        hlwm.get_attr('{}.{}'.format(object_path, attr['name']).lstrip('.'))
-        assert fulltype2shorttype[attr['type']] == attrname2shorttype[attr['name']]
-
-    # 2. test that all documented children actually exist
+    object_path = object_path(hlwm)
     object_path_dot = object_path + '.' if object_path != '' else ''
-    for _, child in object_doc['children'].items():
-        hlwm.call(['object_tree', object_path_dot + child['name']])
 
-    # collect all attributes and children
-    attributes = object_doc['attributes']
-    children = object_doc['children']
-
-    # 3. test that all children/attributes are documented
     entries = hlwm.complete(['get_attr', object_path_dot], position=1, partial=True)
     for full_entry_path in entries:
         if undocumented_path_re.match(full_entry_path):
@@ -132,6 +121,7 @@ def test_attributes(hlwm, clsname, object_path, json_doc):
         assert full_entry_path[0:len(object_path_dot)] == object_path_dot
         entry = full_entry_path[len(object_path_dot):]
         if entry[-1] == '.':
-            assert entry[0:-1] in children
+            assert entry[0:-1] in json_doc['objects'][clsname]['children']
         else:
-            assert entry[0:-1] in attributes
+            assert entry[-1] == ' ', "it's an attribute if it's no child"
+            assert entry[0:-1] in json_doc['objects'][clsname]['attributes']


### PR DESCRIPTION
This adds a new script doc/gendoc.py which extracts as much information about
herbstluftwm's object tree as possible. So far, this includes the objects,
their attributes, and possible children. The output format of doc/gendoc.py is
json, so we can pass this information around easily and in fact can verify the
json-formatted documentation by the test suite (more specifically by
tests/test_doc.py).

Motivation
----------
There are three reasons for me starting this:

  - Much of the documentation plainly copies information that is already
    in the source code
  - In the long run, I'd like to have live documentation (something like
    a 'help' command as in bash), so in the end the documentation
    (including explanations) should be easily accessible for such a
    'help' command.
  - I'd like to move the object tree documentation out of
    doc/herbstluftwm.txt, because this file has already 1700 lines.

Caveats / Alternatives
----------------------
The doc/gendoc.py script will easily become (or already is?)
unmaintainable. Writing a tokenizer and half a parser from scratch feels
like reinventing the wheel, but I couldn't find a better way to do it.
I've failed with the following alternative approaches:

   - doxygen seems to be the canonical solution for documentation,
     however, it does not seem to parse anything in actual code blocks
     (e.g. the attribute names are only present in the arguments passed
     to the constructor of Attribute_).
   - clang/llvm even has a python api and I have a kind of skeleton to
     parse the hlwm source code, but it seems that sometimes it gets
     confused by template arguments.

I understand that the doc/gendoc.py script itself is way too long to
review, but fortunately, we have the much shorter test suite and one
easily gets a feeling what is going on by simply looking at the
doc/hlwm-doc.json file that is generated by 'make'.
