### PR TITLE
Add focused_frame child in the tiling object

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ Current git version
 -------------------
 
   * New child object 'focused_client' for each tag object.
+  * New child object 'focused_frame' for the tiling object of each tag object.
   * Bug fixes:
     - When hiding windows, correctly set their WM_STATE to IconicState (we set
       it to Withdrawn state before, which means "unmanaged" and thus is wrong).

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -28,6 +28,7 @@ using std::vector;
 
 FrameTree::FrameTree(HSTag* tag, Settings* settings)
     : rootLink_(*this, "root")
+    , focused_frame_(*this, "focused_frame", &FrameTree::focusedFramePlainPtr)
     , tag_(tag)
     , settings_(settings)
 {
@@ -35,6 +36,7 @@ FrameTree::FrameTree(HSTag* tag, Settings* settings)
     rootLink_ = root_.get();
     (void) tag_;
     (void) settings_;
+    // focused_frame_.setDoc("The focused frame (leaf) in this frame tree");
 }
 
 void FrameTree::foreachClient(function<void(Client*)> action)
@@ -339,6 +341,16 @@ shared_ptr<FrameLeaf> FrameTree::findEmptyFrameNearFocusGeometrically(shared_ptr
         }
     }
     return closestFrame;
+}
+
+Frame* FrameTree::focusedFramePlainPtr()
+{
+    auto shared = focusedFrame();
+    if (shared) {
+        return shared.get();
+    } else {
+        return nullptr;
+    }
 }
 
 //! check whether there is an empty frame in the given subtree,

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 
+#include "child.h"
 #include "fixprecdec.h"
 #include "link.h"
 #include "object.h"
@@ -72,10 +73,12 @@ public:
 public: // soon to be come private:
     std::shared_ptr<Frame> root_;
     Link_<Frame> rootLink_;
+    DynChild_<Frame> focused_frame_;
     //! replace a node in the frame tree, either modifying old's parent or the root_
     void replaceNode(std::shared_ptr<Frame> old, std::shared_ptr<Frame> replacement);
 private:
     static std::shared_ptr<FrameLeaf> findEmptyFrameNearFocusGeometrically(std::shared_ptr<Frame> subtree);
+    Frame* focusedFramePlainPtr();
     //! cycle the frames within the current tree
     void cycle_frame(std::function<size_t(size_t,size_t)> indexAndLenToIndex);
     void cycle_frame(int delta);

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1013,3 +1013,18 @@ def test_frame_index_attribute(hlwm):
         # after each splitting operation, check that
         # the frame's index attribute is correct:
         verify_frame_tree('tags.focus.tiling.root', '')
+
+
+def test_focused_frame_child(hlwm):
+    # do it as one test case to see that the
+    # child correctly adjusts at run-time
+    test_data = [
+        ('', '(clients max:0)'),
+        ('0', '(split vertical:0.5:0 (clients max:0) (clients max:0))'),
+        ('1', '(split vertical:0.5:1 (clients max:0) (clients max:0))'),
+        ('00', '(split vertical:0.5:0 (split vertical:0.5:0) (clients max:0))'),
+        ('01', '(split vertical:0.5:0 (split vertical:0.5:1) (clients max:0))'),
+    ]
+    for focused_index, layout in test_data:
+        hlwm.call(['load', layout])
+        assert hlwm.get_attr('tags.0.tiling.focused_frame.index') == focused_index


### PR DESCRIPTION
This focused_frame child points to the focused frame leave and allows to
inspect the frame that is currently focused, e.g. its layout:

    herbstclient attr tags.focus.tiling.focused_frame.algorithm

This prints the layout algorithm used in the currently focused frame,
and thus solves issue #71.