### PR TITLE
Do not call applyLayout() from FrameLeaf

### DIFF
--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -152,6 +152,7 @@ int FrameTree::cycleSelectionCommand(Input input, Output output) {
     if (count != 0) {
         frame->setSelection(MOD(frame->getSelection() + delta, count));
     }
+    get_current_monitor()->applyLayout();
     return 0;
 }
 
@@ -162,6 +163,7 @@ int FrameTree::focusNthCommand(Input input, Output output) {
         return HERBST_NEED_MORE_ARGS;
     }
     focusedFrame()->setSelection(atoi(index.c_str()));
+    get_current_monitor()->applyLayout();
     return 0;
 }
 

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -468,8 +468,6 @@ void FrameLeaf::setSelection(int index) {
         index = clients.size() - 1;
     }
     selection = index;
-    clients[selection]->window_focus();
-    get_current_monitor()->applyLayout();
 }
 
 int Frame::splitsToRoot(SplitAlign align) {

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -304,14 +304,29 @@ def test_cycle(hlwm, running_clients, running_clients_num, num_splits, cycle_del
     new_windex = int(hlwm.get_attr('tags.0.curframe_windex'))
     expected_index = (windex + cycle_delta + wcount) % wcount if wcount > 0 else 0
     assert expected_index == new_windex
+    # check that the right winid is focused
+    layout = hlwm.call(['dump', '', '@']).stdout
+    winids = re.findall('0x[a-fA-f0-9]*', layout)
+    if len(winids) > 0:
+        assert winids[new_windex] == hlwm.get_attr('clients.focus.winid')
 
 
 @pytest.mark.parametrize("running_clients_num", [0, 1, 5])
 @pytest.mark.parametrize("index", [0, 1, 3, 5])
 def test_focus_nth(hlwm, running_clients, running_clients_num, index):
+    # bring the clients in the right order
+    layout = '(clients vertical:0 '
+    layout += ' '.join(running_clients)
+    layout += ')'
+    hlwm.call(['load', layout])
+
+    # focus the n_th
     hlwm.call('focus_nth {}'.format(index))
+
     windex = int(hlwm.get_attr('tags.0.curframe_windex'))
     assert windex == max(0, min(index, running_clients_num - 1))
+    if running_clients_num > 0:
+        assert hlwm.get_attr('clients.focus.winid') == running_clients[windex]
 
 
 @pytest.mark.parametrize("running_clients_num", [5])

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -82,6 +82,23 @@ def test_explode(hlwm, running_clients, running_clients_num):
     verify_frame_objects_via_dump(hlwm)
 
 
+def test_explode_second_client(hlwm):
+    winids = hlwm.create_clients(2)
+    hlwm.call(['load', f'(clients vertical:1 {winids[0]} {winids[1]})'])
+    hlwm.call('split explode')
+
+    assert hlwm.get_attr('tags.0.curframe_wcount') == '1'
+    assert hlwm.get_attr('tags.0.curframe_windex') == '0'
+    # FIXME: in v0.7.2, the focus stayed in the client it was before!
+    expected_layout = textwrap.dedent(f"""\
+    (split vertical:0.5:0
+    (clients vertical:0 {winids[0]})
+    (clients vertical:0 {winids[1]}))
+    """).replace('\n', ' ').strip()
+    assert hlwm.call('dump').stdout == expected_layout
+    verify_frame_objects_via_dump(hlwm)
+
+
 @pytest.mark.parametrize("running_clients_num", [0, 1, 4])
 def test_remove(hlwm, running_clients, running_clients_num):
     hlwm.call('split explode')


### PR DESCRIPTION
In FrameLeaf::split(), the function FrameLeaf::setSelection() was called before
`selection` was (and could be) set correctly. Since setSelection() called
Monitor::applyLayout(), this led to a crash because the `selection` was out of
bounds.

The present change removes all invokations of Monitor::applyLayout() from
setSelection() (the only leftover use of applyLayout() in FrameLeaf/FrameSplit).
To ensure that the actual window geometries update correctly, I went
through all invocations of setSelection and added the applyLayout() where it
wasn't called before (namely, the commands focus_nth and cycle). The other
commands (cycle_all, remove, focus) called applyLayout() already.

Also, I removed the call `clients[selection]->window_focus()` because it is
simply wrong if the FrameLeaf is not focused. Instead, the applyLayout()
function should take care of the focus.

Beside adding a test case for the crash scenario of #1056, I've extended the
test cases for focus_nth and cycle to verify that focus indeed updates
correctly.

This fixes #1056.
