### PR TITLE
'compare': fall back to string-based comparison

### DIFF
--- a/tests/test_root_commands.py
+++ b/tests/test_root_commands.py
@@ -310,6 +310,18 @@ def test_compare_invalid_operator(hlwm):
         .expect_stderr('unknown operator')
 
 
+def test_compare_fallback_string_equal(hlwm):
+    hlwm.call('set_layout max')
+    proc = hlwm.call('compare tags.focus.tiling.root.algorithm = max')
+    assert proc.stdout == ''
+
+
+def test_compare_fallback_string_unequal(hlwm):
+    hlwm.call('set_layout max')
+    proc = hlwm.call('! compare tags.focus.tiling.root.algorithm != max')
+    assert proc.stdout == ''
+
+
 def test_try_command(hlwm):
     proc = hlwm.unchecked_call('try chain , echo foo , false')
 


### PR DESCRIPTION
If compare encounters an attribute of a certain type without an explicit
comparison function, then it should simply use the string
representation for the comparison.

An example is the type of layout algorithms and a test case is added for
that.