### PR TITLE
Make 'split explode' preserve the client focus

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,8 @@ Current git version
     - When hiding windows, correctly set their WM_STATE to IconicState (we set
       it to Withdrawn state before, which means "unmanaged" and thus is wrong).
       This may require restarting pagers when upgrading hlwm live.
+    - Fix crash in 'split explode'
+    - 'split explode' preserves the window focus (as in v0.7.2 and before)
 
 Release 0.9.0 on 2020-10-31
 ---------------------------

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -395,9 +395,9 @@ split 'ALIGN' ['FRACTION' ['FRAMEINDEX']::
     after the split. The other half will be occupied by the currently focused
     frame. After splitting, the originally focused frame will stay focused.
     One special 'ALIGN' mode is 'explode', which splits the frame in such a way
-    that the window sizes and positions are kept as much as possible. If no
-    'FRACTION' is given to 'explode' mode an optimal fraction is picked
-    automatically. Example:
+    that the window focus, window sizes, and positions are kept as much as
+    possible. If no 'FRACTION' is given to 'explode' mode an optimal fraction is
+    picked automatically. Example:
 
         * split explode
         * split bottom 0.5

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -882,7 +882,7 @@ vector<SplitMode> SplitMode::modes(SplitAlign align_explode, SplitAlign align_au
         { "right",      SplitAlign::horizontal,   true,   0   },
         { "horizontal", SplitAlign::horizontal,   true,   0   },
         { "left",       SplitAlign::horizontal,   false,  1   },
-        { "explode",    align_explode,            true,   0   },
+        { "explode",    align_explode,            true,   -1  },
         { "auto",       align_auto,               true,   0   },
     };
 }
@@ -969,7 +969,9 @@ int FrameTree::splitCommand(Input input, Output output)
     if (!m.frameToFirst) {
         frameParent->swapChildren();
     }
-    frameParent->setSelection(m.selection);
+    if (m.selection >= 0) {
+        frameParent->setSelection(m.selection);
+    }
 
     // redraw monitor
     get_current_monitor()->applyLayout();

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -528,6 +528,7 @@ bool FrameLeaf::split(SplitAlign alignment, FixPrecDec fraction, size_t children
     if (splitsToRoot(alignment) > HERBST_MAX_TREE_HEIGHT) {
         return false;
     }
+    childrenLeaving = std::min(clients.size(), childrenLeaving);
     int childrenStaying = std::max((size_t)0, clients.size() - childrenLeaving);
     vector<Client*> leaves(clients.begin() + childrenStaying, clients.end());
     clients.erase(clients.begin() + childrenStaying, clients.end());
@@ -542,6 +543,8 @@ bool FrameLeaf::split(SplitAlign alignment, FixPrecDec fraction, size_t children
     tag_->frame->replaceNode(thisLeaf(), new_this);
     parent_ = new_this;
     if (selection >= childrenStaying) {
+        // if the focused client is moved to the second frameleaf, focus that
+        new_this->setSelection(1);
         second->setSelection(selection - childrenStaying);
         selection = std::max(0, childrenStaying - 1);
     }

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -89,14 +89,24 @@ def test_explode_second_client(hlwm):
 
     assert hlwm.get_attr('tags.0.curframe_wcount') == '1'
     assert hlwm.get_attr('tags.0.curframe_windex') == '0'
-    # FIXME: in v0.7.2, the focus stayed in the client it was before!
     expected_layout = textwrap.dedent(f"""\
-    (split vertical:0.5:0
+    (split vertical:0.5:1
     (clients vertical:0 {winids[0]})
     (clients vertical:0 {winids[1]}))
     """).replace('\n', ' ').strip()
     assert hlwm.call('dump').stdout == expected_layout
     verify_frame_objects_via_dump(hlwm)
+
+
+@pytest.mark.parametrize("running_clients_num", [4])
+@pytest.mark.parametrize("focus_idx", range(0, 4))
+def test_explode_preserves_focus(hlwm, running_clients, running_clients_num, focus_idx):
+    hlwm.call(['focus_nth', focus_idx])
+    winid = hlwm.attr.clients.focus.winid()
+
+    for i in range(0, running_clients_num):
+        hlwm.call('split explode')
+        assert winid == hlwm.attr.clients.focus.winid()
 
 
 @pytest.mark.parametrize("running_clients_num", [0, 1, 4])


### PR DESCRIPTION
This restores the (desirable) behaviour of 'split explode' from v0.7.2
where splitting preserved which client is focused.