### PR TITLE
Parse doc string from sourcecode

### DIFF
--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -682,7 +682,6 @@ class TokTreeInfoExtrator:
             if stream.try_match(arg1, '.', 'setDoc', parameters, ';'):
                 doc_tokens = parameters.value.enclosed_tokens
                 doc_string = ast.literal_eval(' '.join(doc_tokens))
-                # print(f"doc: {classname}::{arg1.value} => {doc_string}")
                 self.objInfo.member_doc(classname, arg1.value, doc_string)
             else:
                 stream.pop()

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -317,6 +317,7 @@ class ObjectInformation:
             self.default_value = None
             self.attribute_class = None  # whether this is an Attribute_ or sth else
             self.constructor_args = None  # the arguments to the constructor
+            self.doc = None  # a longer doc string
 
         def add_constructor_args(self, args):
             # split 'args' by the ',' tokens
@@ -389,6 +390,7 @@ class ObjectInformation:
             self.child_class = None  # whether this is a Link_ or a Child_
             self.type = None  # the template argument to Link_ or Child_
             self.constructor_args = None
+            self.doc = None  # a longer doc string
 
         def add_constructor_args(self, args):
             if len(args) >= 4:
@@ -403,6 +405,7 @@ class ObjectInformation:
         self.base_classes = {}  # mapping class names to base classes
         self.member2info = {}  # mapping (classname,member) to ChildInformation or AttributeInformation
         self.member2init = {}  # mapping (classname,member) to its initializer list
+        self.member2doc = {}  # mapping (classname,member) to its doc string
 
     def base_class(self, subclass, baseclass):
         if subclass not in self.base_classes:
@@ -414,13 +417,16 @@ class ObjectInformation:
         self.member2init[(classname, member)] = init_list
 
     def process_member_init(self):
-        """try to pass colleced member initializations to attributes"""
+        """try to pass collected member initializations and docs to members"""
         for (clsname, attrs), attr in self.member2info.items():
             if attr.constructor_args is not None:
                 continue
             init_list = self.member2init.get((clsname, attr.cpp_name), None)
             if init_list is not None:
                 attr.add_constructor_args(init_list)
+            doc = self.member2doc.get((clsname, attr.cpp_name), None)
+            if doc is not None:
+                attr.doc = doc
 
     def attribute_info(self, classname: str, attr_cpp_name: str):
         """return the AttributeInformation object for
@@ -441,6 +447,10 @@ class ObjectInformation:
             self.member2info[(classname, cpp_name)] = \
                 ObjectInformation.ChildInformation(cpp_name)
         return self.member2info[(classname, cpp_name)]
+
+    def member_doc(self, classname: str, cpp_name: str, doc: str):
+        """set the doc string of a member variable of a class"""
+        self.member2doc[(classname, cpp_name)] = doc
 
     def superclasses_transitive(self):
         """return a set of a dict mapping a class to the set
@@ -516,22 +526,28 @@ class ObjectInformation:
                     if isinstance(member, ObjectInformation.AttributeInformation):
                         # assert uniqueness:
                         assert member.user_name not in attributes
