### PR TITLE
Implement client minimization

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ older versions.
 Current git version
 -------------------
 
+  * Client minimization (controlled by the attribute 'minimized' of every client)
   * The 'index' attribute of tags is now writable. This allows adjusting the
     order of existing tags.
   * New child object 'focused_client' for each tag object.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -38,6 +38,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , urgent_(this, "urgent", false)
     , floating_(this,  "floating", false)
     , fullscreen_(this,  "fullscreen", false)
+    , minimized_(this,  "minimized", false)
     , title_(this,  "title", "")
     , tag_str_(this,  "tag", &Client::tagName)
     , window_id_str(this,  "winid", "")
@@ -67,6 +68,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     ewmhrequests_.setWriteable();
     sizehints_floating_.setWriteable();
     sizehints_tiling_.setWriteable();
+    minimized_.setWriteable();
     for (auto i : {&fullscreen_, &pseudotile_, &sizehints_floating_, &sizehints_tiling_}) {
         i->setWriteable();
         i->changed().connect(this, &Client::requestRedraw);

--- a/src/client.h
+++ b/src/client.h
@@ -57,6 +57,7 @@ public:
     Attribute_<bool> urgent_;
     Attribute_<bool> floating_;
     Attribute_<bool> fullscreen_;
+    Attribute_<bool> minimized_;
     Attribute_<std::string> title_;  // or also called window title; this is never NULL
     DynAttribute_<std::string> tag_str_;
     Attribute_<std::string> window_id_str;

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -38,15 +38,6 @@ ClientManager::ClientManager()
     dragged.setDoc("the object of a client which is currently dragged"
                    " by the mouse, if any. See the documentation of the"
                    "  mousebind command for examples.");
-    focus.changed().connect([this](Client* newFocus) {
-        if (focusCopy && focusCopy != newFocus && focusCopy->minimized_()) {
-            focusCopy->set_visible(false);
-        }
-        focusCopy = newFocus;
-        if (newFocus && newFocus->minimized_()) {
-            newFocus->set_visible(true);
-        }
-    });
 }
 
 ClientManager::~ClientManager()
@@ -453,9 +444,6 @@ void ClientManager::force_unmanage(Client* client) {
         // of the client's tag, so 'focus' must have been updated
         // in the meantime. Anyway, lets be safe:
         focus = nullptr;
-    }
-    if (client == focusCopy) {
-        focusCopy = nullptr;
     }
     delete client;
 }

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -250,9 +250,7 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
     }
     client->send_configure();
 
-    newClient.emit(client);
-    // TODO: make this better; maybe connect to the newClient signal
-    // in the MouseManager
+    // TODO: make this better
     Root::get()->mouse->grab_client_buttons(client, false);
 
     return client;

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -35,13 +35,13 @@ public:
     void remove(Window window);
 
     void unmap_notify(Window win);
-    void force_unmanage(Window win);
     void force_unmanage(Client* client);
 
     void setDragged(Client* client);
 
     Signal_<HSTag*> needsRelayout;
-    Signal_<Client*> floatingStateChanged;
+    Signal_<Client*> clientStateChanged; //! floating or minimized changed
+    Signal_<Client*> newClient;
     Link_<Client> focus;
     Link_<Client> dragged;
 
@@ -62,6 +62,7 @@ public:
 protected:
     int clientSetAttribute(std::string attribute, Input input, Output output);
     void setSimpleClientAttributes(Client* client, const ClientChanges& changes);
+    Client* focusCopy = nullptr; //! a copy of 'focus' to update 'last_focus'
     Theme* theme;
     Settings* settings;
     Ewmh* ewmh;

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -61,7 +61,6 @@ public:
 protected:
     int clientSetAttribute(std::string attribute, Input input, Output output);
     void setSimpleClientAttributes(Client* client, const ClientChanges& changes);
-    Client* focusCopy = nullptr; //! a copy of 'focus' to update visibility of minimized clients
     Theme* theme;
     Settings* settings;
     Ewmh* ewmh;

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -61,7 +61,7 @@ public:
 protected:
     int clientSetAttribute(std::string attribute, Input input, Output output);
     void setSimpleClientAttributes(Client* client, const ClientChanges& changes);
-    Client* focusCopy = nullptr; //! a copy of 'focus' to update 'last_focus'
+    Client* focusCopy = nullptr; //! a copy of 'focus' to update visibility of minimized clients
     Theme* theme;
     Settings* settings;
     Ewmh* ewmh;

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -41,7 +41,6 @@ public:
 
     Signal_<HSTag*> needsRelayout;
     Signal_<Client*> clientStateChanged; //! floating or minimized changed
-    Signal_<Client*> newClient;
     Link_<Client> focus;
     Link_<Client> dragged;
 

