### PR TITLE
Add -h and --help to herbstluftwm

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -22,10 +22,12 @@ of available <<COMMANDS,*COMMANDS*>> is listed below.
 
 'OPTION' can be:
 
-    *-c*, *--autostart* 'PATH'::
-        use 'PATH' as autostart file instead of the one in '$XDG_CONFIG_HOME'
     *-v*, *--version*::
         print version and exit
+    *-h*, *--help*::
+        print a short help and exit
+    *-c*, *--autostart* 'PATH'::
+        use 'PATH' as autostart file instead of the one in '$XDG_CONFIG_HOME'
     *-l*, *--locked*::
         Initially set the monitors_locked setting to 1
     *--exit-on-xerror*::

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -451,7 +451,7 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
                 break;
             case 'h':
                 std::cout << "This starts the herbstluftwm window manager. In order to" << endl;
-                std::cout << "interact with a running herbstluftwm instance use the" << endl;
+                std::cout << "interact with a running herbstluftwm instance, use the" << endl;
                 std::cout << "\'herbstclient\' command." << endl;
                 std::cout << endl;
                 std::cout << "The herbstluftwm command accepts the following options:" << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -432,7 +432,7 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
     // parse options
     while (true) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "+c:vh", long_options, &option_index);
+        int c = getopt_long(argc, argv, "+c:vlh", long_options, &option_index);
         if (c == -1) {
             break;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -463,7 +463,7 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
                         if (long_options[i].has_arg) {
                             std::cout << " ARG";
                         }
-                        std::cout << "  ";
+                        std::cout << ", ";
                     }
                     std::cout << "--" << long_options[i].name;
                     if (long_options[i].has_arg) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -420,8 +420,9 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
     int exit_on_xerror = g.exitOnXlibError;
     int no_tag_import = 0;
     struct option long_options[] = {
-        {"autostart",       1, nullptr, 'c'},
         {"version",         0, nullptr, 'v'},
+        {"help",            0, nullptr, 'h'},
+        {"autostart",       1, nullptr, 'c'},
         {"locked",          0, nullptr, 'l'},
         {"exit-on-xerror",  0, &exit_on_xerror, 1},
         {"no-tag-import",   0, &no_tag_import, 1},
@@ -431,7 +432,7 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
     // parse options
     while (true) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "+c:vl", long_options, &option_index);
+        int c = getopt_long(argc, argv, "+c:vh", long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -448,6 +449,31 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
             case 'l':
                 g.initial_monitors_locked = 1;
                 break;
+            case 'h':
+                std::cout << "This starts the herbstluftwm window manager. In order to" << endl;
+                std::cout << "interact with a running herbstluftwm instance use the" << endl;
+                std::cout << "\'herbstclient\' command." << endl;
+                std::cout << endl;
+                std::cout << "The herbstluftwm command accepts the following options:" << endl;
+                std::cout << endl;
+                for (size_t i = 0; long_options[i].name; i++) {
+                    std::cout << "    ";
+                    if (long_options[i].val != 1) {
+                        std::cout << "-" << static_cast<char>(long_options[i].val);
+                        if (long_options[i].has_arg) {
+                            std::cout << " ARG";
+                        }
+                        std::cout << "  ";
+                    }
+                    std::cout << "--" << long_options[i].name;
+                    if (long_options[i].has_arg) {
+                        std::cout << " ARG";
+                    }
+                    std::cout << endl;
+                }
+                std::cout << endl;
+                std::cout << "See the herbstluftwm(1) man page for their meaning." << endl;
+                exit(EXIT_SUCCESS);
             default:
                 exit(EXIT_FAILURE);
         }


### PR DESCRIPTION
This is long overdue, but herbstluftwm has been lacking the -h and
--help command line flags. On -h and --help, herbstluftwm now prints a
small explanation what it is, prints all command line options and
mentions 'herbstclient' and the man page. I think this is enough for the
time being, because one never interacts manually with the herbstluftwm
binary (only when calling it mistakenly instead of 'herbstclient'
maybe).