### PR TITLE
Remove old debug functions ls() and print()

### DIFF
--- a/src/hookmanager.cpp
+++ b/src/hookmanager.cpp
@@ -10,20 +10,6 @@ HookManager::HookManager()
     wireActions({ &add_, &remove_ });
 }
 
-void HookManager::ls(Path path, Output out)
-{
-    if (path.empty()) {
-        return Object::ls(out);
-    }
-
-    auto child = join_strings(path, ".");
-    if (children_.find(child) != children_.end()) {
-        children_[child]->ls({}, out);
-    } else {
-        out << "child " << child << " not found!" << endl; // TODO
-    }
-}
-
 void HookManager::add(const string &path)
 {
     //auto h = make_shared<NamedHook>(path);

--- a/src/hookmanager.h
+++ b/src/hookmanager.h
@@ -9,9 +9,6 @@ class HookManager : public Object
 public:
     HookManager();
 
-    // custom handling (hook names contain '.', they never have children)
-    void ls(Path path, Output out) override;
-
     void add(const std::string &path);
     void remove(const std::string &path);
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -95,54 +95,6 @@ void Object::ls(Output out)
         out << "  " << it.first << endl;
     }
 }
-void Object::ls(Path path, Output out) {
-    if (path.empty()) {
-        return ls(out);
-    }
-
-    auto child = path.front();
-    if (children_.find(child) != children_.end()) {
-        path.shift();
-        children_[child]->ls(path, out);
-    } else {
-        out << "child " << child << " not found!" << endl; // TODO
-    }
-}
-
-void Object::print(const string &prefix)
-{
-    if (!children_.empty()) {
-        std::cout << prefix << "Children:" << endl;
-        for (auto it : children_) {
-            it.second->print(prefix + "\t| ");
-        }
-        std::cout << prefix << endl;
-    }
-    if (!attribs_.empty()) {
-        std::cout << prefix << "Attributes:" << endl;
-        for (auto it : attribs_) {
-            std::cout << prefix << "\t" << it.first
-                      << " (" << it.second->typestr() << ")";
-            std::cout << "\t[" << it.second->str() << "]";
-            if (it.second->writeable()) {
-                std::cout << "\tw";
-            }
-            if (!it.second->hookable()) {
-                std::cout << "\t!h";
-            }
-            std::cout << endl;
-        }
-    }
-    if (!actions_.empty()) {
-        std::cout << prefix << "Actions:" << endl;
-        std::cout << prefix;
-        for (auto it : actions_) {
-            std::cout << "\t" << it.first;
-        }
-        std::cout << endl;
-    }
-    std::cout << prefix << "Currently " << hooks_.size() << " hooks:" << endl;
-}
 
 Attribute* Object::attribute(const string &name) {
     auto it = attribs_.find(name);

--- a/src/object.h
+++ b/src/object.h
@@ -28,11 +28,8 @@ public:
     Object() = default;
     virtual ~Object() = default;
 
-    virtual void print(const std::string &prefix = "\t| "); // a debug method
-
     // object tree ls command
     virtual void ls(Output out);
-    virtual void ls(Path path, Output out); // traversial version
 
     static std::pair<ArgList,std::string> splitPath(const std::string &path);
 


### PR DESCRIPTION
This removes unused duplicate printing methods that provide a subset of
the features of the `attr` command.