--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -221,7 +221,7 @@ bool floating_focus_direction(Direction dir) {
     int curfocusidx = -1;
     Client* curfocus = get_current_client();
     tag->foreachClient([&](Client* c) {
-        if (c->visible_()) {
+        if (!c->visible_()) {
             return;
         }
         clients.push_back(c);
@@ -254,7 +254,7 @@ Point2D find_rectangle_collision_on_tag(HSTag* tag, Client* curfocus, Direction 
     int idx = 0;
     int curfocusidx = -1;
     tag->foreachClient([&](Client* c) {
-        if (c->visible_()) {
+        if (!c->visible_()) {
             return;
         }
         clients.push_back(c);

--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -221,6 +221,9 @@ bool floating_focus_direction(Direction dir) {
     int curfocusidx = -1;
     Client* curfocus = get_current_client();
     tag->foreachClient([&](Client* c) {
+        if (c->visible_()) {
+            return;
+        }
         clients.push_back(c);
         rects.push_back(make_pair(idx,c->dec->last_outer()));
         if (c == curfocus) {
@@ -251,6 +254,9 @@ Point2D find_rectangle_collision_on_tag(HSTag* tag, Client* curfocus, Direction 
     int idx = 0;
     int curfocusidx = -1;
     tag->foreachClient([&](Client* c) {
+        if (c->visible_()) {
+            return;
+        }
         clients.push_back(c);
         if (c == curfocus) {
             rects.push_back(make_pair(idx,focusrect));

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -820,6 +820,10 @@ bool focus_client(Client* client, bool switch_tag, bool switch_monitor, bool rai
         client->raise();
     }
     cur_mon->applyLayout();
+    // the client will be visible already, but in most
+    // WMs the client will stay un-minimized even
+    // if the focus goes away, so mark it as un-minimized:
+    client->minimized_ = false;
     g_monitors->unlock();
     return found;
 }

--- a/src/link.h
+++ b/src/link.h
@@ -3,6 +3,7 @@
 
 #include "entity.h"
 #include "object.h"
+#include "signal.h"
 
 /*! A pointer to another object in the object tree. if this is
  * assigned a new value, then the child object in the owner is updated
@@ -27,7 +28,9 @@ public:
         } else {
             parent_.removeChild(name_);
         }
+        changed_.emit(new_value);
     }
+    Signal_<T*>& changed() { return changed_; }
     T* operator()() {
         return pointer;
     }
@@ -37,6 +40,7 @@ public:
 private:
     Object& parent_;
     std::string name_;
+    Signal_<T*> changed_;
     T* pointer = nullptr;
 };
 

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -71,8 +71,8 @@ Root::Root(Globals g, XConnection& xconnection, IpcServer& ipcServer)
     // connect slots
     clients->needsRelayout.connect(monitors(), &MonitorManager::relayoutTag);
     tags->needsRelayout_.connect(monitors(), &MonitorManager::relayoutTag);
-    clients->floatingStateChanged.connect([](Client* c) {
-        c->tag()->applyFloatingState(c);
+    clients->clientStateChanged.connect([](Client* c) {
+        c->tag()->applyClientState(c);
     });
     theme->theme_changed_.connect(monitors(), &MonitorManager::relayoutAll);
     panels->panels_changed_.connect(monitors(), &MonitorManager::autoUpdatePads);

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -378,7 +378,7 @@ int HSTag::cycleAllCommand(Input input, Output output)
         bool focusChanged = frame->cycleAll(cdelta, skip_invisible);
         if (!focusChanged) {
             // if frame->cycleAll() reached the end of the tiling layer
-            if (floating_clients_.empty()) {
+            if (!hasVisibleFloatingClients()) {
                 // we need to wrap. when cycling forward, we wrap to the beginning
                 FrameTree::CycleDelta rewind = (delta == 1)
                             ? FrameTree::CycleDelta::Begin

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -119,12 +119,8 @@ void HSTag::applyClientState(Client* client)
     }
     bool focused = client == focusedClient();
     if (focused) {
-        if (!hasVisibleFloatingClients()) {
-            floating_focused = false;
-        } else {
-            // make it that client stays focused
-            floating_focused = client->floating_();
-        }
+        // make it that client stays focused
+        floating_focused = client->floating_();
     }
     // only floated clients can be minimized
     if (client->floating_() || client->minimized_()) {
@@ -149,6 +145,9 @@ void HSTag::applyClientState(Client* client)
             stack->sliceAddLayer(client->slice, LAYER_NORMAL);
         }
     }
+    if (!hasVisibleFloatingClients()) {
+        floating_focused = false;
+    }
     bool client_becomes_visible = !client->minimized_() && this->visible();
     if (client_becomes_visible) {
         needsRelayout_.emit();
@@ -164,7 +163,7 @@ void HSTag::setVisible(bool newVisible)
     visible = newVisible;
     frame->root_->setVisibleRecursive(visible);
     for (Client* c : floating_clients_) {
-        if (c->minimized_() && focusedClient() != c) {
+        if (c->minimized_()) {
             c->set_visible(false);
         } else {
             c->set_visible(visible);

--- a/src/tag.h
+++ b/src/tag.h
@@ -43,6 +43,8 @@ public:
     DynChild_<Client> focused_client;
     int             flags;
     std::vector<Client*> floating_clients_; //! the clients in floating mode
+    // the tag must assert that the floating layer is only
+    // focused if this tag hasVisibleFloatingClients()
     size_t               floating_clients_focus_; //! focus in the floating clients
     std::shared_ptr<Stack> stack;
     void setIndexAttribute(unsigned long new_index) override;

--- a/src/tag.h
+++ b/src/tag.h
@@ -47,9 +47,10 @@ public:
     std::shared_ptr<Stack> stack;
     void setIndexAttribute(unsigned long new_index) override;
     bool focusClient(Client* client);
-    void applyFloatingState(Client* client);
+    void applyClientState(Client* client);
     void setVisible(bool newVisible);
     bool removeClient(Client* client);
+    bool hasVisibleFloatingClients() const;
     void foreachClient(std::function<void(Client*)> loopBody);
     void focusFrame(std::shared_ptr<FrameLeaf> frameToFocus);
     Client* focusedClient();

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -243,7 +243,7 @@ def test_minimization_focus_other_tag(hlwm, floating):
     hlwm.call('add othertag')
     hlwm.call('rule tag=othertag focus=on')
     winid, _ = hlwm.create_client()
-    hlwm.create_client() # another client taking the focus
+    hlwm.create_client()  # another client taking the focus
     hlwm.call(f'set_attr clients.{winid}.floating {floating}')
     assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
     hlwm.call(f'set_attr clients.{winid}.minimized on')
@@ -270,7 +270,7 @@ def test_minimization_focus_window(hlwm, floating):
     hlwm.call(f'jumpto {winid}')
 
     assert hlwm.get_attr(f'clients.{winid}.visible') == 'true'
-    assert hlwm.get_attr(f'clients.focus.winid') == winid
+    assert hlwm.get_attr('clients.focus.winid') == winid
 
 
 def test_minimize_only_floating_client(hlwm):

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -205,3 +205,80 @@ def test_bool_attributes_writable(hlwm, attribute):
     hlwm.create_clients(1)
     for value in ['true', 'false', 'toggle']:
         hlwm.call(f'set_attr clients.focus.{attribute} {value}')
+
+
+@pytest.mark.parametrize("floating", ['on', 'off'])
+def test_minimization_of_visible_client(hlwm, floating):
+    winid, _ = hlwm.create_client()
+    hlwm.call(f'set_attr clients.{winid}.floating {floating}')
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'true'
+
+    hlwm.call(f'set_attr clients.{winid}.minimized on')
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
+
+    hlwm.call(f'set_attr clients.{winid}.minimized off')
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'true'
+
+
+@pytest.mark.parametrize("floating", ['on', 'off'])
+def test_minimization_on_other_tag(hlwm, floating):
+    hlwm.call('add othertag')
+    hlwm.call('rule tag=othertag')
+    winid, _ = hlwm.create_client()
+
+    hlwm.call(f'set_attr clients.{winid}.floating {floating}')
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
+
+    hlwm.call(f'set_attr clients.{winid}.minimized on')
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
+
+    hlwm.call(f'set_attr clients.{winid}.minimized off')
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
+
+
+@pytest.mark.parametrize("floating", ['on', 'off'])
+def test_minimization_focus_other_tag(hlwm, floating):
+    # place a minimized client on an invisible tag
+    # so the client should be invisible, too
+    hlwm.call('add othertag')
+    hlwm.call('rule tag=othertag focus=on')
+    winid, _ = hlwm.create_client()
+    hlwm.create_client() # another client taking the focus
+    hlwm.call(f'set_attr clients.{winid}.floating {floating}')
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
+    hlwm.call(f'set_attr clients.{winid}.minimized on')
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
+
+    # focus the other tag
+    hlwm.call('use othertag')
+
+    # now the client stays invisible since it's minimized
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
+    # client becomes visible on un-minimization
+    hlwm.call(f'set_attr clients.{winid}.minimized off')
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'true'
+
+
+@pytest.mark.parametrize("floating", ['on', 'off'])
+def test_minimization_focus_window(hlwm, floating):
+    winid, _ = hlwm.create_client()
+    hlwm.call(f'set_attr clients.{winid}.minimized on')
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
+    assert 'focus' not in hlwm.list_children('clients')
+
+    # focus the client
+    hlwm.call(f'jumpto {winid}')
+
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'true'
+    assert hlwm.get_attr(f'clients.focus.winid') == winid
+
+
+def test_minimize_only_floating_client(hlwm):
+    hlwm.call('rule floating=on focus=on')
+    winid, _ = hlwm.create_client()
+    assert hlwm.get_attr('clients.focus.winid') == winid
+    assert hlwm.get_attr('tags.focus.floating_focused') == 'true'
+
+    hlwm.call(f'set_attr clients.{winid}.minimized on')
+
+    assert hlwm.get_attr('tags.focus.floating_focused') == 'false'

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -168,7 +168,7 @@ def test_completable_commands(hlwm, request, run_destructives):
         'No such.*client: urgent',  # for apply_rules
         'Could not find client "(urgent|)"',  # for drag
         'No neighbour found',  # for resize and similar commands
-        'There are no floating windows; cannot focus',  # for floating_focused
+        r'There are no \(non-minimized\) floating windows; cannot focus',  # for floating_focused
     ])))
     # a set of commands that make other commands break
     # hence we need to run them separately

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -348,3 +348,15 @@ def test_ewmh_make_client_urgent_no_focus_stealing(hlwm, hc_idle, x11):
     assert demandsAttent in x11.ewmh.getWmState(winHandle, str=True)
     assert 'focus' not in hlwm.list_children('clients')
     assert 'default' == hlwm.get_attr('tags.focus.name')
+
+
+# @pytest.mark.parametrize('floating', [True, False])
+# @pytest.mark.parametrize('minimized', [True, False])
+# def test_minimized_sets_net_wm_state_hidden(hlwm, x11, floating, minimized):
+#     winHandle, winid = x11.create_client()
+#     hlwm.call(f'set_attr clients.{winid}.minimized {hlwm.bool(minimized)}')
+#     hlwm.call(f'set_attr clients.{winid}.floating {hlwm.bool(floating)}')
+# 
+#     hidden = '_NET_WM_STATE_HIDDEN'
+#     x11.display.flush()
+#     assert (hidden in x11.ewmh.getWmState(winHandle, str=True)) == minimized

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -348,15 +348,3 @@ def test_ewmh_make_client_urgent_no_focus_stealing(hlwm, hc_idle, x11):
     assert demandsAttent in x11.ewmh.getWmState(winHandle, str=True)
     assert 'focus' not in hlwm.list_children('clients')
     assert 'default' == hlwm.get_attr('tags.focus.name')
-
-
-# @pytest.mark.parametrize('floating', [True, False])
-# @pytest.mark.parametrize('minimized', [True, False])
-# def test_minimized_sets_net_wm_state_hidden(hlwm, x11, floating, minimized):
-#     winHandle, winid = x11.create_client()
-#     hlwm.call(f'set_attr clients.{winid}.minimized {hlwm.bool(minimized)}')
-#     hlwm.call(f'set_attr clients.{winid}.floating {hlwm.bool(floating)}')
-# 
-#     hidden = '_NET_WM_STATE_HIDDEN'
-#     x11.display.flush()
-#     assert (hidden in x11.ewmh.getWmState(winHandle, str=True)) == minimized

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -285,7 +285,7 @@ def test_floating_focused_vacouus(hlwm):
     # switching to floating layer should not be possible if
     # there is no floating window
     hlwm.call_xfail('attr tags.focus.floating_focused on') \
-        .expect_stderr("There are no \(non-minimized\) floating windows")
+        .expect_stderr(r'There are no \(non-minimized\) floating windows')
 
 
 def test_urgent_count(hlwm, x11):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -285,7 +285,7 @@ def test_floating_focused_vacouus(hlwm):
     # switching to floating layer should not be possible if
     # there is no floating window
     hlwm.call_xfail('attr tags.focus.floating_focused on') \
-        .expect_stderr("There are no floating windows")
+        .expect_stderr("There are no \(non-minimized\) floating windows")
 
 
 def test_urgent_count(hlwm, x11):


### PR DESCRIPTION
This adds a new attribute 'minimized' that hides a client until it is
unminimized. Only floating clients can be minimized, so we move a tiled
client from the 'tiling' to the 'floating' structures in a tag. Such a
client still has 'floating' set to false and will be moved back to the
tiling layer if it gets un-minimized.

It is important that hlwm ensures that minimized clients can not be
focused. If a minimized client shall be focused, it has to be
unminimized first. This is not yet respected by the present PR in the
cycle_all command but must be implemented next.

There is no way to manipulate the minimization state through
EWMH-Requests, but I found the following keybinding helpful for testing.

    herbstclient keybind Alt-m attr clients.focus.minimized toggle
