### PR TITLE
Use ArgParse in cycle_all

### DIFF
--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -329,21 +329,9 @@ int HSTag::cycleAllCommand(Input input, Output output)
 {
     bool skip_invisible = false;
     int delta = 1;
-    string s = "";
-    input >> s;
-    if (s == "--skip-invisible") {
-        skip_invisible = true;
-        // and load the next (optional) argument to s
-        s = "0";
-        input >> s;
-    }
-    try {
-        delta = std::stoi(s);
-    } catch (std::invalid_argument const& e) {
-        output << "invalid argument: " << e.what() << endl;
-        return HERBST_INVALID_ARGUMENT;
-    } catch (std::out_of_range const& e) {
-        output << "out of range: " << e.what() << endl;
+    ArgParse ap;
+    ap.flags({{"--skip-invisible", &skip_invisible}}).optional(delta);
+    if (ap.parsingAllFails(input, output)) {
         return HERBST_INVALID_ARGUMENT;
     }
     if (delta < -1 || delta > 1) {

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -387,6 +387,19 @@ def test_cycle_all_traverses_all(hlwm, running_clients, num_splits, delta):
     assert all_winids == visited_winids
 
 
+def test_cycle_all_errors(hlwm):
+    hlwm.call_xfail('cycle_all 1 2') \
+        .expect_stderr('Unknown argument or flag "2"')
+    hlwm.call_xfail('cycle_all -3') \
+        .expect_stderr('argument out of range')
+    hlwm.call_xfail('cycle_all 3') \
+        .expect_stderr('argument out of range')
+    hlwm.call_xfail('cycle_all -s 1') \
+        .expect_stderr('Cannot.*"-s"')
+    hlwm.call_xfail('cycle_all --skip-invisible -s 1') \
+        .expect_stderr('Cannot.*"-s"')
+
+
 @pytest.mark.parametrize("running_clients_num", [4])
 @pytest.mark.parametrize("delta", [1, -1])
 def test_cycle_all_skip_invisible(hlwm, running_clients, delta):


### PR DESCRIPTION
Migrate cycle_all to the new ArgParse and add tests for the standard
error messages. There are already tests for cycle_all, so this also
covers the successful parsing of the flag and the positional argument.