### PR TITLE
Add AttributeProxy object for python bindings

### DIFF
--- a/python/herbstluftwm/__init__.py
+++ b/python/herbstluftwm/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import shlex
 import subprocess
+from typing import List
 """
 Python bindings for herbstluftwm. The central entity for communication
 with the herbstluftwm server is the Herbstluftwm class. See the example.py
@@ -82,7 +83,7 @@ class AttributeProxy:
       - access children
     """
     _herbstluftwm: Herbstluftwm  # the herbstclient wrapper
-    _path: list[str]  # the path of this attribute/object
+    _path: List[str]  # the path of this attribute/object
 
     def __init__(self, herbstluftwm: Herbstluftwm, attribute_path):
         self._herbstluftwm = herbstluftwm
@@ -93,7 +94,7 @@ class AttributeProxy:
         return f'<AttributeProxy {path}>'
 
     @staticmethod
-    def _compose_path(path: list[str]) -> str:
+    def _compose_path(path: List[str]) -> str:
         return '.'.join(map(str, path))
 
     def _get_value_from_hlwm(self):
@@ -143,7 +144,7 @@ class AttributeProxy:
         self.__setattr__(name, value)
 
 
-def chain(chain_cmd, commands: list[list[str]]) -> list[str]:
+def chain(chain_cmd, commands: List[List[str]]) -> List[str]:
     """return a composed command that executes
     the commands given in the list. chain_cmd is one of:
       - chain

--- a/python/herbstluftwm/__init__.py
+++ b/python/herbstluftwm/__init__.py
@@ -1,11 +1,26 @@
 #!/usr/bin/env python3
 import shlex
 import subprocess
+"""
+Python bindings for herbstluftwm. The central entity for communication
+with the herbstluftwm server is the Herbstluftwm class. See the example.py
+for example usages of the classes provided here.
+
+   import herbstluftwm
+
+   hlwm = herbstluftwm.Herbstluftwm()
+   hlwm.call('add new_tag')
+"""
 
 
 class Herbstluftwm:
     """A herbstluftwm wrapper class that
     gives access to the remote interface of herbstluftwm.
