### PR TITLE
Register theme object children via templates

### DIFF
--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -586,7 +586,7 @@ class TokTreeInfoExtrator:
         stream = TokenStream(toktreelist)
         attr_cls_re = re.compile('^(Dyn|)Attribute(Proxy|)_$')
         attribute_ = TokenStream.PatternArg(re=attr_cls_re)
-        link_ = TokenStream.PatternArg(re=re.compile('^(Link_|Child_)$'))
+        link_ = TokenStream.PatternArg(re=re.compile('^(Link_|Child_|ChildMember_)$'))
         parameters = TokenStream.PatternArg(callback=lambda t: TokenGroup.IsTokenGroup(t, opening_token='('))
 
         def semicolon_or_block_callback(t):

--- a/src/child.h
+++ b/src/child.h
@@ -44,4 +44,29 @@ private:
     std::unique_ptr<T> pointer_ = nullptr;
 };
 
+/*! A member variable that is exported to the object tree.
+ * This is a more direct variation of the Child_<> template,
+ * in the sense that here is no pointer indirection in between.
+ * You can use a member variable of type ChildMember_<T> as you
+ * would use a member of type T.
+ */
+template<typename T>
+class ChildMember_ : public T {
+public:
+    // owner is the 'parent' object
+    // 'name' is the name of the child pointer
+    template<typename... Args>
+    ChildMember_(Object& owner_, const std::string& name_, Args&&... args)
+        : T(std::forward<Args>(args)...)
+        , owner(owner_)
+        , name(name_)
+    {
+        owner.addChild(static_cast<T*>(this), name_);
+    }
+
+private:
+    Object& owner;
+    std::string name;
+};
+
 #endif

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -8,7 +8,7 @@ Theme::Theme()
     , tiling(*this, "tiling")
     , floating(*this, "floating")
     , minimal(*this, "minimal")
-    // in the following array, the ordre must match the order in Theme::Type!
+    // in the following array, the order must match the order in Theme::Type!
     , decTriples{ &fullscreen, &tiling, &floating, &minimal }
 {
     // forward attribute changes: only to tiling and floating

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -3,24 +3,18 @@
 using std::vector;
 using std::string;
 
-Theme::Theme() {
-    // add sub-decorations array as children
-    vector<string> type_names = {
-        "fullscreen",
-        "tiling",
-        "floating",
-        "minimal",
-    };
-    for (int i = 0; i < (int)Type::Count; i++) {
-        addStaticChild(&dec[i], type_names[i]);
-        dec[i].triple_changed_.connect([this](){ this->theme_changed_.emit(); });
-    }
-
+Theme::Theme()
+    : fullscreen(*this, "fullscreen")
+    , tiling(*this, "tiling")
+    , floating(*this, "floating")
+    , minimal(*this, "minimal")
+    // in the following array, the ordre must match the order in Theme::Type!
+    , decTriples{ &fullscreen, &tiling, &floating, &minimal }
+{
     // forward attribute changes: only to tiling and floating
-    auto &t = dec[(int)Type::Tiling], &f = dec[(int)Type::Floating];
-    active.makeProxyFor({&t.active, &f.active});
-    normal.makeProxyFor({&t.normal, &f.normal});
-    urgent.makeProxyFor({&t.urgent, &f.urgent});
+    active.makeProxyFor({&tiling.active, &floating.active});
+    normal.makeProxyFor({&tiling.normal, &floating.normal});
+    urgent.makeProxyFor({&tiling.urgent, &floating.urgent});
 }
 
 DecorationScheme::DecorationScheme()
@@ -49,10 +43,10 @@ DecorationScheme::DecorationScheme()
 }
 
 DecTriple::DecTriple()
+   : normal(*this, "normal")
+   , active(*this, "active")
+   , urgent(*this, "urgent")
 {
-    addStaticChild(&normal, "normal");
-    addStaticChild(&active, "active");
-    addStaticChild(&urgent, "urgent");
     vector<DecorationScheme*> children = {
         &normal,
         &active,

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -11,6 +11,10 @@ Theme::Theme()
     // in the following array, the order must match the order in Theme::Type!
     , decTriples{ &fullscreen, &tiling, &floating, &minimal }
 {
+    for (auto dec : decTriples) {
+        dec->triple_changed_.connect([this](){ this->theme_changed_.emit(); });
+    }
+
     // forward attribute changes: only to tiling and floating
     active.makeProxyFor({&tiling.active, &floating.active});
     normal.makeProxyFor({&tiling.normal, &floating.normal});

--- a/src/theme.h
+++ b/src/theme.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "attribute_.h"
+#include "child.h"
 #include "object.h"
 
 /** The proxy interface
@@ -106,9 +107,9 @@ private:
 class DecTriple : public DecorationScheme {
 public:
     DecTriple();
-    DecorationScheme  normal;
-    DecorationScheme  active;
-    DecorationScheme  urgent;
+    ChildMember_<DecorationScheme> normal;
+    ChildMember_<DecorationScheme> active;
+    ChildMember_<DecorationScheme> urgent;
     //! whenever one of the normal, active, urgend changed
     //! (but not when the proxy attributes are changed)
     Signal triple_changed_;
@@ -131,17 +132,23 @@ public:
         Tiling,
         Floating,
         Minimal,
-        Count,
+        Last = Minimal,
     };
     const DecTriple& operator[](Type t) const {
-        return dec[(int)t];
+        return *decTriples[static_cast<int>(t)];
     };
     Theme();
 
     Signal theme_changed_; //! one of the attributes in one of the triples changed
 
+    ChildMember_<DecTriple> fullscreen;
+    ChildMember_<DecTriple> tiling;
+    ChildMember_<DecTriple> floating;
+    ChildMember_<DecTriple> minimal;
+
+private:
     // a sub-decoration for each type
-    DecTriple dec[(int)Type::Count];
+    std::vector<DecTriple*> decTriples;
 };
 
 

--- a/src/theme.h
+++ b/src/theme.h
@@ -132,7 +132,6 @@ public:
         Tiling,
         Floating,
         Minimal,
-        Last = Minimal,
     };
     const DecTriple& operator[](Type t) const {
         return *decTriples[static_cast<int>(t)];

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -105,9 +105,6 @@ def test_attributes_and_children_are_documented(hlwm, clsname, object_path, json
         r'clients\.0x[0-9a-f]+',
         r'monitors\.[0-9]+',
         r'tags\.by-name\.default',
-        # TODO: the theme children do not yet use the Child_<...> pattern
-        r'theme\.(|.*\.)(active|normal|urgent)',
-        r'theme\.(fullscreen|tiling|floating|minimal)',
     ])
     undocumented_path_re = re.compile(r'^({})[\. ]*$'.format(undocumented_paths))
 


### PR DESCRIPTION
This introduces a variation of the Child_<> template called
ChildMember_<> which augments a usual C++ member variable by the
awareness of hlwm's object tree. So e.g. in the DecTriple class, I can
change the types of the members 'normal', 'active', 'urgent' from
DecorationScheme to ChildMember_<DecorationScheme> without changing the
rest of the codebase. This has two advantages:

   - It is clear in the class definition, which members are exposed to
     the object tree and which are not
   - It is easily parsable for doc/gendoc.py, which now fully covers the
     theme objects (see the removed exceptions in the test cases)