### PR TITLE
Correctly 'load' minimized clients to a frame tree

### DIFF
--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -676,6 +676,10 @@ void FrameTree::applyFrameTree(shared_ptr<Frame> target,
         // this might even involve the above targetLeaf / targetSplit
         // so we need to do this before everything else
         for (const auto& client : sourceLeaf->clients) {
+            // first un-minimize and un-float the client
+            // such that we now that it is in the frame-tree
+            client->floating_ = false;
+            client->minimized_ = false;
             client->tag()->frame->root_->removeClient(client);
             if (client->tag() != tag_) {
                 client->tag()->stack->removeSlice(client->slice);

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -677,7 +677,7 @@ void FrameTree::applyFrameTree(shared_ptr<Frame> target,
         // so we need to do this before everything else
         for (const auto& client : sourceLeaf->clients) {
             // first un-minimize and un-float the client
-            // such that we now that it is in the frame-tree
+            // such that we know that it is in the frame-tree
             client->floating_ = false;
             client->minimized_ = false;
             client->tag()->frame->root_->removeClient(client);

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -176,7 +176,7 @@ def test_load_floating_client(hlwm):
     hlwm.call('set_layout max')
     assert hlwm.call('dump').stdout.rstrip() == '(clients max:0)'
 
-    # soak the client into the frame tree
+    # suck the client into the frame tree
     layout = f'(clients max:0 {winid})'
     hlwm.call(['load', layout])
 
@@ -196,8 +196,7 @@ def test_load_minimized_client(hlwm, othertag, minimized, floating):
         hlwm.call('add othertag')
         hlwm.call('rule tag=othertag')
     winid, _ = hlwm.create_client()
-    if minimized:
-        hlwm.call(f'set_attr clients.{winid}.minimized {hlwm.bool(minimized)}')
+    hlwm.call(f'set_attr clients.{winid}.minimized {hlwm.bool(minimized)}')
     hlwm.call(f'set_attr clients.{winid}.floating {hlwm.bool(floating)}')
     assert hlwm.get_attr(f'clients.{winid}.visible') == 'false'
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -184,11 +184,12 @@ def test_load_floating_client(hlwm):
     assert hlwm.get_attr(f'clients.{winid}.floating') == 'false'
 
 
-@pytest.mark.parametrize("othertag,minimized",
+@pytest.mark.parametrize("othertag,minimized", [
     # all combinations where at least one of the flags is True
     # such that it is not in the tiling layer of the first tag yet
     # and such that it is invisible initially
-    [(True, True), (True, False), (False, True)])
+    (True, True), (True, False), (False, True)
+])
 @pytest.mark.parametrize("floating", [True, False])
 def test_load_minimized_client(hlwm, othertag, minimized, floating):
     if othertag:


### PR DESCRIPTION
This makes the 'load' command handle minimized clients correctly and
adds test cases for it. I'm also setting 'floating' to 'false', since
the client is sucked into the frame tree by the 'load' command and thus
definitely not in the floating state anymore.