+
+    Example:
+
+        print(Herbstluftwm().call('add new_tag').stdout)
+        print(Herbstluftwm().call(['add', 'new_tag']).stdout)
     """
 
     def __init__(self, herbstclient='herbstclient'):
@@ -49,3 +64,104 @@ class Herbstluftwm:
         assert proc.returncode == 0
         assert not proc.stderr
         return proc
+
+    @property
+    def attr(self) -> 'AttributeProxy':
+        """return an attribute proxy"""
+        return AttributeProxy(self, [])
+
+
+class AttributeProxy:
+    """
+    An AttributeProxy object represents an object or attribute in herbstluftwm's
+    object tree. A proxy object can be used to
+
+      - query attribute values
+      - set attribute values
+      - create custom attributes
+      - access children
+    """
+    _herbstluftwm: Herbstluftwm  # the herbstclient wrapper
+    _path: list[str]  # the path of this attribute/object
+
+    def __init__(self, herbstluftwm: Herbstluftwm, attribute_path):
+        self._herbstluftwm = herbstluftwm
+        self._path = attribute_path
+
+    def __repr__(self) -> str:
+        path = AttributeProxy._compose_path(self._path)
+        return f'<AttributeProxy {path}>'
+
+    @staticmethod
+    def _compose_path(path: list[str]) -> str:
+        return '.'.join(map(str, path))
+
+    def _get_value_from_hlwm(self):
+        command = [
+            'get_attr',
+            AttributeProxy._compose_path(self._path)
+        ]
+        return self._herbstluftwm.call(command).stdout
+
+    def __call__(self) -> str:
+        return self._get_value_from_hlwm()
+
+    def __str__(self) -> str:
+        return self._get_value_from_hlwm()
+
+    def __getattr__(self, name) -> 'AttributeProxy':
+        if str(name).startswith('_'):
+            return super(AttributeProxy, self).__getattr__(name)
+        else:
+            return AttributeProxy(self._herbstluftwm, self._path + [name])
+
+    def __getitem__(self, name):
+        """alternate syntax for attributes/children
+        containing a - or starting with a digit
+        """
+        return self.__getattr__(name)
+
+    def __setattr__(self, name, value) -> None:
+        if name[0] == '_':
+            super(AttributeProxy, self).__setattr__(name, value)
+        else:
+            attr_path = AttributeProxy._compose_path(self._path + [name])
+            command = ['set_attr', attr_path, value]
+            if str(name).startswith('my_'):
+                # for custom attributes, silently ensure that the attribute
+                # exists.
+                command = chain('chain', [
+                    ['try', 'silent', 'new_attr', 'string', attr_path],
+                    command
+                ])
+            self._herbstluftwm.call(command)
+
+    def __setitem__(self, name, value) -> None:
+        """alternate syntax for attributes/children
+        containing a - or starting with a digit
+        """
+        self.__setattr__(name, value)
+
+
+def chain(chain_cmd, commands: list[list[str]]) -> list[str]:
+    """return a composed command that executes
+    the commands given in the list. chain_cmd is one of:
+      - chain
+      - and
+      - or
+    """
+    def separator_clashes(separator_name):
+        for cmd in commands:
+            if separator_name in cmd:
+                return True
+        return False
+    # find a token that does not occur in any of the commands
+    separator_num = 0
+    while separator_clashes(f'S{separator_num}'):
+        separator_num += 1
+    separator = f'S{separator_num}'
+    # create the composed command using the separator
+    full_command = [chain_cmd]
+    for cmd in commands:
+        full_command += [separator] + cmd
+    return full_command

--- a/python/herbstluftwm/example.py
+++ b/python/herbstluftwm/example.py
@@ -1,0 +1,35 @@
+import herbstluftwm
+
+
+def main(hlwm):
+    hlwm.call('version')
+
+    # if you pass a string to call, it will be tokenized automatically:
+    hlwm.call('add new_tag')
+    # but you can also pass a list to avoid whitespace issues:
+    hlwm.call(['merge_tag', 'new_tag'])
+
+    # hlwm.attr is a convenience wrapper for accessing attributes
+    # 1. reading attributes
+    old_name = hlwm.attr.tags.focus.name()
+    print(f"The focused tag has the name '{old_name}'")
+    # The attribute value is queried on (). Alternatively, string conversion
+    # queries implicitly:
+    print(f"The focused tag has the name '{hlwm.attr.tags.focus.name}'")
+
+    # 2. writing attributes
+    hlwm.attr.tags.focus.name = "TagFocus"
+    # One can also use [...] notation, if needed:
+    hlwm.attr.tags['by-name'].TagFocus.name = old_name
+
+    # 3. creating attributes (attribute name must start with 'my_')
+    hlwm.attr.tags.focus.my_altname = "Attribute Value"
+
+    # the AttributeProxy objects can be used multiple times
+    curtag = hlwm.attr.tags.focus
+    curtag['my_other_attribute'] = 'value'
+    assert curtag.my_other_attribute() == 'value'
+
+
+if __name__ == '__main__':
+    main(herbstluftwm.Herbstluftwm())

--- a/tests/test_python_binds.py
+++ b/tests/test_python_binds.py
@@ -1,0 +1,81 @@
+import pytest
+import herbstluftwm.example
+
+
+def test_example(hlwm):
+    # test the example.py shipped with the bindings
+    herbstluftwm.example.main(hlwm)
+
+
+def test_attr_get(hlwm):
+    assert hlwm.attr.tags.focus.index() == '0'
+    assert str(hlwm.attr.tags.focus.index) == '0'
+
+
+def test_multi_objects_format(hlwm):
+    tag = hlwm.attr.tags.focus
+    assert f'{tag.index} / {tag.frame_count}' == '0 / 1'
+
+
+def test_attr_set(hlwm):
+    hlwm.attr.tags.focus.name = 'newname'
+
+    assert hlwm.call('get_attr tags.focus.name').stdout == 'newname'
+    assert hlwm.attr.tags.focus.name() == 'newname'
+
+
+def test_attr_custom_attribute(hlwm):
+    hlwm.attr.monitors.my_new_attr = 'myvalue'
+
+    assert hlwm.call('get_attr monitors.my_new_attr').stdout == 'myvalue'
+    assert hlwm.attr.monitors.my_new_attr() == 'myvalue'
+
+
+def test_attr_get_dict_child(hlwm):
+    assert hlwm.attr.monitors['0'].index() == '0'
+    assert hlwm.attr.monitors[0].index() == '0'
+
+
+def test_attr_get_dict_attribute(hlwm):
+    assert hlwm.attr.monitors['0']['index']() == '0'
+
+
+def test_attr_set_dict_attribute(hlwm):
+    hlwm.attr.monitors['0']['name'] = 'newname'
+
+    assert hlwm.call('get_attr monitors.0.name').stdout == 'newname'
+
+
+def test_attr_set_dict_custom_attribute(hlwm):
+    hlwm.attr.monitors['0']['my_test'] = 'value'
+
+    assert hlwm.call('get_attr monitors.0.my_test').stdout == 'value'
+
+
+@pytest.mark.parametrize('value', ['a', 'b', 'c'])
+def test_chain_commands_if_then_else(hlwm, value):
+    from herbstluftwm import chain
+
+    # perform the comparison value == 'a' in hlwm:
+    hlwm.attr.my_attr = value
+    cmd = chain('or', [
+        chain('and', [
+            ['compare', 'my_attr', '=', 'a'],
+            chain('chain', [
+                ['echo', 'then branch 1'],
+                ['echo', 'then branch 2'],
+            ]),
+        ]),
+        chain('chain', [
+            ['echo', 'else branch 1'],
+            ['echo', 'else branch 2'],
+        ]),
+    ])
+    if value == 'a':
+        expected = 'then branch 1\nthen branch 2\n'
+    else:
+        expected = 'else branch 1\nelse branch 2\n'
+
+    output = hlwm.call(cmd).stdout
+
+    assert output == expected


### PR DESCRIPTION
This simplifies the reading and writing of attributes via the python
bindings. Also, this adds:

  - Test cases for thew new AttributeProxy functionality
  - example.py showing the example usage (and we call it from the test
    suite to ensure that the examples indeed work)
  - an utility function for combining commands via chain/and/or