### PR TITLE
Add test cases for compare

### DIFF
--- a/tests/test_root_commands.py
+++ b/tests/test_root_commands.py
@@ -305,6 +305,34 @@ def test_export_completion(hlwm):
     assert [name + '='] == hlwm.complete('export ' + prefix, position=1, partial=True)
 
 
+@pytest.mark.parametrize('attrpath,value,operator,othervalue,is_correct', [
+    # bool
+    ('settings.always_show_frame', 'on', '=', 'true', True),
+    ('settings.always_show_frame', 'on', '=', 'off', False),
+    # color
+    ('settings.frame_border_active_color', '#9fbc00', '=', '#9fbc00', True),
+    ('settings.frame_border_active_color', 'red', '=', '#ff0000', True),
+    # FIXME: make the following work:
+    # ('settings.frame_border_active_color', '#ff0000', '=', 'red', True),
+    # ('settings.frame_border_active_color', 'red', '=', 'red', True),
+    # uint
+    ('my_uint', '05', 'gt', '4', True),
+    ('my_uint', '8', 'lt', '8', False),
+    # int
+    ('my_int', '-3', 'lt', '-2', True),
+    ('settings.frame_border_width', '4', 'lt', '5', True),
+    ('settings.frame_border_width', '04', '=', '4', True),
+])
+def test_compare_example_values(hlwm, attrpath, value, operator, othervalue, is_correct):
+    hlwm.call('chain , new_attr uint my_uint , new_attr int my_int')
+    hlwm.call(['set_attr', attrpath, value])
+    cmd = ['compare', attrpath, operator, othervalue]
+    if not is_correct:
+        cmd = ['!'] + cmd
+    p = hlwm.call(cmd)
+    assert p.stdout == ''
+
+
 def test_compare_invalid_operator(hlwm):
     hlwm.call_xfail('compare monitors.count -= 1') \
         .expect_stderr('unknown operator')


### PR DESCRIPTION
This adds a bunch of test cases for the 'compare' command. There are two
deactivated test cases which can be activated as soon as a related (yet
unknown) problem in the Color comparison is fixed.