### PR TITLE
Add basic python bindings

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -14,9 +14,7 @@ def tox(tox_args, build_dir):
     """
     tox_env = os.environ.copy()
     tox_env['PWD'] = build_dir
-    # here, we pass --recreate to tox to enforce that the package
-    # of the hlwm python bindings is updated in the virtual environment
-    sp.check_call(f'tox --recreate {tox_args}', shell=True, cwd=build_dir, env=tox_env)
+    sp.check_call(f'tox {tox_args}', shell=True, cwd=build_dir, env=tox_env)
 
 
 parser = argparse.ArgumentParser()

--- a/ci/build.py
+++ b/ci/build.py
@@ -14,7 +14,9 @@ def tox(tox_args, build_dir):
     """
     tox_env = os.environ.copy()
     tox_env['PWD'] = build_dir
-    sp.check_call(f'tox {tox_args}', shell=True, cwd=build_dir, env=tox_env)
+    # here, we pass --recreate to tox to enforce that the package
+    # of the hlwm python bindings is updated in the virtual environment
+    sp.check_call(f'tox --recreate {tox_args}', shell=True, cwd=build_dir, env=tox_env)
 
 
 parser = argparse.ArgumentParser()

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,4 @@
+# Python bindings for herbstluftwm
+
+This wraps the `herbstclient` in order to provide a herbstluftwm library for python
+with a native look and feel.

--- a/python/herbstluftwm/__init__.py
+++ b/python/herbstluftwm/__init__.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import shlex
+import subprocess
+
+
+class Herbstluftwm:
+    """A herbstluftwm wrapper class that
+    gives access to the remote interface of herbstluftwm.
+    """
+
+    def __init__(self, herbstclient='herbstclient'):
+        """
+        Create a wrapper object. The herbstclient parameter is
+        the path or command to the 'herbstclient' executable.
+        """
+        self.herbstclient_path = herbstclient
+        self.env = None
+
+    def _parse_command(self, cmd):
+        """
+        Parse a command (a string using shell quotes or
+        a string list) to a string list.
+        """
+        if isinstance(cmd, list):
+            args = [str(x) for x in cmd]
+            assert args
+        else:
+            args = shlex.split(cmd)
+        return args
+
+    def unchecked_call(self, cmd):
+        """Call the command but do not check exit code or stderr"""
+        args = self._parse_command(cmd)
+
+        proc = subprocess.run([self.herbstclient_path, '-n'] + args,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              env=self.env,
+                              universal_newlines=True,
+                              # Kill hc when it hangs due to crashed server:
+                              timeout=2
+                              )
+
+        return proc
+
+    def call(self, cmd):
+        """call the command and expect it to have exit code zero
+        and no output on stderr"""
+        proc = self.unchecked_call(cmd)
+        assert proc.returncode == 0
+        assert not proc.stderr
+        return proc

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,26 @@
+import setuptools
+import pathlib
+import os
+
+here = pathlib.Path(__file__).parent.resolve()
+
+with open(os.path.join(here, "README.md"), "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="herbstluftwm",
+    version='0.1.0',
+    author="Thorsten Wißmann",
+    author_email="edu@thorsten-wissmann.de",
+    description="python bindings for herbstluftwm",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/herbstluftwm/herbstluftwm",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Simplified BSD License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
     ewmh
     pytest-xdist
     python-xlib
+    ./python/
 
 ; Pass $PWD as it is when tox is invoked to pytest (used to find hlwm binaries)
 ; LSAN_OPTIONS is used for suppressing warnings about known memory leaks

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,14 @@ skipsdist = true
 ###
 [testenv]
 # OBACHT / CAUTION: you need to have xvfb installed (xorg-server-xvfb)
-commands = {envpython} -m pytest {posargs}
+#
+# we need to ensure the local dependency (./python) is up to date
+# in the virtual env, so we always re-install it before testing. (We do not
+# need to do this in testenv:flake8, because that scans the entire git
+# repository anyway)
+commands =
+    pip install ./python/
+    {envpython} -m pytest {posargs}
 deps =
     ewmh
     pytest-xdist


### PR DESCRIPTION
This initiates python bindings to herbstluftwm. The purpose of this is
to make it easier to write python scripts for hlwm. Moreover, as soon as
there are more useful functions in the bindings, we can also make use of
them in the test suite. Thus, we don't need a dedicated testsuite for
the bindings.

So far, the only functionality is call(), unchecked_call(), and
argument parsing.