### PR TITLE
Fix the value of WM_STATE for hidden windows

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,8 +9,8 @@ Current git version
 
   * Bug fixes:
     - When hiding windows, correctly set their WM_STATE to IconicState (we set
-      it to WithDrawn state before, which means "unmanaged" and thus is wrong).
-      This may require restarting pagers when uprading hlwm live.
+      it to Withdrawn state before, which means "unmanaged" and thus is wrong).
+      This may require restarting pagers when upgrading hlwm live.
 
 Release 0.9.0 on 2020-10-31
 ---------------------------

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,14 @@ herbstluftwm NEWS -- History of user-visible changes
 See the link:MIGRATION[] file for changes that introduced incompatibility to
 older versions.
 
+Current git version
+-------------------
+
+  * Bug fixes:
+    - When hiding windows, correctly set their WM_STATE to IconicState (we set
+      it to WithDrawn state before, which means "unmanaged" and thus is wrong).
+      This may require restarting pagers.
+
 Release 0.9.0 on 2020-10-31
 ---------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,7 @@ Current git version
   * Bug fixes:
     - When hiding windows, correctly set their WM_STATE to IconicState (we set
       it to WithDrawn state before, which means "unmanaged" and thus is wrong).
-      This may require restarting pagers.
+      This may require restarting pagers when uprading hlwm live.
 
 Release 0.9.0 on 2020-10-31
 ---------------------------

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -468,7 +468,7 @@ void Client::set_visible(bool visible) {
            events, and because the ICCCM tells us to! */
         XUnmapWindow(g_display, this->dec->decorationWindow());
         XUnmapWindow(g_display, this->window_);
-        ewmh.windowUpdateWmState(this->window_, WmState::WSWithdrawnState);
+        ewmh.windowUpdateWmState(this->window_, WmState::WSIconicState);
         this->ignore_unmaps_++;
     }
     this->visible_ = visible;

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -228,6 +228,8 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
             // if the client is not directly displayed on any monitor,
             // take the current monitor
             get_current_monitor()->evaluateClientPlacement(client, changes.floatplacement);
+            // mark the client as hidden
+            ewmh->windowUpdateWmState(client->window_, WmState::WSIconicState);
         }
     }
     client->send_configure();

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -46,6 +46,7 @@ const std::array<const char*,NetCOUNT> Ewmh::netatomNames_ =
     { NetFrameExtents                , "_NET_FRAME_EXTENTS"                },
     /* window states */
     { NetWmStateFullscreen           , "_NET_WM_STATE_FULLSCREEN"          },
+    { NetWmStateHidden               , "_NET_WM_STATE_HIDDEN"              },
     { NetWmStateDemandsAttention     , "_NET_WM_STATE_DEMANDS_ATTENTION"   },
     /* window types */
     { NetWmWindowTypeDesktop         , "_NET_WM_WINDOW_TYPE_DESKTOP"       },

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -32,6 +32,7 @@ enum {
     NetWmMoveresize,
     NetFrameExtents,
     /* window states */
+    NetWmStateHidden,
     NetWmStateFullscreen,
     NetWmStateDemandsAttention,
     /* window types */

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -152,6 +152,28 @@ def test_wm_state_type(hlwm, x11):
     assert len(prop.value) == 2
 
 
+def test_wm_state_of_visible_client(hlwm, x11):
+    win, _ = x11.create_client(sync_hlwm=True)
+    wm_state = x11.display.intern_atom('WM_STATE')
+    prop = win.get_full_property(wm_state, X.AnyPropertyType)
+    assert prop.value[0] == 1  # NormalState
+
+
+@pytest.mark.parametrize('show_for_a_moment', [True, False])
+def test_wm_state_of_hidden_client(hlwm, x11, show_for_a_moment):
+    hlwm.call('chain , add foo , rule tag=foo')
+    win, _ = x11.create_client(sync_hlwm=True)
+    wm_state = x11.display.intern_atom('WM_STATE')
+
+    if show_for_a_moment:
+        hlwm.call('use foo')
+        hlwm.call('use_previous')
+
+    prop = win.get_full_property(wm_state, X.AnyPropertyType)
+    assert prop.value[0] == 3  # IconicState
+    # see https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.3.1
+
+
 def test_ewmh_focus_client(hlwm, x11):
     hlwm.call('set focus_stealing_prevention off')
     # add another client that has the focus


### PR DESCRIPTION
A window that is managed but hidden must have WM_STATE=IconicState
whereas hlwm set it to WithdrawnState before. This is described in
ICCCM[1] but also in the implementation note on virtual desktops in
EWMH[2].

Also, when a window is managed but moved to a hidden tag by the rules,
hlwm didn't set WM_STATE at all.

To make it clear to taskbars and pagers that this IconicState does not
mean 'minimized to taskbar', I've added the _NET_WM_STATE_HIDDEN to
_NET_SUPPORTED to make it clear that hlwm would set _NET_WM_STATE_HIDDEN
flag if a window was minimized.

Both these bugs regarding WM_STATE are fixed by the present commit and
checked via test cases.

[1] https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.3.1
[2] https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html#idm46035376813792