### PR TITLE
Extend .mergify to simplify self-approval of PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,3 +10,13 @@ pull_request_rules:
               method: squash
               strict: smart
               commit_message: title+body
+    - name: Implicitly allow t-wissmann to approve own pull requests
+      conditions:
+          - author=t-wissmann
+          - status-success=Travis CI - Pull Request
+          - label≠wip
+          - label=self-approved
+      actions:
+          review:
+              type: APPROVE
+              message: "Approved via the `self-approved` label"


### PR DESCRIPTION
This makes it easier for me to merge own simple PRs that do not need to
go through a thorough review process.