### PR TITLE
Fix theme of urgent clients with smart_window

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -56,6 +56,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , theme(*cm.theme)
     , settings(*cm.settings)
     , ewmh(*cm.ewmh)
+    , mostRecentThemeType(Theme::Type::Tiling)
 {
     stringstream tmp;
     window_id_str = WindowID(window).str();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -220,15 +220,7 @@ void Client::window_focus() {
 }
 
 const DecTriple& Client::getDecTriple() {
-    auto triple_idx = Theme::Type::Tiling;
-    if (fullscreen_()) {
-        triple_idx = Theme::Type::Fullscreen;
-    } else if (is_client_floated()) {
-        triple_idx = Theme::Type::Floating;
-    } else {
-        triple_idx = Theme::Type::Tiling;
-    }
-    return theme[triple_idx];
+    return theme[mostRecentThemeType];
 }
 
 void Client::setup_border(bool focused) {
@@ -237,6 +229,7 @@ void Client::setup_border(bool focused) {
 
 void Client::resize_fullscreen(Rectangle monitor_rect, bool isFocused) {
     dec->resize_outline(monitor_rect, theme[Theme::Type::Fullscreen](isFocused,urgent_()));
+    mostRecentThemeType = Theme::Type::Fullscreen;
 }
 
 void Client::raise() {
@@ -253,6 +246,7 @@ void Client::resize_tiling(Rectangle rect, bool isFocused, bool minimalDecoratio
     // only apply minimal decoration if the window is not pseudotiled
     auto themetype = (minimalDecoration && !pseudotile_())
             ? Theme::Type::Minimal : Theme::Type::Tiling;
+    mostRecentThemeType = themetype;
     auto& scheme = theme[themetype](isFocused, urgent_());
     if (this->pseudotile_) {
         auto inner = this->float_size_;
@@ -420,6 +414,7 @@ void Client::resize_floating(Monitor* m, bool isFocused) {
               m->rect.y + m->pad_up() - rect.height + space,
               m->rect.y + m->rect.height - m->pad_up() - m->pad_down() - space);
     dec->resize_inner(rect, theme[Theme::Type::Floating](isFocused,urgent_()));
+    mostRecentThemeType = Theme::Type::Floating;
 }
 
 Rectangle Client::outer_floating_rect() {
@@ -633,6 +628,7 @@ void Client::fuzzy_fix_initial_position() {
     int extreme_x = float_size_.x;
     int extreme_y = float_size_.y;
     const auto& t = theme[Theme::Type::Floating];
+    mostRecentThemeType = Theme::Type::Floating;
     auto r = t.active.inner_rect_to_outline(float_size_);
     extreme_x = std::min(extreme_x, r.x);
     extreme_y = std::min(extreme_y, r.y);

--- a/src/client.h
+++ b/src/client.h
@@ -7,6 +7,7 @@
 #include "attribute_.h"
 #include "object.h"
 #include "regexstr.h"
+#include "theme.h"
 #include "types.h"
 #include "x11-types.h"
 
@@ -17,7 +18,6 @@ class Slice;
 class HSTag;
 class Monitor;
 class Settings;
-class Theme;
 class ClientManager;
 
 class Client : public Object {
@@ -132,6 +132,7 @@ private:
     Ewmh& ewmh;
     std::string tagName();
     const DecTriple& getDecTriple();
+    Theme::Type mostRecentThemeType;
 };
 
 

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -327,7 +327,7 @@ TilingResult FrameLeaf::computeLayout(Rectangle rect) {
 
     auto window_gap = settings_->window_gap();
     if (!smart_window_surroundings_active) {
-        // dedunct 'window_gap' many pixels from the left
+        // deduct 'window_gap' many pixels from the left
         // and from the top border. Later, we will deduct
         // 'window_gap' many pixels from the bottom and the
         // right from every window

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -519,6 +519,31 @@ def test_smart_window_surroundings(hlwm, x11, border_width, minimal_border_width
         == mon_height
 
 
+def test_smart_window_surroundings_urgent(hlwm, x11):
+    hlwm.call('set smart_window_surroundings on')
+    hlwm.call('set smart_frame_surroundings on')
+    hlwm.call('attr theme.border_width 42')
+    hlwm.call('attr theme.minimal.border_width 0')
+
+    win1, win1_id = x11.create_client()
+
+    # With only one client and smart_window_surroundings enabled,
+    # no gaps or surroundings are applied and
+    # the minimal decoration scheme is used
+    geo1 = win1.get_geometry()
+    assert (geo1.x, geo1.y) == (0, 0)
+
+    # Move it to another tag and make it urgent
+    hlwm.call('add otherTag')
+    hlwm.call('move otherTag')
+    x11.make_window_urgent(win1)
+    assert hlwm.get_attr(f'clients.{win1_id}.urgent') == 'true'
+
+    # The minimal theme should still apply!
+    geo1 = win1.get_geometry()
+    assert (geo1.x, geo1.y) == (0, 0)
+
+
 @pytest.mark.parametrize('running_clients_num,start_idx_range', [
     # number of clients and indices where we should start
     (6, range(0, 6)),


### PR DESCRIPTION
As #937 reported, if smart_window_surroundings is enabled, the only
client on a tag correctly uses the minimal theme for surroundings. If
however the client gets an urgency hint, it suddenly uses the normal
theme for displaying the urgent border.

Add a test for this and fix it by caching the most recently used theme
type in order to choose the correct one when drawing the urgent border
(as suggested by Thorsten).