### PR TITLE
Sort input file list

### DIFF
--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -13,7 +13,8 @@ def findfiles(sourcedir, regex_object):
     filename matches 'regex_object'
     """
     for root, dirs, files in os.walk(sourcedir):
-        for file in files:
+        dirs.sort()
+        for file in sorted(files):
             if regex_object.match(file):
                 yield os.path.join(root, file)
 


### PR DESCRIPTION
Sort input file list
so that `hlwm-doc.json` builds in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.