### PR TITLE
Add the old tag name to tag_renamed hook

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -4,6 +4,13 @@ herbstluftwm migration guide
 This guide describes the list of incompatible changes between the different
 herbstluftwm releases and how to migrate scripts and configuration.
 
+Current git version
+-------------------
+
+The tag_renamed hook has changed. The hook now emits *two* parameters.
+The first parameter contains the old name of the tag
+and the second parameter is the new name of the tag.
+
 0.5.3 to 0.6.0
 --------------
 // Will be activated as soon as the patches are fixed and re-reverted

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1667,6 +1667,9 @@ tag_added 'TAG'::
 tag_removed 'TAG'::
     The tag named 'TAG' was removed.
 
+tag_renamed 'OLD' 'NEW::
+    The tag name changed from 'OLD' to 'NEW'.
+
 urgent [on|off] 'WINID'::
     The urgent state of client with given 'WINID' has been changed to [on|off].
 

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1667,7 +1667,7 @@ tag_added 'TAG'::
 tag_removed 'TAG'::
     The tag named 'TAG' was removed.
 
-tag_renamed 'OLD' 'NEW::
+tag_renamed 'OLD' 'NEW'::
     The tag name changed from 'OLD' to 'NEW'.
 
 urgent [on|off] 'WINID'::

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -41,6 +41,7 @@ HSTag::HSTag(string name_, TagManager* tags, Settings* settings)
         [this] () { return frame->focusedFrame()->clientCount(); } )
     , flags(0)
     , floating_clients_focus_(0)
