### PR TITLE
New command 'mirror' for mirroring the frame tree

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ Current git version
     order of existing tags.
   * New child object 'focused_client' for each tag object.
   * New child object 'focused_frame' for the tiling object of each tag object.
+  * New command 'mirror'
   * Bug fixes:
     - When hiding windows, correctly set their WM_STATE to IconicState (we set
       it to Withdrawn state before, which means "unmanaged" and thus is wrong).

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -519,6 +519,10 @@ rotate::
     Rotates the layout on the focused tag counterclockwise by 90 degrees. This
     only manipulates the alignment of frames, not the content of them.
 
+mirror ['--vertical'|'--horizontal']::
+    Mirrors the layout on the focused tag vertically, horizontally, or both.
+    This only manipulates the alignment of frames, not the content of them.
+
 set 'NAME' 'VALUE'::
     Sets the specified setting 'NAME' to 'VALUE'. Allowed values for boolean
     settings are 'on' or 'true' for on, 'off' or 'false' for off, 'toggle' to

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -519,9 +519,10 @@ rotate::
     Rotates the layout on the focused tag counterclockwise by 90 degrees. This
     only manipulates the alignment of frames, not the content of them.
 
-mirror ['--vertical'|'--horizontal']::
-    Mirrors the layout on the focused tag vertically, horizontally, or both.
-    This only manipulates the alignment of frames, not the content of them.
+mirror ['vertical'|'horizontal'|'both']::
+    Mirrors the layout on the focused tag vertically, horizontally, or both; the
+    default is 'horizontal'. This command only manipulates the alignment of
+    frames, not the content of them.
 
 set 'NAME' 'VALUE'::
     Sets the specified setting 'NAME' to 'VALUE'. Allowed values for boolean

--- a/src/finite.h
+++ b/src/finite.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 #include "completion.h"
 
 /** The Finite<T> class defines the Converter methods
@@ -13,6 +15,7 @@
 template<typename T>
 class Finite {
 public:
+
     using ValueList = std::vector<std::pair<T, std::string>>;
     static ValueList values;
     static std::string str(T cp) {
@@ -54,3 +57,37 @@ public:
         }
     }
 };
+
+template <typename T>
+struct is_finite : std::false_type {};
+
+/**
+ * A Converter implementation for types XX which are 'finite'. To make this applicable
+ * to a type XX, one needs to:
+ *
+ *   1. define the static variable:
+ *
+ *      Finite<XX>::values;
+ *
+ *   2. make the type fulfill the is_finite predicate:
+ *
+ *     template <>
+ *     struct is_finite<XX> : std::true_type {};
+ */
+template <typename T>
+class Converter<T, typename std::enable_if< is_finite<T>::value >::type> {
+public:
+    static T parse(const std::string& source) {
+        return Finite<T>::parse(source);
+    }
+    static std::string str(T payload) {
+        return Finite<T>::str(payload);
+    }
+    static void complete(Completion& complete, T const* relativeTo) {
+        Finite<T>::complete(complete, relativeTo);
+    }
+    static void complete(Completion& complete) {
+        Finite<T>::complete(complete, nullptr);
+    }
+};
+

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "child.h"
+#include "finite.h"
 #include "fixprecdec.h"
 #include "link.h"
 #include "object.h"
@@ -60,6 +61,14 @@ public:
     int focusNthCommand(Input input, Output output);
     int removeFrameCommand();
     int rotateCommand();
+    enum class MirrorDirection {
+        Horizontal,
+        Vertical,
+        Both,
+    };
+
+    int mirrorCommand(Input input, Output output);
+    void mirrorCompletion(Completion& complete);
     bool cycleAll(CycleDelta cdelta, bool skip_invisible);
     int cycleFrameCommand(Input input, Output output);
     int loadCommand(Input input, Output output);
@@ -90,5 +99,9 @@ private:
     HSTag* tag_;
     Settings* settings_;
 };
