### PR TITLE
Add dynamic children DynChild_<> for objects

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@ older versions.
 Current git version
 -------------------
 
-  * A child object 'focused_client' for each tag object.
+  * New child object 'focused_client' for each tag object.
   * Bug fixes:
     - When hiding windows, correctly set their WM_STATE to IconicState (we set
       it to Withdrawn state before, which means "unmanaged" and thus is wrong).

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@ herbstluftwm NEWS -- History of user-visible changes
 See the link:MIGRATION[] file for changes that introduced incompatibility to
 older versions.
 
+Current git version
+-------------------
+
+  * A child object 'focused_client' for each tag object.
+
 Release 0.9.0 on 2020-10-31
 ---------------------------
 

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -586,7 +586,7 @@ class TokTreeInfoExtrator:
         stream = TokenStream(toktreelist)
         attr_cls_re = re.compile('^(Dyn|)Attribute(Proxy|)_$')
         attribute_ = TokenStream.PatternArg(re=attr_cls_re)
-        link_ = TokenStream.PatternArg(re=re.compile('^(Link_|Child_|ChildMember_)$'))
+        link_ = TokenStream.PatternArg(re=re.compile('^(Link_|Child_|DynChild_|ChildMember_)$'))
         parameters = TokenStream.PatternArg(callback=lambda t: TokenGroup.IsTokenGroup(t, opening_token='('))
 
         def semicolon_or_block_callback(t):

--- a/src/child.h
+++ b/src/child.h
@@ -69,4 +69,16 @@ private:
     std::string name;
 };
 
+template<typename T>
+class DynChild_ {
+public:
+    // A dynamic child is a callback function that dynamically
+    // returns an object of a certain type.
+    template <typename Owner>
+    DynChild_(Owner& owner, const std::string &name, T* (Owner::*getter)())
+    {
+        owner.addDynamicChild( [&owner,getter] { return (owner.*getter)(); }, name);
+    }
+};
+
 #endif

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -12,6 +12,7 @@
 #include "utils.h"
 
 using std::endl;
+using std::function;
 using std::make_shared;
 using std::pair;
 using std::shared_ptr;
@@ -163,7 +164,7 @@ void Object::notifyHooks(HookEvent event, const string& arg)
     }
 }
 
-void Object::addDynamicChild(std::function<Object* ()> child, const std::string& name)
+void Object::addDynamicChild(function<Object* ()> child, const string& name)
 {
     childrenDynamic_[name] = child;
 }
@@ -200,7 +201,7 @@ void Object::removeHook(Hook* hook)
                     hook), hooks_.end());
 }
 
