### PR TITLE
Expose visibility information via the object tree

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -34,7 +34,7 @@ static Client* lastfocus = nullptr;
 Client::Client(Window window, bool visible_already, ClientManager& cm)
     : window_(window)
     , dec(make_unique<Decoration>(this, *cm.settings))
-    , visible_(visible_already)
+    , visible_(this, "visible", visible_already)
     , urgent_(this, "urgent", false)
     , floating_(this,  "floating", false)
     , fullscreen_(this,  "fullscreen", false)
@@ -88,6 +88,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     });
 
     init_from_X();
+    visible_.setDoc("whether this client is rendered currently");
 }
 
 void Client::init_from_X() {
@@ -114,7 +115,7 @@ void Client::make_full_client() {
     XReparentWindow(g_display, window_, dec->decorationWindow(), 40, 40);
     // if this client is visible, then reparenting will make it invisible
     // and will create a unmap notify event
-    if (visible_ == true) {
+    if (visible_()) {
         ignore_unmaps_++;
         visible_ = false;
     }
@@ -451,7 +452,7 @@ void Client::requestClose() { //! ask the client to close
 }
 
 void Client::set_visible(bool visible) {
-    if (visible == this->visible_) {
+    if (visible == this->visible_()) {
         return;
     }
     if (visible) {

--- a/src/client.h
+++ b/src/client.h
@@ -33,7 +33,7 @@ public:
     Slice* slice = {};
     bool        ewmhfullscreen_ = false; // ewmh fullscreen state
     bool        neverfocus_ = false; // do not give the focus via XSetInputFocus
-    bool        visible_;
+    Attribute_<bool> visible_;
     bool        dragged_ = false;  // if this client is dragged currently
     int         ignore_unmaps_ = 0;  // Ignore one unmap for each reparenting
                                 // action, because reparenting creates an unmap
@@ -111,7 +111,7 @@ public:
     bool applysizehints_xy(int *x, int *y, int *w, int *h);
     void updatesizehints();
 
-    void set_visible(bool visible_);
+    void set_visible(bool visible);
 
     void set_urgent_force(bool state);
     void requestClose(); //! ask the client to close

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -31,6 +31,7 @@ static bool    g_tag_flags_dirty = true;
 HSTag::HSTag(string name_, TagManager* tags, Settings* settings)
     : frame(*this, "tiling")
     , index(this, "index", 0, &HSTag::isValidTagIndex)
+    , visible(this, "visible", false)
     , floating(this, "floating", false, [](bool){return "";})
     , floating_focused(this, "floating_focused", false, [](bool){return "";})
     , name(this, "name", name_,
@@ -69,6 +70,7 @@ HSTag::HSTag(string name_, TagManager* tags, Settings* settings)
         return this->floatingLayerCanBeFocused(v);
     });
 
+    visible.setDoc("if this tag is shown on some monitor");
     floating.setDoc("if the entire tag is set to floating mode");
     floating_focused.setDoc("if the floating layer is focused"
                             " (otherwise the tiling layer is)");
@@ -142,8 +144,9 @@ void HSTag::applyFloatingState(Client* client)
     needsRelayout_.emit();
 }
 
-void HSTag::setVisible(bool visible)
+void HSTag::setVisible(bool newVisible)
 {
+    visible = newVisible;
     frame->root_->setVisibleRecursive(visible);
     for (Client* c : floating_clients_) {
         c->set_visible(visible);

--- a/src/tag.h
+++ b/src/tag.h
@@ -31,6 +31,7 @@ public:
     ~HSTag() override;
     Child_<FrameTree>        frame;  // the frame tree
     Attribute_<unsigned long> index;
+    Attribute_<bool>         visible;
     Attribute_<bool>         floating;
     Attribute_<bool>         floating_focused; // if a floating client is focused
     Attribute_<std::string>  name;   // name of this tag
@@ -47,7 +48,7 @@ public:
     void setIndexAttribute(unsigned long new_index) override;
     bool focusClient(Client* client);
     void applyFloatingState(Client* client);
-    void setVisible(bool visible);
+    void setVisible(bool newVisible);
     bool removeClient(Client* client);
     void foreachClient(std::function<void(Client*)> loopBody);
     void focusFrame(std::shared_ptr<FrameLeaf> frameToFocus);


### PR DESCRIPTION
This extends the tag and client objects by a new read-only attribute
'visible'. It indicates whether a tag (resp. client) is shown on the
screen at the moment.

The information is there anyway, and I found it helpful when debugging
the first drafts of the window minimization code.