+
+template <>
+struct is_finite<FrameTree::MirrorDirection> : std::true_type {};
+template<> Finite<FrameTree::MirrorDirection>::ValueList Finite<FrameTree::MirrorDirection>::values;
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,6 +154,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
         {"rename",         BIND_OBJECT(tags, tag_rename_command) },
         {"move",           BIND_OBJECT(tags, tag_move_window_command) },
         {"rotate",         { tags->frameCommand(&FrameTree::rotateCommand) }},
+        {"mirror",         { tags->frameCommand(&FrameTree::mirrorCommand, &FrameTree::mirrorCompletion) }},
         {"move_index",     BIND_OBJECT(tags, tag_move_window_by_index_command) },
         {"add_monitor",    BIND_OBJECT(monitors, addMonitor)},
         {"raise_monitor",  { monitors, &MonitorManager::raiseMonitorCommand,

--- a/src/types.h
+++ b/src/types.h
@@ -56,7 +56,7 @@ protected:
 void completeFull(Completion& complete, std::string string);
 
 /* Primitive types that can be converted from/to user input/output */
-template<typename T>
+template<typename T, typename = void>
 struct Converter {
     /** Parse a text into the right type
      * @throws std::invalid_argument or std::out_of_range

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1075,3 +1075,43 @@ def test_focused_frame_child(hlwm):
     for focused_index, layout in test_data:
         hlwm.call(['load', layout])
         assert hlwm.get_attr('tags.0.tiling.focused_frame.index') == focused_index
+
+
+@pytest.mark.parametrize("old,new", [
+    ('(split vertical:0.4:0 {a} {b})', '(split vertical:0.6:1 {b} {a})'),
+    ('(split horizontal:0.3:0 {a} {b})', '(split horizontal:0.7:1 {b} {a})'),
+    ('(split vertical:0.5:1 {a} {b})', '(split vertical:0.5:0 {b} {a})'),
+    ('(split horizontal:0.2:1 {a} {b})', '(split horizontal:0.8:0 {b} {a})'),
+])
+@pytest.mark.parametrize("mode", ['horizontal', 'vertical'])
+def test_mirror_horizontal_or_vertical_one_split(hlwm, old, new, mode):
+    frame_a = '(clients horizontal:0)'
+    frame_b = '(clients vertical:0)'
+    hlwm.call(['load', old.format(a=frame_a, b=frame_b)])
+
+    hlwm.call(f'mirror {mode}')
+
+    if old.find(mode) < 0:
+        expected = old.format(a=frame_a, b=frame_b)  # nothing changes
+    else:
+        expected = new.format(a=frame_a, b=frame_b)
+    assert hlwm.call('dump').stdout == expected
+
+
+@pytest.mark.parametrize("num_splits", [1, 2, 3, 4])
+def test_mirror_vs_rotate(hlwm, num_splits):
+    for _ in range(0, num_splits):
+        hlwm.call('split explode 0.4')
+
+    layout = hlwm.call('dump').stdout
+
+    # compute the effect of rotating by 180 degrees
+    hlwm.call('chain , rotate , rotate')
+    layout_after_rotate = hlwm.call('dump').stdout
+    # restore original layout
+    hlwm.call(['load', layout])
+
+    # rotating by 180 degrees is the same as
+    # flipping both horizontally and vertically
+    hlwm.call('mirror both')
+    assert layout_after_rotate == hlwm.call('dump').stdout


### PR DESCRIPTION
This adapts the 'mirror' implementation from the PR #93 to the new
codebase. Additionally, it accepts a positional argument along which
axis the layout is to be mirrored.

On the implementation side, it uses type_traits and a new 'is_finite'
predicate to avoid boilerplate code when instantiating the Converter
class to the enum class type Horizontal/Vertical/Both. There is still a
bit to write, but much less compared to the Converter-implementation for
the ClientPlacement class.

In order to make Converter applicable to type traits, a new template
parameter to Converter "typename = void" was necessary.