+    , oldName_(name_)
     , settings_(settings)
 {
     stack = make_shared<Stack>();

--- a/src/tag.h
+++ b/src/tag.h
@@ -51,6 +51,7 @@ public:
     void foreachClient(std::function<void(Client*)> loopBody);
     void focusFrame(std::shared_ptr<FrameLeaf> frameToFocus);
     Client* focusedClient();
+    std::string oldName_;  // Previous name of the tag, in case it got renamed
 
     void insertClient(Client* client, std::string frameIndex = {}, bool focus = true);
     Signal needsRelayout_;

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -70,7 +70,11 @@ HSTag* TagManager::add_tag(const string& name) {
     }
     HSTag* tag = new HSTag(name, this, settings_);
     addIndexed(tag);
-    tag->name.changed().connect([this,tag]() { this->onTagRename(tag); });
+    tag->name.changed().connect([this,tag,name]() {
+        static string old_tag = name;
+        this->onTagRename(old_tag, tag);
+        old_tag = tag->name();
+    });
     tag->needsRelayout_.connect([this,tag]() { this->needsRelayout_.emit(tag); });
 
     Ewmh::get().updateDesktops();
@@ -173,9 +177,9 @@ int TagManager::tag_rename_command(Input input, Output output) {
     return 0;
 }
 
-void TagManager::onTagRename(HSTag* tag) {
+void TagManager::onTagRename(const string& old_tag_name, HSTag* tag) {
     Ewmh::get().updateDesktopNames();
-    hook_emit({"tag_renamed", tag->name()});
+    hook_emit({"tag_renamed", old_tag_name, tag->name()});
 }
 
 HSTag* TagManager::ensure_tags_are_available() {

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -197,7 +197,7 @@ HSTag* TagManager::byIndexStr(const string& index_str, bool skip_visible_tags) {
     } catch (...) {
         return nullptr;
     }
-    // index must be treated relative, if it's first char is + or -
+    // index must be treated relative, if its first char is + or -
     bool is_relative = index_str[0] == '+' || index_str[0] == '-';
     Monitor* monitor = get_current_monitor();
     if (is_relative) {

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -70,10 +70,9 @@ HSTag* TagManager::add_tag(const string& name) {
     }
     HSTag* tag = new HSTag(name, this, settings_);
     addIndexed(tag);
-    tag->name.changed().connect([this,tag,name]() {
-        static string old_tag = name;
-        this->onTagRename(old_tag, tag);
-        old_tag = tag->name();
+    tag->name.changed().connect([this,tag]() {
+        this->onTagRename(tag);
+        tag->oldName_ = tag->name;
     });
     tag->needsRelayout_.connect([this,tag]() { this->needsRelayout_.emit(tag); });
 
@@ -177,9 +176,9 @@ int TagManager::tag_rename_command(Input input, Output output) {
     return 0;
 }
 
-void TagManager::onTagRename(const string& old_tag_name, HSTag* tag) {
+void TagManager::onTagRename(HSTag* tag) {
     Ewmh::get().updateDesktopNames();
-    hook_emit({"tag_renamed", old_tag_name, tag->name()});
+    hook_emit({"tag_renamed", tag->oldName_, tag->name()});
 }
 
 HSTag* TagManager::ensure_tags_are_available() {

--- a/src/tagmanager.h
+++ b/src/tagmanager.h
@@ -44,7 +44,7 @@ public:
     Signal_<HSTag*> needsRelayout_;
 private:
     std::function<void(Completion&)> frameCompletion(FrameCompleter completer);
-    void onTagRename(const std::string& old_tag_name, HSTag* tag);
+    void onTagRename(HSTag* tag);
     ByName by_name_;
     MonitorManager* monitors_ = {}; // circular dependency
     Settings* settings_;

--- a/src/tagmanager.h
+++ b/src/tagmanager.h
@@ -44,7 +44,7 @@ public:
     Signal_<HSTag*> needsRelayout_;
 private:
     std::function<void(Completion&)> frameCompletion(FrameCompleter completer);
-    void onTagRename(HSTag* tag);
+    void onTagRename(const std::string& old_tag_name, HSTag* tag);
     ByName by_name_;
     MonitorManager* monitors_ = {}; // circular dependency
     Settings* settings_;

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -263,3 +263,17 @@ def test_urgent_count(hlwm, x11):
 
     # since one of them gets focused, 4 urgent clients remain
     assert int(hlwm.get_attr('tags.focus.urgent_count')) == 4
+
+
+def test_rename_different_tags(hlwm, hc_idle):
+    hlwm.call('add foo_old')
+    hlwm.call('add bar_old')
+    hc_idle.hooks()  # clear hooks
+
+    hlwm.call('rename foo_old foo_new')
+    hlwm.call('rename bar_old bar_new')
+
+    assert hc_idle.hooks() == [
+        ['tag_renamed', 'foo_old', 'foo_new'],
+        ['tag_renamed', 'bar_old', 'bar_new']
+    ]

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -263,7 +263,7 @@ def test_urgent_count(hlwm, x11):
     assert int(hlwm.get_attr('tags.focus.urgent_count')) == 4
 
 
-def test_rename_different_tags(hlwm, hc_idle):
+def test_rename_multiple_tags(hlwm, hc_idle):
     hlwm.call('add foo_old')
     hlwm.call('add bar_old')
     hc_idle.hooks()  # clear hooks

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -92,7 +92,14 @@ def test_rename_tag(hlwm, hc_idle, rename_command):
     hlwm.call(rename_command + ['foobar'])
 
     assert hlwm.get_attr('tags.0.name') == 'foobar'
-    assert hc_idle.hooks() == [['tag_renamed', 'foobar']]
+    assert hc_idle.hooks() == [['tag_renamed', 'default', 'foobar']]
+
+    rename_once_more = rename_command.copy()
+    rename_once_more[1] = rename_once_more[1].replace('default', 'foobar')
+    hlwm.call(rename_once_more + ['baz'])
+
+    assert hlwm.get_attr('tags.0.name') == 'baz'
+    assert hc_idle.hooks() == [['tag_renamed', 'foobar', 'baz']]
 
 
 @pytest.mark.parametrize("rename_command", RENAMING_COMMANDS)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -83,20 +83,18 @@ def test_merge_tag_into_another_tag(hlwm):
 
 RENAMING_COMMANDS = [
     # commands for renaming the default tag
-    ['set_attr', 'tags.by-name.default.name'],
-    ['rename', 'default']]
+    lambda old, new: ['set_attr', 'tags.by-name.{}.name'.format(old), new],
+    lambda old, new: ['rename', old, new]]
 
 
 @pytest.mark.parametrize("rename_command", RENAMING_COMMANDS)
 def test_rename_tag(hlwm, hc_idle, rename_command):
-    hlwm.call(rename_command + ['foobar'])
+    hlwm.call(rename_command('default', 'foobar'))
 
     assert hlwm.get_attr('tags.0.name') == 'foobar'
     assert hc_idle.hooks() == [['tag_renamed', 'default', 'foobar']]
 
-    rename_once_more = rename_command.copy()
-    rename_once_more[1] = rename_once_more[1].replace('default', 'foobar')
-    hlwm.call(rename_once_more + ['baz'])
+    hlwm.call(rename_command('foobar', 'baz'))
 
     assert hlwm.get_attr('tags.0.name') == 'baz'
     assert hc_idle.hooks() == [['tag_renamed', 'foobar', 'baz']]
@@ -104,7 +102,7 @@ def test_rename_tag(hlwm, hc_idle, rename_command):
 
 @pytest.mark.parametrize("rename_command", RENAMING_COMMANDS)
 def test_rename_tag_empty(hlwm, rename_command):
-    hlwm.call_xfail(rename_command + [""]) \
+    hlwm.call_xfail(rename_command('default', '')) \
         .expect_stderr('An empty tag name is not permitted')
 
 
@@ -112,7 +110,7 @@ def test_rename_tag_empty(hlwm, rename_command):
 def test_rename_tag_existing_tag(hlwm, rename_command):
     hlwm.call('add foobar')
 
-    hlwm.call_xfail(rename_command + ["foobar"]) \
+    hlwm.call_xfail(rename_command('default', 'foobar')) \
         .expect_stderr('"foobar" already exists')
 
 


### PR DESCRIPTION
As stated correctly in #999, this hook would be more useful
if you'd know which tag was renamed.