### PR TITLE
Disallow 'drag' for minimized clients

### DIFF
--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -137,7 +137,7 @@ int MouseManager::dragCommand(Input input, Output output)
         output << input.command() << ": Unknown mouse action \"" << mouseAction << "\"" << endl;
         return HERBST_INVALID_ARGUMENT;
     }
-    if (monitors_->byTag(client->tag()) == nullptr) {
+    if (monitors_->byTag(client->tag()) == nullptr || client->minimized_()) {
         output << input.command() << ": cannot drag invisible client \"" << winid << "\"" << endl;
         return HERBST_INVALID_ARGUMENT;
     }

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -152,6 +152,14 @@ def test_drag_invisible_client(hlwm):
     # inward he's grown :-)
 
 
+def test_drag_minimized_client(hlwm):
+    winid, _ = hlwm.create_client()
+    hlwm.call(f'set_attr clients.{winid}.minimized on')
+
+    hlwm.call_xfail(['drag', winid, 'resize']) \
+        .expect_stderr('cannot drag invisible client')
+
+
 def test_drag_resize_tiled_client(hlwm, mouse):
     winid, _ = hlwm.create_client()
     layout = '(split horizontal:{}:1 (clients max:0) (clients max:0 {}))'


### PR DESCRIPTION
It makes no sense to drag a minimized client, so lets be safe and forbid
it.