### PR TITLE
Make index attribute of tags writable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ older versions.
 Current git version
 -------------------
 
+  * The 'index' attribute of tags is now writable. This allows adjusting the
+    order of existing tags.
   * Bug fixes:
     - When hiding windows, correctly set their WM_STATE to IconicState (we set
       it to Withdrawn state before, which means "unmanaged" and thus is wrong).

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -249,11 +249,7 @@ void Ewmh::windowUpdateTag(Window win, HSTag* tag) {
     if (!tag) {
         return;
     }
-    int index = tags_->index_of(tag);
-    if (index < 0) {
-        HSWarning("tag %s not found in internal list\n", tag->name->c_str());
-        return;
-    }
+    int index = tag->index();
     X_.setPropertyCardinal(win, netatom_[NetWmDesktop], { index });
 }
 

--- a/src/indexingobject.h
+++ b/src/indexingobject.h
@@ -4,7 +4,6 @@
 #include <cstddef>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #include "attribute_.h"
 #include "object.h"

--- a/src/indexingobject.h
+++ b/src/indexingobject.h
@@ -103,7 +103,6 @@ public:
         if (newIndex == oldIndex) {
             return;
         }
-        printf("fixing indices\n");
         // go from newIndex to oldIndex
         int delta = (newIndex < oldIndex) ? 1 : -1;
         T* lastValue = object;

--- a/src/indexingobject.h
+++ b/src/indexingobject.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "attribute_.h"
 #include "object.h"
@@ -83,7 +84,48 @@ public:
         data.erase(data.begin(), data.end());
     }
 
+    void indexChangeRequested(T* object, size_t newIndex) {
+        if (newIndex < data.size() && data[newIndex] == object) {
+            // nothing to do
+            return;
+        }
+        if (data.empty()) {
+            return;
+        }
+        if (newIndex >= data.size()) {
+            newIndex = data.size() - 1;
+        }
+        int oldIndexSigned = index_of(object);
+        if (oldIndexSigned < 0) {
+            return;
+        }
+        size_t oldIndex = static_cast<size_t>(oldIndexSigned);
+        if (newIndex == oldIndex) {
+            return;
+        }
+        printf("fixing indices\n");
+        // go from newIndex to oldIndex
+        int delta = (newIndex < oldIndex) ? 1 : -1;
+        T* lastValue = object;
+        for (size_t i = newIndex; i != oldIndex; i+= delta) {
+            // swap data[i] with lastValue
+            T* tmp = data[i];
+            data[i] = lastValue;
+            lastValue = tmp;
+        }
+        data[oldIndex] = lastValue;
+        // for each of these, update the index
+        for (size_t i = newIndex; i != oldIndex; i+= delta) {
+            data[i]->setIndexAttribute(i);
+            addChild(data[i], std::to_string(i));
+        }
+        data[oldIndex]->setIndexAttribute(oldIndex);
+        addChild(data[oldIndex], std::to_string(oldIndex));
+        indicesChanged.emit();
+    }
+
     DynAttribute_<unsigned long> count;
+    Signal indicesChanged;
 
     // iterators
     typedef typename std::vector<T*>::iterator iterator_type;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -1,5 +1,6 @@
 #include "tag.h"
 
+#include <sstream>
 #include <type_traits>
 
 #include "argparse.h"
@@ -23,6 +24,7 @@ using std::function;
 using std::make_shared;
 using std::shared_ptr;
 using std::string;
+using std::stringstream;
 
 static bool    g_tag_flags_dirty = true;
 
@@ -528,12 +530,12 @@ int HSTag::closeOrRemoveCommand() {
     return 0;
 }
 
-std::string HSTag::isValidTagIndex(unsigned long newIndex)
+string HSTag::isValidTagIndex(unsigned long newIndex)
 {
     if (newIndex < tags_->size()) {
         return "";
     }
-    std::stringstream ss;
+    stringstream ss;
     ss << "Index must be between 0 and " << (tags_->size() - 1);
     return ss.str();
 }

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -528,9 +528,9 @@ int HSTag::closeOrRemoveCommand() {
     return 0;
 }
 
