### PR TITLE
Fix race condition in test_tags_restored_after_wmexec

### DIFF
--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -136,7 +136,9 @@ def test_tags_restored_after_wmexec(hlwm, hlwm_process):
     hlwm.create_client()
 
     # Restart hlwm:
-    hlwm.call(['wmexec', hlwm_process.bin_path, '--verbose'])
+    p = hlwm.unchecked_call(['wmexec', hlwm_process.bin_path, '--verbose'],
+                            read_hlwm_output=False)
+    assert p.returncode == 0
     hlwm_process.read_and_echo_output(until_stdout='hlwm started')
 
     assert hlwm.list_children('tags.by-name') == sorted(expected_tags)


### PR DESCRIPTION
This fixes a race condition in a test case using wmexec. The race
condition occurred in the debian build log

https://buildd.debian.org/status/fetch.php?pkg=herbstluftwm&arch=ppc64el&ver=0.9.0-1~bpo10%2B1&stamp=1607007505&raw=0

and consists of the magic string "hlwm started" showing up to early such
that the read_and_echo_output() within hlwm.call() consumed it
and not the read_hlwm_output() in the test case.

As a fix, we use the unchecked_call() for which we can deactivate the
consumption of hlwm output.

I've successfully reproduced the race condition by updating the test
case to:

    @pytest.mark.parametrize('n', range(0, 200))
    def test_tags_restored_after_wmexec(hlwm, hlwm_process, n):

and passing read_hlwm_output=False fixes it.