### PR TITLE
Make codecov interaction optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
                 focal sh -c '
                     /hlwm/ci/build.py --build-dir=/hlwm/build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=/.ccache --compile --run-tests
                 '
-              - bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo Warning codecov report failed
+              - "bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo Warning: codecov report failed"
 
         - name: "Build with Clang, run linters and static analyzers"
           env: TRAVIS_CACHE_ID=focal-linter

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
                 focal sh -c '
                     /hlwm/ci/build.py --build-dir=/hlwm/build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=/.ccache --compile --run-tests
                 '
-              - bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo "Warning: codecov report failed!"
+              - bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo Warning: codecov report failed
 
         - name: "Build with Clang, run linters and static analyzers"
           env: TRAVIS_CACHE_ID=focal-linter

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
                 focal sh -c '
                     /hlwm/ci/build.py --build-dir=/hlwm/build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=/.ccache --compile --run-tests
                 '
-              - bash <(wget -O - https://codecov.io/bash) -f coverage.info || true
+              - bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo "Warning: codecov report failed!"
 
         - name: "Build with Clang, run linters and static analyzers"
           env: TRAVIS_CACHE_ID=focal-linter

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
                 focal sh -c '
                     /hlwm/ci/build.py --build-dir=/hlwm/build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=/.ccache --compile --run-tests
                 '
-              - bash <(curl -s https://codecov.io/bash) -f coverage.info
+              - bash <(wget -O - https://codecov.io/bash) -f coverage.info || true
 
         - name: "Build with Clang, run linters and static analyzers"
           env: TRAVIS_CACHE_ID=focal-linter

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
                 focal sh -c '
                     /hlwm/ci/build.py --build-dir=/hlwm/build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=/.ccache --compile --run-tests
                 '
-              - bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo Warning: codecov report failed
+              - bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo Warning codecov report failed
 
         - name: "Build with Clang, run linters and static analyzers"
           env: TRAVIS_CACHE_ID=focal-linter


### PR DESCRIPTION
Also switch from curl to wget, which does not print the response body to
stdout on failure. Before, curl printed the error message in html
format, which was piped directly into bash.