### PR TITLE
Fix moving a minimized client between tags

### DIFF
--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -236,9 +236,9 @@ Client *HSTag::focusedClient()
 
 void HSTag::insertClient(Client* client, string frameIndex, bool focus)
 {
-    if (client->floating_()) {
+    if (client->floating_() || client->minimized_()) {
         floating_clients_.push_back(client);
-        if (focus) {
+        if (focus && !client->minimized_()) {
             floating_clients_focus_ = floating_clients_.size() - 1;
             floating_focused = true;
         }
@@ -258,7 +258,7 @@ void HSTag::insertClientSlice(Client* client)
     stack->insertSlice(client->slice);
     if (floating()) {
         stack->sliceAddLayer(client->slice, LAYER_FLOATING);
-    } else if (!client->floating_()) {
+    } else if (!client->floating_() && !client->minimized_()) {
         stack->sliceRemoveLayer(client->slice, LAYER_FLOATING);
     }
 }

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -270,7 +270,7 @@ void TagManager::moveClient(Client* client, HSTag* target, string frameIndex, bo
         monitor_target->applyLayout();
     }
     if (!monitor_source && monitor_target) {
-        client->set_visible(true);
+        client->set_visible(!client->minimized_());
     }
     tag_set_flags_dirty();
 }

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -393,7 +393,7 @@ def test_minimized_window_stays_floating_on_tag_change(hlwm):
     assert hlwm.get_attr(f'clients.{winid}.tag') == this_tag
 
     # the minimized client is not in the tiling layer
-    assert hlwm.get_attr(f'tags.focus.tiling.root.client_count') == '0'
+    assert hlwm.get_attr('tags.focus.tiling.root.client_count') == '0'
     assert hlwm.get_attr(f'clients.{winid}.floating') == 'false'
     # but after un-minimizing it, it is
     hlwm.call(f'set_attr clients.{winid}.minimized false')

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -351,3 +351,50 @@ def test_focused_client_multiple_tags(hlwm):
         if len(clients) > 0:
             assert hlwm.get_attr(f'tags.by-name.{t}.focused_client.winid') \
                 == clients[0]
+
+
+def test_minimized_window_stays_invisible_on_tag_change(hlwm):
+    hlwm.call('add othertag')
+    hlwm.call('rule tag=othertag')
+    winid, _ = hlwm.create_client()
+    hlwm.call(f'set_attr clients.{winid}.minimized true')
+    assert hlwm.get_attr(f'clients.{winid}.floating') == 'false'
+    assert hlwm.get_attr(f'clients.{winid}.tag') == 'othertag'
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
+
+    this_tag = 'default'
+    # bring the window to this_tag without focusing it
+    hlwm.call(['unrule', '--all'])
+    hlwm.call(['rule', 'tag=' + this_tag])
+    hlwm.call(['apply_rules', winid])
+    assert hlwm.get_attr(f'clients.{winid}.tag') == this_tag
+
+    # after bringing the client to a visible tag, it must stay
+    # invisible
+    assert hlwm.get_attr(f'clients.{winid}.minimized') == 'true'
+    assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
+    # and the minimized client is not in the tiling layer!
+    assert hlwm.get_attr('tags.focus.tiling.root.client_count') == '0'
+    assert hlwm.get_attr(f'clients.{winid}.floating') == 'false'
+
+
+def test_minimized_window_stays_floating_on_tag_change(hlwm):
+    hlwm.call('add othertag')
+    hlwm.call('rule tag=othertag')
+    winid, _ = hlwm.create_client()
+    hlwm.call(f'set_attr clients.{winid}.minimized true')
+    assert hlwm.get_attr(f'clients.{winid}.floating') == 'false'
+
+    this_tag = 'default'
+    # bring the window to this_tag without focusing it
+    hlwm.call(['unrule', '--all'])
+    hlwm.call(['rule', 'tag=' + this_tag])
+    hlwm.call(['apply_rules', winid])
+    assert hlwm.get_attr(f'clients.{winid}.tag') == this_tag
+
+    # the minimized client is not in the tiling layer
+    assert hlwm.get_attr(f'tags.focus.tiling.root.client_count') == '0'
+    assert hlwm.get_attr(f'clients.{winid}.floating') == 'false'
+    # but after un-minimizing it, it is
+    hlwm.call(f'set_attr clients.{winid}.minimized false')
+    assert hlwm.get_attr('tags.focus.tiling.root.client_count') == '1'

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -378,7 +378,7 @@ def test_minimized_window_stays_invisible_on_tag_change(hlwm):
     assert hlwm.get_attr(f'clients.{winid}.floating') == 'false'
 
 
-def test_minimized_window_stays_floating_on_tag_change(hlwm):
+def test_minimized_window_stays_minimized_on_tag_change(hlwm):
     hlwm.call('add othertag')
     hlwm.call('rule tag=othertag')
     winid, _ = hlwm.create_client()
@@ -395,6 +395,7 @@ def test_minimized_window_stays_floating_on_tag_change(hlwm):
     # the minimized client is not in the tiling layer
     assert hlwm.get_attr('tags.focus.tiling.root.client_count') == '0'
     assert hlwm.get_attr(f'clients.{winid}.floating') == 'false'
+    assert hlwm.get_attr(f'clients.{winid}.minimized') == 'true'
     # but after un-minimizing it, it is
     hlwm.call(f'set_attr clients.{winid}.minimized false')
     assert hlwm.get_attr('tags.focus.tiling.root.client_count') == '1'


### PR DESCRIPTION
This sets the visibility of minimized clients correctly when they are
moved between tags. The test cases for it use the 'apply_rules' command
to move a client between tags since there is no direct way to do so via
the object system but it is possible via EWMH (see the test case
test_ewmh_move_client_to_tag), but I wanted the test cases in the
present change to be independent of X11.