### PR TITLE
Make rule parsing a static member of RuleManager

### DIFF
--- a/src/rulemanager.h
+++ b/src/rulemanager.h
@@ -14,10 +14,11 @@ public:
     void unruleCompletion(Completion& complete);
     int listRulesCommand(Output output);
     ClientChanges evaluateRules(Client* client, ClientChanges changes = {});
+    static int parseRule(Input input, Output output, Rule& rule, bool& prepend);
 
 private:
     size_t removeRules(std::string label);
-    std::tuple<std::string, char, std::string> tokenizeArg(std::string arg);
+    static std::tuple<std::string, char, std::string> tokenizeArg(std::string arg);
 
     //! Ever-incrementing index for labeling new rules
     unsigned long long rule_label_index_ = 0;


### PR DESCRIPTION
This is another step towards a command that applies a single temporary
rule. Since this does not change hlwm's behaviour, the existing set of
tests in test_rules.py should be sufficient.