### PR TITLE
www: Abandon frame and poisonous colors

### DIFF
--- a/www/compose.py
+++ b/www/compose.py
@@ -55,7 +55,6 @@ print("""\
   <title>{title}</title>
  </head>
  <body>
-  <div id="frame">
    <div id="header">
     <div id="logoname">
      <img id="icon" src="herbstluftwm.svg"/>
@@ -66,14 +65,16 @@ print("""\
        </div>
      </div>
     </div>
-   </div>""".format(title=windowtitle))
+   </div>
+  """.format(title=windowtitle))
 
 # ====~===~=========~==
 # Navigation bar
 # ====~===~=========~==
 
 print("""\
-    <ul id="navigationbar">""")
+    <ul id="navigationbar">
+     <div class="pagewidth">""")
 
 for title, subpages in tabs.items():
     classstring = "notab"
@@ -90,6 +91,7 @@ for title, subpages in tabs.items():
 
 
 print("""\
+     </div>\
     </ul>\
     <div class="tabbarseparator"></div>
 """)
@@ -98,6 +100,7 @@ subpages = tabs.get(page2tab[name], OrderedDict([]))
 
 if len(subpages) > 1:
     print('<div class="subpagebar">')
+    print(' <div class="pagewidth">')
     for basename, title in subpages.items():
         if basename == name:
             cls = "subpagecur subpage"
@@ -106,9 +109,11 @@ if len(subpages) > 1:
         print('<span class="{cls}">'.format(cls=cls))
         print('<a href="{url}">{title}</a></span>'.format(
             url=basename + ".html", title=title))
+    print(" </div>")
     print("</div>")
 
 print("""\
+   <div class="pagewidth">\
     <div id="content">\
 """)
 

--- a/www/main.css
+++ b/www/main.css
@@ -1,29 +1,29 @@
 body {
-    background-color: #FFD694;
-    padding: 10px;
+    padding: 0px;
     margin: 0px;
 }
 
-#frame {
+.pagewidth {
+    /* this class controls the maximum page width */
     margin-left: auto;
     margin-right: auto;
-    margin-top: 0.5em;
-    margin-bottom: 2em;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    padding: 0px;
     width: 90%; max-width: 70em;
+    border: none;
 }
 
 #header, #navigationbar {
-    background-color: #C3FFB2;
-}
-#frame {
-    border: 4px solid #176800;
+    background-color: #B8DEB1;
 }
 
 @media (max-width: 35em) {
-    #frame {
+    .pagewidth {
         border: none;
         width: 100%;
         margin: 0px;
+        padding: 0px;
     }
     body {
         padding: 0px;
@@ -32,7 +32,7 @@ body {
 }
 
 
-#frame , #navigationbar .curtab {
+body, #navigationbar .curtab {
     background-color: white;
 }
 
@@ -359,7 +359,7 @@ table thead th {
 .toc {
     list-style: outside none;
     border: 1px solid #5D9B4C;
-    background-color: #E9FEE3;
+    background-color: #EAF7E6;
     marker-offset: 0px;
     padding: 0.4em;
     margin: 1em;


### PR DESCRIPTION
This updates the visual layout of the web page in order to make it look
more modern:

  - change poisonous colors
  - remove the unnecessary frame around the text content such that the
    text margin on the left and right more look like the margin around
    the text on a piece of paper.

In recent weeks, many spam mails reached the (moderation queue of the)
mailinglist critizing that our web page looks much older and less modern
than those of our competitors; and actually that's true. The present
change tries to fix this.