### PR TITLE
Fix 'bring' for minimized clients

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -445,8 +445,14 @@ int frame_current_bring(int argc, char** argv, Output output) {
     }
     HSTag* tag = get_current_monitor()->tag;
     global_tags->moveClient(client, tag, {}, true);
+    // mark as un-minimized first, such that a minimized tiling client
+    // is added to the frame tree now.
+    client->minimized_ = false;
     auto frame = tag->frame->root_->frameWithClient(client);
-    if (!client->is_client_floated() && !frame->isFocused()) {
+    if (frame && !frame->isFocused()) {
+        // regardless of the client's floating or minimization state:
+        // if the client was in the frame tree, it is moved
+        // to the focused frame
         frame->removeClient(client);
         tag->frame->focusedFrame()->insertClient(client, true);
     }

--- a/tests/test_floating.py
+++ b/tests/test_floating.py
@@ -109,6 +109,31 @@ def test_bring_floating_from_different_tag(hlwm, x11):
     assert hlwm.get_attr(f'clients.{winid}.floating') == hlwm.bool(True)
 
 
+@pytest.mark.parametrize('othertag', [True, False])
+@pytest.mark.parametrize('floating', [True, False])
+def test_bring_minimized_window(hlwm, othertag, floating):
+    if othertag:
+        hlwm.call('add othertag')
+        hlwm.call('rule tag=othertag')
+    hlwm.call('chain , split explode , split explode , split explode')
+    winid, _ = hlwm.create_client()
+    hlwm.call(f'set_attr clients.{winid}.minimized on')
+    hlwm.call(f'set_attr clients.{winid}.floating {hlwm.bool(floating)}')
+    # also focus another frame than one that carried the client
+    hlwm.call('cycle_frame')
+    # and remember which frame was focused before 'bring' is called
+    frame_focused = hlwm.get_attr('tags.focus.tiling.focused_frame.index')
+
+    hlwm.call(f'bring {winid}')
+
+    assert hlwm.get_attr('clients.focus.winid') == winid
+    assert hlwm.get_attr('clients.focus.minimized') == hlwm.bool(False)
+    assert hlwm.get_attr('clients.focus.visible') == hlwm.bool(True)
+    assert hlwm.get_attr('clients.focus.floating') == hlwm.bool(floating)
+    assert frame_focused == hlwm.get_attr('tags.focus.tiling.focused_frame.index'), \
+        "'bring' must not change the frame focus"
+
+
 @pytest.mark.parametrize('direction', ['down', 'right', ])
 def test_resize_floating_client(hlwm, x11, direction):
     hlwm.call('attr settings.snap_gap 0')


### PR DESCRIPTION
If a minimized tiling client is passed to 'bring' hlwm crashed because
is_client_floated() returned false but the client was also not
contained in the frame tree. To fix this, we do the following:

   - Un-minimize the client first such that a minimized and tiled client
     already is in the frame tree when looking for the client in the
     frame tree.
   - Explicitly check whether the client is in the frame tree instead of
     indirectly relying on is_client_floated().

Hopefully, this fixes #1037.