### PR TITLE
Extend ArgParse with boolean command line flags

### DIFF
--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -51,7 +51,7 @@ bool ArgParse::parsingFails(Input& input, Output& output)
         string valueString;
         input >> valueString;
         // try to parse this token as a flag
-        if (optionalArgumentsRemaining && tryParseFlag(valueString)) {
+        while (optionalArgumentsRemaining && tryParseFlag(valueString)) {
             optionalArgumentsRemaining--;
             // if this token was the last optional argument
             if (optionalArgumentsRemaining == 0 && arg.optional_) {

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -100,7 +100,7 @@ bool ArgParse::parsingFails(Input& input, Output& output)
  * tokens left in the input.
  * @param input
  * @param output
- * @return whether there has been a
+ * @return whether there is an unparsable flag or unexpected argument at the end
  */
 bool ArgParse::parsingAllFails(Input& input, Output& output)
 {

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -6,7 +6,11 @@ using std::pair;
 using std::string;
 
 /**
- * @brief try to parse the arguments
+ * @brief try to parse the positional arguments and as many flags
+ * as possible. When the last positional argument has been read
+ * then flags are still read until the first unknown token.
+ * If unknown tokens at the end of input should be regarded as
+ * an error, use parsingAllFails()
  * @param input
  * @param output
  * @return return whether there has been an error (true = error, false = no error)
@@ -91,6 +95,13 @@ bool ArgParse::parsingFails(Input& input, Output& output)
     return false;
 }
 
+/**
+ * @brief run parsingFails() and assert that there are no unknown
+ * tokens left in the input.
+ * @param input
+ * @param output
+ * @return whether there has been a
+ */
 bool ArgParse::parsingAllFails(Input& input, Output& output)
 {
     return parsingFails(input, output) || unparsedTokens(input, output);
@@ -111,7 +122,7 @@ bool ArgParse::unparsedTokens(Input& input, Output& output)
 
 /**
  * @brief Accept boolean flags (e.g. --all --horizontal ...) at
- * any position
+ * any position between the (mandatory or optional) positional arguments
  * @param a list of flags
  * @return
  */

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 
+using std::pair;
 using std::string;
 
 /**
@@ -21,6 +22,7 @@ bool ArgParse::parsingFails(Input& input, Output& output)
             mandatoryArguments++;
         }
     }
+    optionalArguments += flags_.size();
     if (input.size() < mandatoryArguments) {
         output << input.command() << ": Expected ";
         if (optionalArguments) {
@@ -39,18 +41,31 @@ bool ArgParse::parsingFails(Input& input, Output& output)
     // the number of optional arguments that are provided by 'input':
     size_t optionalArgumentsRemaining = input.size() - mandatoryArguments;
     for (const auto& arg : arguments_) {
-        if (arg.optional_) {
-            if (optionalArgumentsRemaining) {
-                optionalArgumentsRemaining--;
-            } else {
-                // skip this argument if it's optional and there
-                // are not more optional arguments in the input
-                continue;
-            }
+        if (arg.optional_ && optionalArgumentsRemaining == 0) {
+            continue;
         }
         string valueString;
-        // the following can't fail because we checked input.size() before
         input >> valueString;
+        // try to parse this token as a flag
+        if (optionalArgumentsRemaining && tryParseFlag(valueString)) {
+            optionalArgumentsRemaining--;
+            // if this token was the last optional argument
+            if (optionalArgumentsRemaining == 0 && arg.optional_) {
+                // then skip this 'arg'
+                continue;
+            }
+            // otherwise, there is room for another optional
+            // argument or 'arg' is mandatory. So get another
+            // token from the input, and parse it to the
+            // current 'arg'
+            input >> valueString;
+        }
+        // in any case, we have this here:
+        // assert (!arg.optional_ || optionalArgumentsRemaining > 0);
+        if (arg.optional_) {
+            optionalArgumentsRemaining--;
+        }
+
         try {
             arg.tryParse_(valueString);
         }  catch (std::exception& e) {
@@ -60,8 +75,69 @@ bool ArgParse::parsingFails(Input& input, Output& output)
             return true;
         }
     }
+    // try to parse more flags after the positional arguments
+    while (!input.empty()) {
+        // only consume tokens if they are recognized flags
+        if (tryParseFlag(input.front())) {
+            input.shift();
+        } else {
+            break;
+        }
+    }
+
     // if all arguments were parsed, then we report that there were
     // no errors. It's ok if there are remaining elements in 'input' that
     // have not been parsed.
     return false;
+}
+
+bool ArgParse::parsingAllFails(Input& input, Output& output)
+{
+    return parsingFails(input, output) || unparsedTokens(input, output);
+}
+
+bool ArgParse::unparsedTokens(Input& input, Output& output)
+{
+    string extraToken;
+    if (input >> extraToken) {
+        output << input.command()
+           << ": Unknown argument or flag \""
+           << extraToken << "\" given.\n";
+        errorCode_ = HERBST_INVALID_ARGUMENT;
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @brief Accept boolean flags (e.g. --all --horizontal ...) at
+ * any position
+ * @param a list of flags
+ * @return
+ */
+ArgParse& ArgParse::flags(std::initializer_list<Flag> flagTable)
+{
+    for (auto& it : flagTable) {
+        // the usual array-style assignment does not work
+        // because Flag has no parameterless constructor.
+        // hence, we explicitly call 'insert':
+        flags_.insert(pair<string, Flag>(it.name_, it));
+    }
+    return *this;
+}
+
+/**
+ * @brief try parse a flag
+ * @param argument token from a Input object
+ * @return whether the token was a flag
+ */
+bool ArgParse::tryParseFlag(std::string inputToken)
+{
+    auto flag = flags_.find(inputToken);
+    if (flag == flags_.end()) {
+        // stop parsing flags on the first non-flag
+        return false;
+    }
+    flag->second.callback_();
+    return true;
 }

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -142,7 +142,7 @@ ArgParse& ArgParse::flags(std::initializer_list<Flag> flagTable)
  * @param argument token from a Input object
  * @return whether the token was a flag
  */
-bool ArgParse::tryParseFlag(std::string inputToken)
+bool ArgParse::tryParseFlag(string inputToken)
 {
     auto flag = flags_.find(inputToken);
     if (flag == flags_.end()) {

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -18,6 +18,8 @@ public:
     }
 
     bool parsingFails(Input& input, Output& output);
+    bool parsingAllFails(Input& input, Output& output);
+    bool unparsedTokens(Input& input, Output& output);
 
     class Argument {
     public:
@@ -27,6 +29,32 @@ public:
         std::function<void(std::string)> tryParse_;
         //! whether the present argument is only optional
         bool optional_;
+    };
+
+    /**
+     * @brief A flag is a command line flag (prefixed with one or two dashes)
+     * and without a parameter. If a flag is given, the callback
+     * function is called.
+     */
+    class Flag {
+    public:
+        Flag(std::string name, std::function<void()> callback)
+            : name_(name)
+            , callback_(callback)
+        {}
+        //! directly activate a boolean variable
+        Flag(std::string name, bool* target)
+            : name_(name)
+        {
+            callback_ = [target] () {
+                if (target) {
+                    *target = true;
+                }
+            };
+        }
+
+        std::string name_;
+        std::function<void()> callback_;
     };
 
     /**
@@ -68,10 +96,19 @@ public:
         return *this;
     }
 
+    /**
+     * @brief accept certain boolean flags at this position
+     * @param names and which boolean to modify
+     * @return
+     */
+    ArgParse& flags(std::initializer_list<Flag> flagTable);
+
     int exitCode() const { return errorCode_; }
 
 private:
+    bool tryParseFlag(std::string inputToken);
     std::vector<Argument> arguments_;
+    std::map<std::string, Flag> flags_;
     int errorCode_ = 0;
 };
 

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -19,7 +19,6 @@ public:
 
     bool parsingFails(Input& input, Output& output);
     bool parsingAllFails(Input& input, Output& output);
-    bool unparsedTokens(Input& input, Output& output);
 
     class Argument {
     public:
@@ -96,16 +95,12 @@ public:
         return *this;
     }
 
-    /**
-     * @brief accept certain boolean flags at this position
-     * @param names and which boolean to modify
-     * @return
-     */
     ArgParse& flags(std::initializer_list<Flag> flagTable);
 
     int exitCode() const { return errorCode_; }
 
 private:
+    bool unparsedTokens(Input& input, Output& output);
     bool tryParseFlag(std::string inputToken);
     std::vector<Argument> arguments_;
     std::map<std::string, Flag> flags_;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -275,20 +275,14 @@ void HSTag::removeClientSlice(Client* client)
 int HSTag::focusInDirCommand(Input input, Output output)
 {
     bool external_only = settings_->default_direction_external_only();
-    if (input.size() >= 2) {
-        string internextern;
-        input >> internextern;
-        if (internextern == "-i") {
-            external_only = false;
-        }
-        if (internextern == "-e") {
-            external_only = true;
-        }
-    }
     Direction direction = Direction::Left; // some default to satisfy the linter
     ArgParse ap;
+    ap.flags({
+        {"-i", [&external_only] () { external_only = false; }},
+        {"-e", [&external_only] () { external_only = true; }},
+    });
     ap.mandatory(direction);
-    if (ap.parsingFails(input, output)) {
+    if (ap.parsingAllFails(input, output)) {
         return ap.exitCode();
     }
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -155,7 +155,7 @@ def test_focus_wrap(hlwm, running_clients, running_clients_num):
             hlwm.call('focus down')
 
 
-@pytest.mark.parametrize("mode", ['setting', 'flag'])
+@pytest.mark.parametrize("mode", ['setting', 'flag', 'flag-double', 'flag-shadow'])
 @pytest.mark.parametrize("setting_value", [True, False])
 @pytest.mark.parametrize("external_only", [True, False])
 @pytest.mark.parametrize("running_clients_num", [3])
@@ -171,13 +171,22 @@ def test_focus_internal_external(hlwm, mode, setting_value, external_only, runni
 
     # we will now run 'focus' 'down' with -i or -e
     cmd = ['focus']
-    if mode == 'flag':
-        if external_only:
-            cmd += ['-e']
-        else:
-            cmd += ['-i']
-    else:
+    if mode == 'setting':
         hlwm.call(f'set default_direction_external_only {hlwm.bool(external_only)}')
+    else:
+        # mode is one of the flag*-modes
+        extonly2flag = {
+            True: '-e',
+            False: '-i',
+        }
+        if mode == 'flag-shadow':
+            # something like: focus -i -e down
+            # Here, an earlier and contradictory flag gets shadowed
+            cmd.append(extonly2flag[not external_only])
+        if mode == 'flag-double':
+            cmd.append(extonly2flag[external_only])
+        # the significant command line flag:
+        cmd.append(extonly2flag[external_only])
     cmd += ['down']
     hlwm.call(cmd)
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -155,6 +155,54 @@ def test_focus_wrap(hlwm, running_clients, running_clients_num):
             hlwm.call('focus down')
 
 
+@pytest.mark.parametrize("mode", ['setting', 'flag'])
+@pytest.mark.parametrize("setting_value", [True, False])
+@pytest.mark.parametrize("external_only", [True, False])
+@pytest.mark.parametrize("running_clients_num", [3])
+def test_focus_internal_external(hlwm, mode, setting_value, external_only, running_clients):
+    hlwm.call(f'set default_direction_external_only {hlwm.bool(setting_value)}')
+    layout = f"""
+    (split vertical:0.5:0
+        (clients vertical:0 {running_clients[0]} {running_clients[1]})
+        (clients vertical:0 {running_clients[2]}))
+    """.replace('\n', ' ').strip()
+    hlwm.call(['load', layout])
+    assert hlwm.get_attr('clients.focus.winid') == running_clients[0]
+
+    # we will now run 'focus' 'down' with -i or -e
+    cmd = ['focus']
+    if mode == 'flag':
+        if external_only:
+            cmd += ['-e']
+        else:
+            cmd += ['-i']
+    else:
+        hlwm.call(f'set default_direction_external_only {hlwm.bool(external_only)}')
+    cmd += ['down']
+    hlwm.call(cmd)
+
+    if external_only:
+        expected_new_focus = running_clients[2]
+    else:
+        expected_new_focus = running_clients[1]
+    assert hlwm.get_attr('clients.focus.winid') == expected_new_focus
+
+
+def test_argparse_invalid_flag(hlwm):
+    # here, '-v' is not a valid flag, so it is assumed
+    # to be the first positional argument
+    hlwm.call_xfail('focus -v down') \
+        .expect_stderr('Cannot parse argument "-v"')
+    # in the following, the positional argument has been
+    # parsed already, so the error message is different:
+    hlwm.call_xfail('focus down -v') \
+        .expect_stderr('Unknown argument or flag "-v"')
+    hlwm.call_xfail('focus down -v -i') \
+        .expect_stderr('Unknown argument or flag "-v"')
+    hlwm.call_xfail('focus down -i -v') \
+        .expect_stderr('Unknown argument or flag "-v"')
+
+
 @pytest.mark.parametrize("path", '@ 0 1 00 11 . / /. ./'.split(' '))
 @pytest.mark.parametrize("running_clients_num", [3])
 @pytest.mark.parametrize("num_splits", [0, 1, 2])


### PR DESCRIPTION
This adds support for command line flags to the ArgParse class. A flag
can appear at any position in the command line arguments between the
(mandatory or optional) positional arguments. A flag is usually prefixed
with one or two dashes, but there is no formal requirement for this in
the ArgParse implementation.

A unknown flag will simply be ignored and parsed as a positional
argument instead. This is because I don't want negative numbers on the
command line to be misinterpreted as unknown command line flags.

For illustration and testing, this migrates the focus command to ArgParse with
flags.
