### PR TITLE
Use -D_GLIBCXX_ASSERTIONS and other security flags

### DIFF
--- a/cmake/debugflags.cmake
+++ b/cmake/debugflags.cmake
@@ -18,11 +18,6 @@ set(FLAGS
     # range checks for C++ datatypes:
     -D_GLIBCXX_ASSERTIONS
 
-    # more stack protection:
-    -fstack-protector-strong
-    -fcf-protection
-    -fstack-clash-protection
-
     # TODO: Fix complaints, then enable -Wconversion (gcc and clang might behave
     # differently)
 
@@ -36,6 +31,13 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         -Wduplicated-cond -Wduplicated-branches -Wlogical-op
 
         # TODO: Consider adding -fanalyzer here (new in GCC-10)
+        
+        
+
+        # more stack protection:
+        -fstack-protector-strong
+        -fcf-protection
+        -fstack-clash-protection
         )
 
     # Add GCC- *and* C++-specific flags

--- a/cmake/debugflags.cmake
+++ b/cmake/debugflags.cmake
@@ -15,6 +15,14 @@ set(FLAGS
     # Disable unused parameter warnings (most cases are on purpose):
     -Wno-unused-parameter
 
+    # range checks for C++ datatypes:
+    -D_GLIBCXX_ASSERTIONS
+
+    # more stack protection:
+    -fstack-protector-strong
+    -fcf-protection
+    -fstack-clash-protection
+
     # TODO: Fix complaints, then enable -Wconversion (gcc and clang might behave
     # differently)
 


### PR DESCRIPTION
In the debug build, activate range checks for C++ datatypes. This flag
would have been prevented crash #1056 on fedora, that has these flags
per default. While at it, I've also added further stack protection flags
in the hope that this helps us to detect bugs earlier.