### PR TITLE
Let cycle_all skip minimized clients

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -341,7 +341,7 @@ cycle_all [*--skip-invisible*] ['DIRECTION']::
     acts similar to the 'cycle' command. If *--skip-invisible* is given,
     then this only cycles through all visible windows and skips invisible
     windows in the max layout (the flag only affects invisible windows in the
-    max layout; minimized windows are always skipped). After after each focus
+    max layout; minimized windows are always skipped). After each focus
     change, the focused window is raised.
 
 cycle_frame ['DIRECTION']::

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -335,14 +335,14 @@ cycle ['DELTA']::
     means: cycle in the opposite direction by 1.
 
 cycle_all [*--skip-invisible*] ['DIRECTION']::
-    Cycles through all windows and frames on the current tag. 'DIRECTION' = 1
-    means forward, 'DIRECTION' = -1 means backward, 'DIRECTION' = 0 has no
-    effect. 'DIRECTION' defaults to 1. If there are multiple windows within one
-    frame, then it acts similar to the 'cycle' command. (The 'cycle_all' command
-    focuses the next/previous leaf in the 'layout' tree.). If
-    *--skip-invisible* is given, then this only cycles through all visible
-    windows and skips invisible windows in the max layout. The focused window
-    is raised.
+    Cycles through all non-minimized windows and frames on the current tag.
+    'DIRECTION' = 1 means forward (default value), 'DIRECTION' = -1 means backward, 'DIRECTION'
+    = 0 has no effect. If there are multiple windows within one frame, then it
+    acts similar to the 'cycle' command. If *--skip-invisible* is given,
+    then this only cycles through all visible windows and skips invisible
+    windows in the max layout (the flag only affects invisible windows in the
+    max layout; minimized windows are always skipped). After after each focus
+    change, the focused window is raised.
 
 cycle_frame ['DIRECTION']::
     Cycles through all frames on the current tag. 'DIRECTION' = 1 means forward,


### PR DESCRIPTION
Following the principle of #1032 that minimized clients shall never be
focused or visible, the cycle_all command must skip minimized clients.
This implements the skipping of minimized clients and adds a number of
test cases for it.

While at it, I've removed a unnecessary call to the raise() function of
the newly focused client. It was unnecessary because the raise()
function is called anyway at the end of cycleAllCommand() for floating
clients.
