### PR TITLE
Make rule evaluation a member function of Rule

### DIFF
--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -6,6 +6,7 @@
 #include "client.h"
 #include "ewmh.h"
 #include "finite.h"
+#include "globals.h"
 #include "hook.h"
 #include "root.h"
 #include "utils.h"
@@ -139,6 +140,58 @@ bool Rule::setLabel(char op, string value, Output output) {
 
 Rule::Rule() {
     birth_time = get_monotonic_timestamp();
+}
+
+/**
+ * @brief apply the rule to a client and return whether the rule matched
+ * @param the client to apply the rules to
+ * @param the resulting changes
+ * @return whether the rule matched.
+ */
+bool Rule::evaluate(Client* client, ClientChanges& changes)
+{
+    bool rule_match = true; // if entire rule matches
+
+    // check all conditions
+    for (auto& cond : conditions) {
+        if (!rule_match && cond.name != "maxage") {
+            // implement lazy AND &&
+            // ... except for maxage
+            continue;
+        }
+
+        bool matches = Condition::matchers.at(cond.name)(&cond, client);
+
+        if (!matches && !cond.negated && cond.name == "maxage")
+        {
+            // if not negated maxage does not match anymore
+            // then it will never match again in the future
+            expired_ = true;
+        }
+
+        if (cond.negated) {
+            matches = ! matches;
+        }
+        rule_match = rule_match && matches;
+    }
+
+    if (rule_match) {
+        // apply all consequences
+        for (auto& cons : consequences) {
+            try {
+                Consequence::appliers.at(cons.name)(&cons, client, &changes);
+            } catch (std::exception& e) {
+                HSWarning("Invalid argument \"%s\" for rule consequence \"%s\": %s\n",
+                  cons.value.c_str(),
+                  cons.name.c_str(),
+                  e.what());
+            }
+        }
+    }
+    if (rule_match && once) {
+        expired_ = true;
+    }
+    return rule_match;
 }
 
 void Rule::print(Output output) {

--- a/src/rules.h
+++ b/src/rules.h
@@ -134,6 +134,11 @@ private:
 class Rule {
 public:
     Rule();
+    //! whether this rule should not be used anymore
+    bool expired() {
+        return expired_;
+    };
+    bool evaluate(Client* client, ClientChanges& changes);
 
     std::string label;
     std::vector<Condition> conditions;
@@ -146,6 +151,8 @@ public:
     bool addConsequence(std::string name, char op, const char* value, Output output);
 
     void print(Output output);
+private:
+    bool expired_ = false;
 };
 
 #endif


### PR DESCRIPTION
This moves the rule evaluation code into the class Rule. This has the
advantage that (a) the RuleManager does less member access to members of
the Rule class and (b) we can implement a command for applying a
standalone rule to a given window without adding the rule to the full
rule list.