### PR TITLE
Make man page date reproducible

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -16,6 +16,7 @@ function(gen_manpage sourcefile man_nr)
     set(src_orig "${CMAKE_CURRENT_SOURCE_DIR}/${sourcefile}.txt")
     set(src "${CMAKE_CURRENT_BINARY_DIR}/${sourcefile}.txt")
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${sourcefile}.${man_nr}")
+    STRING(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)
 
     add_custom_target("doc_man_${sourcefile}" ALL DEPENDS ${dst})
     add_custom_command(
@@ -27,7 +28,7 @@ function(gen_manpage sourcefile man_nr)
                 --no-xmllint
                 -f manpage
                 -a \"herbstluftwmversion=herbstluftwm ${VERSION}\"
-                -a \"date=`date +%Y-%m-%d`\"
+                -a \"date=${BUILD_DATE}\"
                 ${src}
         DEPENDS ${src_orig}
         )


### PR DESCRIPTION
Make man page date reproducible

See https://reproducible-builds.org/ for why this is good

CMake already uses `SOURCE_DATE_EPOCH` for `TIMESTAMP`
The SOURCE_DATE_EPOCH variable is documented in
https://reproducible-builds.org/docs/source-date-epoch/

Also use UTC to be independent of timezone.

This is mostly a rebase of #553 that I finally managed to test on 0.9.0 now.

This PR was done while working on [reproducible builds](https://reproducible-builds.org/) for [openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).