### PR TITLE
maximize.sh: Don't restore if layout changed

### DIFF
--- a/scripts/maximize.sh
+++ b/scripts/maximize.sh
@@ -26,6 +26,8 @@ substitute FOCUS clients.focus.winid chain
 . lock
 . or : and # if there is more than one frame, then don't restore, but maximize again!
            , compare tags.focus.frame_count = 1
+           # if the frame layout was switched manually, don't restore either
+           , compare tags.focus.tiling.root.algorithm = "$mode"
            # if we have such a stored layout, then restore it, else maximize
            , silent substitute STR tags.focus.my_unmaximized_layout load STR
            # remove the stored layout


### PR DESCRIPTION
I often do the following:

1) Call maximize.sh
2) Do some work
3) Later assume this is a "normal" max layout rather than a maximized window, thus press Mod-Space to switch to e.g. grid layout
4) Call maximize.sh again because I want to maximize another window

Instead of a new window being maximized, the layout at step 1) is restored. With this change, if the layout changed in the meantime, it's assumed the user wants to maximize again (just like when there's >1 frame already).