-                        attributes[member.user_name] = {
+                        obj = {
                             'name': member.user_name,
                             'cpp_name': member.cpp_name,
                             'type': member.type.to_user_type_name(),
                             'default_value': member.default_value,
                             'class': member.attribute_class,
                         }
+                        if member.doc is not None:
+                            obj['doc'] = member.doc
+                        attributes[member.user_name] = obj
                     if isinstance(member, ObjectInformation.ChildInformation):
                         # assert uniqueness:
                         assert member.user_name not in children
-                        children[member.user_name] = {
+                        obj = {
                             'name': member.user_name,
                             'cpp_name': member.cpp_name,
                             'type': member.type.to_user_type_name(),
                             'class': member.child_class,
                         }
+                        if member.doc is not None:
+                            obj['doc'] = member.doc
+                        children[member.user_name] = obj
             assert clsname not in result  # assert uniqueness
             result[clsname] = {
                 'classname': clsname,
@@ -654,6 +670,20 @@ class TokTreeInfoExtrator:
                 # we found a member initialization
                 init_list = parameters.value.enclosed_tokens
                 self.objInfo.member_init(classname, arg1.value, init_list)
+            else:
+                stream.pop()
+        # we're now on a codeblock
+        self.stream_consume_setDoc(classname, TokenStream(codeblock.value.enclosed_tokens))
+
+    def stream_consume_setDoc(self, classname, stream):
+        arg1 = TokenStream.PatternArg()
+        parameters = TokenStream.PatternArg(callback=lambda t: TokenGroup.IsTokenGroup(t, opening_token='('))
+        while not stream.empty():
+            if stream.try_match(arg1, '.', 'setDoc', parameters, ';'):
+                doc_tokens = parameters.value.enclosed_tokens
+                doc_string = ast.literal_eval(' '.join(doc_tokens))
+                # print(f"doc: {classname}::{arg1.value} => {doc_string}")
+                self.objInfo.member_doc(classname, arg1.value, doc_string)
             else:
                 stream.pop()
 

--- a/src/attribute.h
+++ b/src/attribute.h
@@ -40,7 +40,7 @@ class Completion;
  * Note that for similar reasons, dynamic attributes are not hookable.
  */
 
-class Attribute : public Entity {
+class Attribute : public Entity, public HasDocumentation {
 
 public:
     Attribute(const std::string &name,

--- a/src/child.h
+++ b/src/child.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "entity.h"
 #include "object.h"
 
 /*! implement a static child object in the object tree. Static means that
@@ -12,7 +13,7 @@
  * accordingly.
  */
 template<typename T>
-class Child_ {
+class Child_ : public HasDocumentation {
 public:
     // owner is the 'parent' object
     // 'name' is the name of the child pointer

--- a/src/child.h
+++ b/src/child.h
@@ -71,7 +71,7 @@ private:
 };
 
 template<typename T>
-class DynChild_ {
+class DynChild_ : public HasDocumentation {
 public:
     // A dynamic child is a callback function that dynamically
     // returns an object of a certain type.

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -34,6 +34,10 @@ ClientManager::ClientManager()
     , settings(nullptr)
     , ewmh(nullptr)
 {
+    focus.setDoc("the focused client (only exists if a client is focused)");
+    dragged.setDoc("the object of a client which is currently dragged"
+                   " by the mouse, if any. See the documentation of the"
+                   "  mousebind command for examples.");
 }
 
 ClientManager::~ClientManager()

--- a/src/entity.h
+++ b/src/entity.h
@@ -50,6 +50,17 @@ static const std::map<Type, std::pair<std::string, char>> type_strings = {
 
 bool operator<(Type t1, Type t2);
 
+class HasDocumentation  {
+public:
+    void setDoc(const char text[]) { doc_ = text; }
+    std::string doc() const { return doc_; };
+private:
+    /** we avoid the duplication of the doc string
+     * with every instance of the owning class.
+     */
+    const char* doc_ = nullptr;
+};
+
 class Entity {
 public:
     Entity() = default;

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -36,7 +36,7 @@ FrameTree::FrameTree(HSTag* tag, Settings* settings)
     rootLink_ = root_.get();
     (void) tag_;
     (void) settings_;
-    // focused_frame_.setDoc("The focused frame (leaf) in this frame tree");
+    focused_frame_.setDoc("The focused frame (leaf) in this frame tree");
 }
 
 void FrameTree::foreachClient(function<void(Client*)> action)

--- a/src/link.h
+++ b/src/link.h
@@ -1,6 +1,7 @@
 #ifndef HLWM_LINK_H_
 #define HLWM_LINK_H_
 
+#include "entity.h"
 #include "object.h"
 
 /*! A pointer to another object in the object tree. if this is
@@ -8,7 +9,7 @@
  * automatically.
  */
 template<typename T>
-class Link_ {
+class Link_ : public HasDocumentation {
 public:
     // 'name' is the name of the child pointer
     Link_(Object& parent, std::string name)

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -57,6 +57,15 @@ HSTag::HSTag(string name_, TagManager* tags, Settings* settings)
     floating_focused.setValidator([this](bool v) {
         return this->floatingLayerCanBeFocused(v);
     });
+
+    floating.setDoc("if the entire tag is set to floating mode");
+    floating_focused.setDoc("if the floating layer is focused"
+                            " (otherwise the tiling layer is)");
+    frame_count.setDoc("the number of frames on this tag");
+    client_count.setDoc("the number of clients on this tag");
+    urgent_count.setDoc("the number of urgent clients on this tag");
+    curframe_windex.setDoc("index of the focused client in the select frame");
+    curframe_wcount.setDoc("number of clients in the selected frame");
 }
 
 HSTag::~HSTag() {

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -75,7 +75,7 @@ HSTag::HSTag(string name_, TagManager* tags, Settings* settings)
     frame_count.setDoc("the number of frames on this tag");
     client_count.setDoc("the number of clients on this tag");
     urgent_count.setDoc("the number of urgent clients on this tag");
-    curframe_windex.setDoc("index of the focused client in the select frame");
+    curframe_windex.setDoc("index of the focused client in the selected frame");
     curframe_wcount.setDoc("number of clients in the selected frame");
 }
 


### PR DESCRIPTION
This contributes the following:

  - A new C++ base class HasDocumentation is added. It has a member
    function setDoc() which allows to set user documentation within the
    hlwm source code. So far, there is no functionality to pass the doc
    string further to the user
  - doc/gendoc.py is extended such that it reads these invocation of
    setDoc() and puts this documentation text into the hlwm-doc.json