### PR TITLE
Improve try/silent handling in maximize.sh

### DIFF
--- a/scripts/maximize.sh
+++ b/scripts/maximize.sh
@@ -30,7 +30,7 @@ substitute FOCUS clients.focus.winid chain
            , silent substitute STR tags.focus.my_unmaximized_layout load STR
            # remove the stored layout
            , remove_attr tags.focus.my_unmaximized_layout
-     : chain , new_attr string tags.focus.my_unmaximized_layout
+     : chain , silent new_attr string tags.focus.my_unmaximized_layout
              # save the current layout in the attribute
              , set_attr tags.focus.my_unmaximized_layout "$layout"
              # force all windows into a single frame in max layout

--- a/scripts/maximize.sh
+++ b/scripts/maximize.sh
@@ -17,8 +17,6 @@ set -e
 # similar to that of Mac OS X.
 mode=${1:-max} # just some valid layout algorithm name
 
-# FIXME: for some unknown reason, remove_attr always fails
-#        fix that in the hlwm core and remove the "try" afterwards
 layout=$(herbstclient dump)
 cmd=(
 # remember which client is focused
@@ -31,7 +29,7 @@ substitute FOCUS clients.focus.winid chain
            # if we have such a stored layout, then restore it, else maximize
            , silent substitute STR tags.focus.my_unmaximized_layout load STR
            # remove the stored layout
-           , try remove_attr tags.focus.my_unmaximized_layout
+           , remove_attr tags.focus.my_unmaximized_layout
      : chain , new_attr string tags.focus.my_unmaximized_layout
              # save the current layout in the attribute
              , set_attr tags.focus.my_unmaximized_layout "$layout"


### PR DESCRIPTION
- Remove 'try' for remove_attr
    
The underlying issue was fixed, most likely in 5664c64b67f2f44e2e828f6ba231eccab60c5324.

- Make new_attr silent
    
If we aborted above because the user switched frames/layouts, the my_unmaximized_layout attribute could still exist from the previous run.