### PR TITLE
Use Converter for Finite class where possible

### DIFF
--- a/src/framedata.cpp
+++ b/src/framedata.cpp
@@ -4,64 +4,20 @@
 
 using std::string;
 
-static const char* g_align_names[] = {
-    "vertical",
-    "horizontal",
-    nullptr,
+template<> Finite<SplitAlign>::ValueList Finite<SplitAlign>::values = {
+    { SplitAlign::vertical, "vertical" },
+    { SplitAlign::horizontal, "horizontal" },
 };
 
-static const char* g_layout_names[] = {
-    "vertical",
-    "horizontal",
-    "max",
-    "grid",
-    nullptr,
+template<> Finite<LayoutAlgorithm>::ValueList Finite<LayoutAlgorithm>::values = {
+    { LayoutAlgorithm::vertical, "vertical" },
+    { LayoutAlgorithm::horizontal, "horizontal" },
+    { LayoutAlgorithm::max, "max" },
+    { LayoutAlgorithm::grid, "grid" },
 };
 
 size_t layoutAlgorithmCount() {
-    size_t i = 0;
-    while (g_layout_names[i] != nullptr) {
-        i++;
-    }
-    return i;
-}
-
-template<> LayoutAlgorithm Converter<LayoutAlgorithm>::parse(const string& source) {
-    for (size_t i = 0; g_layout_names[i] != nullptr; i++) {
-        if (source == g_layout_names[i]) {
-            return (LayoutAlgorithm) i;
-        }
-    }
-    throw std::invalid_argument("Invalid layout name: \"" + source + "\"");
-}
-
-template<> string Converter<LayoutAlgorithm>::str(LayoutAlgorithm payload) {
-    return g_layout_names[(int) payload];
-}
-
-template<> void Converter<LayoutAlgorithm>::complete(Completion& complete, LayoutAlgorithm const* relativeTo) {
-    for (size_t i = 0; g_layout_names[i] != nullptr; i++) {
-        complete.full(g_layout_names[i]);
-    }
-}
-
-template<> SplitAlign Converter<SplitAlign>::parse(const string& source) {
-    for (size_t i = 0; g_align_names[i] != nullptr; i++) {
-        if (source == g_align_names[i]) {
-            return (SplitAlign) i;
-        }
-    }
-    throw std::invalid_argument("Invalid split align name: \"" + source + "\"");
-}
-
-template<> string Converter<SplitAlign>::str(SplitAlign payload) {
-    return g_align_names[(int) payload];
-}
-
-template<> void Converter<SplitAlign>::complete(Completion& complete, SplitAlign const* relativeTo) {
-    for (size_t i = 0; g_align_names[i] != nullptr; i++) {
-        complete.full(g_align_names[i]);
-    }
+    return Finite<LayoutAlgorithm>::values.size();
 }
 
 //! embed the SplitAlign type into the LayoutAlgorithm type

--- a/src/framedata.h
+++ b/src/framedata.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "attribute_.h"
+#include "finite.h"
 #include "fixprecdec.h"
 #include "types.h"
 
@@ -27,7 +28,9 @@ enum class SplitAlign {
     horizontal,
 };
 
-ConverterInstance(SplitAlign)
+template <>
+struct is_finite<SplitAlign> : std::true_type {};
+template<> Finite<SplitAlign>::ValueList Finite<SplitAlign>::values;
 
 template<>
 inline Type Attribute_<SplitAlign>::staticType() { return Type::ATTRIBUTE_NAMES; }
@@ -39,8 +42,9 @@ enum class LayoutAlgorithm {
     grid,
 };
 
-ConverterInstance(LayoutAlgorithm)
-template<> void Converter<LayoutAlgorithm>::complete(Completion& complete, LayoutAlgorithm const* relativeTo);
+template <>
+struct is_finite<LayoutAlgorithm> : std::true_type {};
+template<> Finite<LayoutAlgorithm>::ValueList Finite<LayoutAlgorithm>::values;
 
 template<>
 inline Type Attribute_<LayoutAlgorithm>::staticType() { return Type::ATTRIBUTE_NAMES; }

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -5,7 +5,6 @@
 
 #include "client.h"
 #include "ewmh.h"
-#include "finite.h"
 #include "globals.h"
 #include "hook.h"
 #include "root.h"
@@ -381,20 +380,3 @@ Finite<ClientPlacement>::ValueList Finite<ClientPlacement>::values = {
     { ClientPlacement::Unchanged, "none" },
     { ClientPlacement::Smart, "smart" },
 };
-
-template<>
-string Converter<ClientPlacement>::str(ClientPlacement cp) {
-    return Finite<ClientPlacement>::str(cp);
-}
-
-template<>
-ClientPlacement Converter<ClientPlacement>::parse(const string& payload) {
-    return Finite<ClientPlacement>::parse(payload);
-}
-
-template<>
-void Converter<ClientPlacement>::complete(Completion& complete, ClientPlacement const* relativeTo) {
-    return Finite<ClientPlacement>::complete(complete, relativeTo);
-}
-
-

--- a/src/rules.h
+++ b/src/rules.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <regex>
 
+#include "finite.h"
 #include "optional.h"
 #include "regexstr.h"
 #include "types.h"
@@ -69,11 +70,9 @@ enum class ClientPlacement {
     Smart, //! as little overlaps as possible
 };
 
-template<> std::string Converter<ClientPlacement>::str(ClientPlacement cp);
-template<> ClientPlacement Converter<ClientPlacement>::parse(const std::string& payload);
-template<> void Converter<ClientPlacement>::complete(Completion& complete, ClientPlacement const*);
-
-
+template <>
+struct is_finite<ClientPlacement> : std::true_type {};
+template<> Finite<ClientPlacement>::ValueList Finite<ClientPlacement>::values;
 
 class ClientChanges {
 public:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -896,7 +896,7 @@ def test_focus_other_monitor(hlwm, other_mon_exists, setting):
 
 def test_set_layout_invalid_layout_name(hlwm):
     hlwm.call_xfail('set_layout foobar') \
-        .expect_stderr('Invalid layout name: "foobar"')
+        .expect_stderr('Cannot.* "foobar":.*one of: vertical, horizontal')
 
 
 def test_focus_edge(hlwm):

--- a/tests/test_root_commands.py
+++ b/tests/test_root_commands.py
@@ -335,7 +335,7 @@ def test_compare_example_values(hlwm, attrpath, value, operator, othervalue, is_
 
 def test_compare_invalid_operator(hlwm):
     hlwm.call_xfail('compare monitors.count -= 1') \
-        .expect_stderr('unknown operator')
+        .expect_stderr('Cannot.* "-=": Expecting one of: =, !=,')
 
 
 def test_compare_fallback_string_equal(hlwm):


### PR DESCRIPTION
This simplifies the Converter implementations of the types SplitAlign,
LayoutAlgorithm, ClientPlacement, and also of a new type CompareOperator
that is now used in the input processing of the 'compare' command.