-std::map<std::string, Object*> Object::children() {
+std::map<string, Object*> Object::children() {
     // copy the map of 'static' children
     auto allChildren = children_;
     // and add the dynamic children

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -62,9 +62,10 @@ void Object::wireActions(vector<Action*> actions)
 
 void Object::ls(Output out)
 {
-    out << children_.size() << (children_.size() == 1 ? " child" : " children")
-        << (!children_.empty() ? ":" : ".") << endl;
-    for (auto it : children_) {
+    const auto& children = this->children();
+    out << children.size() << (children.size() == 1 ? " child" : " children")
+        << (!children.empty() ? ":" : ".") << endl;
+    for (auto it : children) {
         out << "  " << it.first << "." << endl;
     }
 
@@ -155,6 +156,10 @@ Attribute* Object::attribute(const string &name) {
 
 
 Object* Object::child(const string &name) {
+    auto it_dyn = childrenDynamic_.find(name);
+    if (it_dyn != childrenDynamic_.end()) {
+        return it_dyn->second();
+    }
     auto it = children_.find(name);
     if (it != children_.end()) {
         return it->second;
@@ -173,17 +178,15 @@ Object* Object::child(Path path, Output output) {
     Object* cur = this;
     string cur_path = "";
     while (!path.empty()) {
-        auto it = cur->children_.find(path.front());
-        if (it != cur->children_.end()) {
-            cur = it->second;
-            cur_path += path.front();
-            cur_path += ".";
-        } else {
+        cur = cur->child(path.front());
+        if (!cur) {
             output << "Object \"" << cur_path << "\""
                 << " has no child named \"" << path.front()
                 << "\"" << endl;
             return nullptr;
         }
+        cur_path += path.front();
+        cur_path += ".";
         path.shift();
     }
     return cur;
@@ -206,6 +209,11 @@ void Object::notifyHooks(HookEvent event, const string& arg)
             }
         } // TODO: else throw
     }
+}
+
+void Object::addDynamicChild(std::function<Object* ()> child, const std::string& name)
+{
+    childrenDynamic_[name] = child;
 }
 
 void Object::addChild(Object* child, const string &name)
@@ -238,6 +246,19 @@ void Object::removeHook(Hook* hook)
                     hooks_.begin(),
                     hooks_.end(),
                     hook), hooks_.end());
+}
+
+std::map<std::string, Object*> Object::children() {
+    // copy the map of 'static' children
+    auto allChildren = children_;
+    // and add the dynamic children
+    for (auto& it : childrenDynamic_) {
+        Object* obj = it.second();
+        if (obj) {
+            allChildren[it.first] = obj;
+        }
+    }
+    return allChildren;
 }
 
 class DirectoryTreeInterface : public TreeInterface {

--- a/src/object.h
+++ b/src/object.h
@@ -1,6 +1,7 @@
 #ifndef __HS_OBJECT_H_
 #define __HS_OBJECT_H_
 
+#include <functional>
 #include <map>
 #include <string>
 #include <utility>
@@ -61,6 +62,11 @@ public:
     /* Called by the directory whenever children are added or removed */
     void notifyHooks(HookEvent event, const std::string &arg);
 
+    /** a child with the given name exists if the function
+     * returns a non-null pointer
+     */
+    void addDynamicChild(std::function<Object*()> child, const std::string &name);
+
     void addChild(Object* child, const std::string &name);
     void addStaticChild(Object* child, const std::string &name);
     void removeChild(const std::string &child);
@@ -68,7 +74,7 @@ public:
     void addHook(Hook* hook);
     void removeHook(Hook* hook);
 
-    const std::map<std::string, Object*>& children() { return children_; }
+    std::map<std::string, Object*> children();
 
     void printTree(Output output, std::string rootLabel);
 
@@ -80,6 +86,7 @@ protected:
     std::map<std::string, Attribute*> attribs_;
     std::map<std::string, Action*> actions_;
 
+    std::map<std::string, std::function<Object*()>> childrenDynamic_;
     std::map<std::string, Object*> children_;
     std::vector<Hook*> hooks_;
 

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -39,6 +39,7 @@ HSTag::HSTag(string name_, TagManager* tags, Settings* settings)
         [this] () { return frame->focusedFrame()->getSelection(); } )
     , curframe_wcount(this, "curframe_wcount",
         [this] () { return frame->focusedFrame()->clientCount(); } )
+    , focused_client(*this, "focused_client", &HSTag::focusedClient)
     , flags(0)
     , floating_clients_focus_(0)
     , oldName_(name_)

--- a/src/tag.h
+++ b/src/tag.h
@@ -39,6 +39,7 @@ public:
     DynAttribute_<int> urgent_count; //! The number of urgent clients
     DynAttribute_<int> curframe_windex;
     DynAttribute_<int> curframe_wcount;
+    DynChild_<Client> focused_client;
     int             flags;
     std::vector<Client*> floating_clients_; //! the clients in floating mode
     size_t               floating_clients_focus_; //! focus in the floating clients

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -37,6 +37,7 @@ def create_tag_with_all_links(hlwm):
     hlwm.create_client()
     return 'tags.0'
 
+
 # map every c++ class name to a function ("constructor") accepting an hlwm
 # fixture and returning the path to an example object of the C++ class
 classname2examplepath = [

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -32,6 +32,11 @@ def create_frame_split(hlwm):
     return 'tags.0.tiling.root'
 
 
+def create_tag_with_all_links(hlwm):
+    """create a tag with focused_client set"""
+    hlwm.create_client()
+    return 'tags.0'
+
 # map every c++ class name to a function ("constructor") accepting an hlwm
 # fixture and returning the path to an example object of the C++ class
 classname2examplepath = [
@@ -42,7 +47,7 @@ classname2examplepath = [
     ('DecorationScheme', lambda _: 'theme.tiling.urgent'),
     ('FrameLeaf', lambda _: 'tags.0.tiling.root'),
     ('FrameSplit', create_frame_split),
-    ('HSTag', lambda _: 'tags.0'),
+    ('HSTag', create_tag_with_all_links),
     ('Monitor', lambda _: 'monitors.0'),
     ('MonitorManager', lambda _: 'monitors'),
     ('Root', lambda _: ''),

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -275,3 +275,45 @@ def test_rename_multiple_tags(hlwm, hc_idle):
         ['tag_renamed', 'foo_old', 'foo_new'],
         ['tag_renamed', 'bar_old', 'bar_new']
     ]
+
+
+# the test cases on focused_client are implicitly tests
+# for the DynChild_ related code.
+@pytest.mark.parametrize("client_exists", [True, False])
+def test_focused_client_existence(hlwm, client_exists):
+    # here, I want the same python code for the positive
+    # and negative test, because the negative test only checks
+    # whether no entry exists.
+    if client_exists:
+        winid, _ = hlwm.create_client()
+
+    def test_children(children):
+        assert ('focused_client' in children) == client_exists
+        assert 'tiling' in children
+
+    test_children(hlwm.list_children_via_attr('tags.0'))
+    test_children(hlwm.list_children('tags.0'))
+
+    if client_exists:
+        assert hlwm.get_attr('tags.0.focused_client.winid') == winid
+
+
+def test_focused_client_multiple_tags(hlwm):
+    tagname2clientcount = [
+        ('t1', 1),
+        ('t2', 0),
+        ('t3', 3),
+        ('t4', 1),
+    ]
+    tagname2clients = {}
+    for t, cnt in tagname2clientcount:
+        # replace dict entry by client list
+        hlwm.call(f'chain , add {t} , rule tag={t} focus=off')
+        tagname2clients[t] = [hlwm.create_client()[0] for _ in range(0, cnt)]
+
+    for t, clients in tagname2clients.items():
+        assert ('focused_client' in hlwm.list_children(f'tags.by-name.{t}')) \
+            == (len(clients) > 0)
+        if len(clients) > 0:
+            assert hlwm.get_attr(f'tags.by-name.{t}.focused_client.winid') \
+                == clients[0]


### PR DESCRIPTION
This allows that a child entry of an object is not an explicit Object*
but a lambda instead that dynamically returns the Object* in this child
entry. This is usefull for entries that are indirectly determined by
other values. For those entries it would be much more coding effort to
keep the links up to date, so instead we just look the information up
when the information is queried, just as in the case of DynAttribute_.