-std::string HSTag::isValidTagIndex(unsigned long index)
+std::string HSTag::isValidTagIndex(unsigned long newIndex)
 {
-    if (index < tags_->size()) {
+    if (newIndex < tags_->size()) {
         return "";
     }
     std::stringstream ss;

--- a/src/tag.h
+++ b/src/tag.h
@@ -74,6 +74,7 @@ public:
     int closeAndRemoveCommand();
     int closeOrRemoveCommand();
 private:
+    std::string isValidTagIndex(unsigned long index);
     std::string floatingLayerCanBeFocused(bool floatingFocused);
     void onGlobalFloatingChange(bool newState);
     void fixFocusIndex();
@@ -83,6 +84,7 @@ private:
     int computeFrameCount();
     //! get the number of urgent clients on this tag
     int countUrgentClients();
+    TagManager* tags_;
     Settings* settings_;
 };
 

--- a/src/tag.h
+++ b/src/tag.h
@@ -74,7 +74,7 @@ public:
     int closeAndRemoveCommand();
     int closeOrRemoveCommand();
 private:
-    std::string isValidTagIndex(unsigned long index);
+    std::string isValidTagIndex(unsigned long newIndex);
     std::string floatingLayerCanBeFocused(bool floatingFocused);
     void onGlobalFloatingChange(bool newState);
     void fixFocusIndex();

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -25,6 +25,10 @@ TagManager::TagManager()
     , settings_(nullptr)
     , focus_(*this, "focus")
 {
+    indicesChanged.connect([](){
+        Ewmh::get().updateDesktopNames();
+        tag_set_flags_dirty();
+    });
 }
 
 void TagManager::injectDependencies(MonitorManager* m, Settings *s) {

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -27,6 +27,7 @@ TagManager::TagManager()
 {
     indicesChanged.connect([](){
         Ewmh::get().updateDesktopNames();
+        Ewmh::get().updateCurrentDesktop();
         tag_set_flags_dirty();
     });
 }

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -37,7 +37,7 @@ def test_net_wm_desktop_after_tag_index_increment(hlwm, x11):
     win, winid = x11.create_client()
     assert x11.get_property('_NET_WM_DESKTOP', win)[0] == 1
 
-    # move the tag3 to the begin of the list
+    # move the tag3 to the beginning of the list
     hlwm.call('attr tags.by-name.tag3.index 0')
     # so the index of the tag of the client increased by one
     assert x11.get_property('_NET_WM_DESKTOP', win)[0] == 2
@@ -61,7 +61,7 @@ def test_net_wm_desktop_after_tag_index_decrement(hlwm, method, x11):
         # remove 'tag1' so all later tags experience a index shift
         hlwm.call('merge_tag tag1 default')
 
-    # so the index of the tag of the client increased by one
+    # so the index of the tag of the client decreased by one
     assert hlwm.get_attr('tags.by-name.tag3.index') == '2'
     assert x11.get_property('_NET_WM_DESKTOP', win)[0] == 2
 

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -66,6 +66,41 @@ def test_net_wm_desktop_after_tag_index_decrement(hlwm, method, x11):
     assert x11.get_property('_NET_WM_DESKTOP', win)[0] == 2
 
 
+@pytest.mark.parametrize('new_idx', [0, 1, 2])
+def test_net_wm_desktop_after_tag_index_direct_change(hlwm, x11, new_idx):
+    hlwm.call('add tag1')
+    hlwm.call('add tag2')
+    hlwm.call('rule tag=tag2')
+    win, winid = x11.create_client()
+    assert hlwm.get_attr('tags.by-name.tag2.index') == '2'
+    assert x11.get_property('_NET_WM_DESKTOP', win)[0] == 2
+
+    hlwm.call(f'attr tags.by-name.tag2.index {new_idx}')
+
+    assert int(hlwm.get_attr('tags.by-name.tag2.index')) == new_idx
+    assert x11.get_property('_NET_WM_DESKTOP', win)[0] == new_idx
+
+
+@pytest.mark.parametrize('focus_idx', range(0, 4))
+@pytest.mark.parametrize('old_idx', range(0, 4))
+@pytest.mark.parametrize('new_idx', range(0, 4))
+def test_net_current_desktop_after_tag_index_change(hlwm, x11, focus_idx, old_idx, new_idx):
+    hlwm.call('add tag1')
+    hlwm.call('add tag2')
+    hlwm.call('add tag3')
+
+    hlwm.call(f'use_index {focus_idx}')
+    x11.display.sync()
+    assert int(hlwm.get_attr('tags.focus.index')) == x11.ewmh.getCurrentDesktop()
+    focus_name = hlwm.get_attr('tags.focus.name')
+
+    hlwm.call(f'attr tags.{old_idx}.index {new_idx}')
+
+    x11.display.sync()
+    assert int(hlwm.get_attr('tags.focus.index')) == x11.ewmh.getCurrentDesktop()
+    assert focus_name == hlwm.get_attr('tags.focus.name')
+
+
 @pytest.mark.parametrize('utf8names,desktop_names', [
     (False, ['default']),
     (False, ['foo']),

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -105,6 +105,16 @@ def test_index_change(hlwm, tag_count, old_idx, new_idx):
         assert hlwm.get_attr(f'tags.{i}.name') == new_names[i]
 
 
+@pytest.mark.parametrize("tag_count", [1, 4])
+def test_index_to_big(hlwm, tag_count):
+    for i in range(1, tag_count):  # one tag already exists
+        hlwm.call(f'add tag{i}')
+
+    for new_idx in [tag_count, tag_count + 10]:
+        hlwm.call_xfail(f'attr tags.0.index {new_idx}') \
+            .expect_stderr(f'Index must be between 0 and {tag_count - 1}')
+
+
 RENAMING_COMMANDS = [
     # commands for renaming the default tag
     lambda old, new: ['set_attr', 'tags.by-name.{}.name'.format(old), new],

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -81,6 +81,29 @@ def test_merge_tag_into_another_tag(hlwm):
     assert hlwm.get_attr('tags.0.name') == 'foobar'
 
 
+@pytest.mark.parametrize("tag_count, old_idx, new_idx",
+    [(count, old, new) for count in range(0, 6)
+                       for old in range(0, count)
+                       for new in range(0, count)])
+def test_index_change(hlwm, tag_count, old_idx, new_idx):
+    names = ["orig" + str(i) for i in range(0, tag_count)]
+    for n in names:
+        hlwm.call(['add', n])
+
+    # get rid of the 'default' tag
+    hlwm.call('use_index 1')
+    hlwm.call('merge_tag default')
+
+    hlwm.call(f'attr tags.{old_idx}.index {new_idx}')
+
+    assert hlwm.get_attr(f'tags.{new_idx}.name') == names[old_idx]
+    new_names = [n for n in names if n != names[old_idx]]
+    new_names.insert(new_idx, names[old_idx])
+    for i in range(0, tag_count):
+        assert hlwm.get_attr(f'tags.{i}.index') == str(i)
+        assert hlwm.get_attr(f'tags.{i}.name') == new_names[i]
+
+
 RENAMING_COMMANDS = [
     # commands for renaming the default tag
     lambda old, new: ['set_attr', 'tags.by-name.{}.name'.format(old), new],

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -81,10 +81,11 @@ def test_merge_tag_into_another_tag(hlwm):
     assert hlwm.get_attr('tags.0.name') == 'foobar'
 
 
-@pytest.mark.parametrize("tag_count, old_idx, new_idx",
-    [(count, old, new) for count in range(0, 6)
-                       for old in range(0, count)
-                       for new in range(0, count)])
+@pytest.mark.parametrize("tag_count, old_idx, new_idx", [
+    (count, old, new)
+    for count in range(0, 6)
+    for old in range(0, count)
+    for new in range(0, count)])
 def test_index_change(hlwm, tag_count, old_idx, new_idx):
     names = ["orig" + str(i) for i in range(0, tag_count)]
     for n in names:


### PR DESCRIPTION
This requires the respective array operations in the IndexingObject and
also it requires that the EWMH properties are updated accordingly.
While writing test cases for that, I noticed that the EWMH properties
are not updated properly when a tag is removed (this changes the index
of the clients on later tags).

The wiring of the signals now solves both issues.