### PR TITLE
Migrate CI to github actions

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -1,51 +1,23 @@
 name: HLWM CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-test-current:
     # Name the Job
     name: Build and test on current ubuntu
     # Set the type of machine to run on
-    runs-on: ubuntu-latest
+    container: hlwm/ci:focal
 
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          DEBIAN_FRONTEND=noninteractive sudo apt-get -y install \
-            ccache \
-            clang-10 \
-            clang-tidy-10 \
-            cmake \
-            g++-9 \
-            iwyu \
-            lcov \
-            libx11-dev \
-            libxext-dev \
-            libxinerama-dev \
-            libxrandr-dev \
-            ninja-build \
-            pkg-config \
-            python3.8 \
-            tox \
-            x11-xserver-utils \
-            xdotool \
-            xterm \
-            xvfb \
-            xserver-xephyr
-
-
-      # Runs the Super-Linter action
       - name: Build
         run: |
-          ci/build.py --build-dir=./build --build-type=Debug --ccache=.ccache --compile
+          /hlwm/ci/build.py --build-dir=/hlwm/build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=/.ccache --compile
 
-      # Runs the Super-Linter action
       - name: Test
         run: |
-          ci/build.py --build-dir=./build --build-type=Debug --run-tests
+          /hlwm/ci/build.py --build-dir=/hlwm/build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=/.ccache --run-tests

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -14,6 +14,31 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y install \
+            ccache \
+            clang-10 \
+            clang-tidy-10 \
+            cmake \
+            g++-9 \
+            iwyu \
+            lcov \
+            libx11-dev \
+            libxext-dev \
+            libxinerama-dev \
+            libxrandr-dev \
+            ninja-build \
+            pkg-config \
+            python3.8 \
+            tox \
+            x11-xserver-utils \
+            xdotool \
+            xterm \
+            xvfb \
+            xserver-xephyr
+
+
       # Runs the Super-Linter action
       - name: Build
         run: |

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Test process subst
+        run: cat <(echo works) || echo Warning
+
       - uses: actions/cache@v1
         name: Cache ~/.ccache
         with:

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -1,7 +1,11 @@
 name: HLWM CI
 
 # on: [push, pull_request]
-on: push
+on:
+  push:
+    paths-ignore:
+    - '.mergify.yml'
+    - 'share/**'
 
 jobs:
   build-test-current:

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -92,6 +92,11 @@ jobs:
           key: ccache-gcc-4.8 # different name than in build-test-current
 
       - name: Build
+        env:
+          CC: gcc-4.8
+          CXX: g++-4.8
+          CXXFLAGS: -m32
+          CFLAGS: -m32
         run: |
           ccache -z --max-size=500M
           mkdir build

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -102,5 +102,5 @@ jobs:
           mkdir build
           cd build
           cmake -GNinja -DWITH_DOCUMENTATION=NO -DENABLE_CCACHE=YES ..
-          time ninja -v -k10
+          ninja -v -k10
           ccache -s

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -37,6 +37,7 @@ jobs:
           ci/build.py --build-dir=build --run-tests
 
       - name: Codecov report
+        continue-on-error: true
         run: |
           wget -O codecov-io.bash https://codecov.io/bash
           bash codecov-io.bash -f coverage.info
@@ -61,21 +62,21 @@ jobs:
           path: .tox-cache
           key: focal-tox # same name as in build-test-current
 
-      - name: Build
-        run: |
-          ci/build.py --build-dir=build --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
-
       - name: Check usage of std-prefix
         run: |
           ci/build.py --build-dir=build --check-using-std
 
-      - name: Check includes using iwyu
-        run: |
-          ci/build.py --build-dir=build --iwyu
-
       - name: Check python using flake8
         run: |
           ci/build.py --build-dir=build --flake8
+
+      - name: Build
+        run: |
+          ci/build.py --build-dir=build --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
+
+      - name: Check includes using iwyu
+        run: |
+          ci/build.py --build-dir=build --iwyu
 
   build-old-32bit:
     name: Build for 32bit with ancient GCC on Ubuntu 14.04

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           ci/build.py --build-dir=build --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
 
-      - name: Check usage of std:: prefix
+      - name: Check usage of std-prefix
         run: |
           ci/build.py --build-dir=build --check-using-std
 

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -7,6 +7,7 @@ jobs:
     # Name the Job
     name: Build and test on current ubuntu
     # Set the type of machine to run on
+    runs-on: ubuntu-latest
     container: hlwm/ci:focal
 
     steps:

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -36,6 +36,6 @@ jobs:
         run: |
           ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=.ccache --run-tests
 
-      - name: Codecov report
-        run: |
-          bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo Warning: codecov report failed
+#      - name: Codecov report
+#        run: |
+#          bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo Warning: codecov report failed

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -23,18 +23,18 @@ jobs:
           key: focal-ccache
 
       - uses: actions/cache@v1
-        name: Cache ~/.tox-cache
+        name: Cache .tox-cache
         with:
-          path: ~/.tox-cache
+          path: .tox-cache
           key: focal-tox
 
       - name: Build
         run: |
-          ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=.ccache --compile
+          ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
 
       - name: Test
         run: |
-          ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=.ccache --run-tests
+          ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --run-tests
 
 #      - name: Codecov report
 #        run: |

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -16,7 +16,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -y install \
+          sudo apt-get update
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -y install \
             ccache \
             clang-10 \
             clang-tidy-10 \

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -1,0 +1,25 @@
+name: HLWM CI
+
+on: [push]
+
+jobs:
+  build-test-current:
+    # Name the Job
+    name: Build and test on current ubuntu
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Runs the Super-Linter action
+      - name: Build
+        run: |
+          ci/build.py --build-dir=./build --build-type=Debug --ccache=.ccache --compile
+
+      # Runs the Super-Linter action
+      - name: Test
+        run: |
+          ci/build.py --build-dir=./build --build-type=Debug --run-tests

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -17,8 +17,8 @@ jobs:
 
       - name: Build
         run: |
-          /hlwm/ci/build.py --build-dir=/hlwm/build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=/.ccache --compile
+          ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=.ccache --compile
 
       - name: Test
         run: |
-          /hlwm/ci/build.py --build-dir=/hlwm/build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=/.ccache --run-tests
+          ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=.ccache --run-tests

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Test process subst
-        run: 'cat <(echo works) || echo Warning'
-
       - uses: actions/cache@v1
         name: Cache ~/.ccache
         with:
@@ -39,6 +36,7 @@ jobs:
         run: |
           ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --run-tests
 
-#      - name: Codecov report
-#        run: |
-#          bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo Warning: codecov report failed
+      - name: Codecov report
+        run: |
+          wget -O codecov-io.bash https://codecov.io/bash
+          bash codecov-io.bash -f coverage.info

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -1,6 +1,7 @@
 name: HLWM CI
 
-on: [push, pull_request]
+# on: [push, pull_request]
+on: push
 
 jobs:
   build-test-current:
@@ -15,6 +16,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - uses: actions/cache@v1
+        name: Cache ~/.ccache
+        with:
+          path: ~/.ccache
+          key: focal-ccache
+
+      - uses: actions/cache@v1
+        name: Cache ~/.tox-cache
+        with:
+          path: ~/.tox-cache
+          key: focal-tox
+
       - name: Build
         run: |
           ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=.ccache --compile
@@ -22,3 +35,7 @@ jobs:
       - name: Test
         run: |
           ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=.ccache --run-tests
+
+      - name: Codecov report
+        run: |
+          bash <(wget -O - https://codecov.io/bash) -f coverage.info || echo Warning: codecov report failed

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -30,13 +30,72 @@ jobs:
 
       - name: Build
         run: |
-          ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
+          ci/build.py --build-dir=build --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
 
       - name: Test
         run: |
-          ci/build.py --build-dir=build --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --run-tests
+          ci/build.py --build-dir=build --run-tests
 
       - name: Codecov report
         run: |
           wget -O codecov-io.bash https://codecov.io/bash
           bash codecov-io.bash -f coverage.info
+
+  build-clang:
+    name: Build with Clang, run linters and static analyzers
+    runs-on: ubuntu-latest
+    container: hlwm/ci:focal
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        name: Cache ~/.ccache
+        with:
+          path: ~/.ccache
+          key: focal-clang-ccache # different name than in build-test-current
+
+      - uses: actions/cache@v1
+        name: Cache .tox-cache
+        with:
+          path: .tox-cache
+          key: focal-tox # same name as in build-test-current
+
+      - name: Build
+        run: |
+          ci/build.py --build-dir=build --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
+
+      - name: Check usage of std:: prefix
+        run: |
+          ci/build.py --build-dir=build --check-using-std
+
+      - name: Check includes using iwyu
+        run: |
+          ci/build.py --build-dir=build --iwyu
+
+      - name: Check python using flake8
+        run: |
+          ci/build.py --build-dir=build --flake8
+
+  build-old-32bit:
+    name: Build for 32bit with ancient GCC on Ubuntu 14.04
+    runs-on: ubuntu-latest
+    container: hlwm/ci:trusty
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        name: Cache ~/.ccache
+        with:
+          path: ~/.ccache
+          key: ccache-gcc-4.8 # different name than in build-test-current
+
+      - name: Build
+        run: |
+          ccache -z --max-size=500M
+          mkdir build
+          cd build
+          cmake -GNinja -DWITH_DOCUMENTATION=NO -DENABLE_CCACHE=YES ..
+          time ninja -v -k10
+          ccache -s

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Test process subst
-        run: cat <(echo works) || echo Warning
+        run: 'cat <(echo works) || echo Warning'
 
       - uses: actions/cache@v1
         name: Cache ~/.ccache

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,9 @@ pull_request_rules:
     - name: automatic merge on CI success and review
       conditions:
           - base=master
-          - status-success=Travis CI - Pull Request
+          - status-success=Build and test on current ubuntu
+          - status-success=Build with Clang, run linters and static analyzers
+          - status-success=Build for 32bit with ancient GCC on Ubuntu 14.04
           - "#approved-reviews-by>=1"
           - label≠wip
       actions:
@@ -13,7 +15,9 @@ pull_request_rules:
     - name: Implicitly allow t-wissmann to approve own pull requests
       conditions:
           - author=t-wissmann
-          - status-success=Travis CI - Pull Request
+          - status-success=Build and test on current ubuntu
+          - status-success=Build with Clang, run linters and static analyzers
+          - status-success=Build for 32bit with ancient GCC on Ubuntu 14.04
           - label≠wip
           - label=self-approved
       actions:

--- a/ci/build.py
+++ b/ci/build.py
@@ -32,7 +32,10 @@ parser.add_argument('--ccache', nargs='?', metavar='ccache dir', type=str,
                     const=os.environ.get('CCACHE_DIR') or True)
 args = parser.parse_args()
 
-repo = Path(__file__).resolve().parent.parent
+repo = sp.run('git rev-parse --show-toplevel',
+              shell=True,
+              universal_newlines=True,
+              stdout=sp.PIPE).stdout.rstrip()
 build_dir = Path(args.build_dir)
 build_dir.mkdir(exist_ok=True)
 

--- a/ci/build.py
+++ b/ci/build.py
@@ -129,7 +129,7 @@ if args.run_tests:
 
     # First, run only the tests that are NOT marked to be excluded from code
     # coverage collection.
-    tox('-e py38 -- -n auto --cache-clear -v -x -k herbst', build_dir)
+    tox('-e py38 -- -n auto --cache-clear -v -x -m "not exclude_from_coverage"', build_dir)
 
     # Create the code coverage report:
     sp.check_call('lcov --capture --directory . --output-file coverage.info', shell=True, cwd=build_dir)

--- a/ci/build.py
+++ b/ci/build.py
@@ -32,10 +32,7 @@ parser.add_argument('--ccache', nargs='?', metavar='ccache dir', type=str,
                     const=os.environ.get('CCACHE_DIR') or True)
 args = parser.parse_args()
 
-repo = sp.run('git rev-parse --show-toplevel',
-              shell=True,
-              universal_newlines=True,
-              stdout=sp.PIPE).stdout.rstrip()
+repo = Path(__file__).resolve().parent.parent
 build_dir = Path(args.build_dir)
 build_dir.mkdir(exist_ok=True)
 

--- a/ci/build.py
+++ b/ci/build.py
@@ -129,7 +129,7 @@ if args.run_tests:
 
     # First, run only the tests that are NOT marked to be excluded from code
     # coverage collection.
-    tox('-e py38 -- -n auto --cache-clear -v -x -m "not exclude_from_coverage"', build_dir)
+    tox('-e py38 -- -n auto --cache-clear -v -x -k herbst', build_dir)
 
     # Create the code coverage report:
     sp.check_call('lcov --capture --directory . --output-file coverage.info', shell=True, cwd=build_dir)

--- a/ci/build.py
+++ b/ci/build.py
@@ -20,6 +20,7 @@ def tox(tox_args, build_dir):
 parser = argparse.ArgumentParser()
 parser.add_argument('--build-dir', type=str, required=True)
 parser.add_argument('--build-type', type=str, choices=('Release', 'Debug'), required=True)
+parser.add_argument('--cmake', action='store_true')
 parser.add_argument('--compile', action='store_true')
 parser.add_argument('--run-tests', action='store_true')
 parser.add_argument('--build-docs', action='store_true')
@@ -57,32 +58,33 @@ if args.ccache:
     # Print config for confirmation:
     sp.check_call('ccache -p', shell=True)
 
-build_env = os.environ.copy()
-build_env.update({
-    'CC': args.cc,
-    'CXX': args.cxx,
-    'CFLAGS': '--coverage -Werror -fsanitize=address,leak,undefined',
-    'CXXFLAGS': '--coverage -Werror -fsanitize=address,leak,undefined',
+if args.cmake:
+    build_env = os.environ.copy()
+    build_env.update({
+        'CC': args.cc,
+        'CXX': args.cxx,
+        'CFLAGS': '--coverage -Werror -fsanitize=address,leak,undefined',
+        'CXXFLAGS': '--coverage -Werror -fsanitize=address,leak,undefined',
 
-    # Hash-verifying the compiler is required when building with
-    # clang-and-tidy.sh (because the script's mtime is not stable) and for
-    # other cases, the overhead is minimal):
-    'CCACHE_COMPILERCHECK': 'content',
+        # Hash-verifying the compiler is required when building with
+        # clang-and-tidy.sh (because the script's mtime is not stable) and for
+        # other cases, the overhead is minimal):
+        'CCACHE_COMPILERCHECK': 'content',
 
-    # In case clang-and-tidy.sh is used for building, it will need this to call
-    # clang-tidy:
-    'CLANG_TIDY_BUILD_DIR': str(build_dir),
-})
+        # In case clang-and-tidy.sh is used for building, it will need this to call
+        # clang-tidy:
+        'CLANG_TIDY_BUILD_DIR': str(build_dir),
+    })
 
-cmake_args = [
-    '-GNinja',
-    '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-    f'-DCMAKE_BUILD_TYPE={args.build_type}',
-    f'-DWITH_DOCUMENTATION={"YES" if args.build_docs else "NO"}',
-    f'-DENABLE_CCACHE={"YES" if args.ccache else "NO"}',
-]
+    cmake_args = [
+        '-GNinja',
+        '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
+        f'-DCMAKE_BUILD_TYPE={args.build_type}',
+        f'-DWITH_DOCUMENTATION={"YES" if args.build_docs else "NO"}',
+        f'-DENABLE_CCACHE={"YES" if args.ccache else "NO"}',
+    ]
 
-sp.check_call(['cmake', *cmake_args, repo], cwd=build_dir, env=build_env)
+    sp.check_call(['cmake', *cmake_args, repo], cwd=build_dir, env=build_env)
 
 if args.compile:
     sp.check_call(['bash', '-c', 'time ninja -v -k 10'], cwd=build_dir, env=build_env)

--- a/ci/build.py
+++ b/ci/build.py
@@ -19,7 +19,7 @@ def tox(tox_args, build_dir):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--build-dir', type=str, required=True)
-parser.add_argument('--build-type', type=str, choices=('Release', 'Debug'), required=True)
+parser.add_argument('--build-type', type=str, choices=('Release', 'Debug'))
 parser.add_argument('--cmake', action='store_true')
 parser.add_argument('--compile', action='store_true')
 parser.add_argument('--run-tests', action='store_true')


### PR DESCRIPTION
This converts the travis ci configuration to github actions. Again we
have three jobs: one with gcc, one with clang, both on a current 64 bit
system, and one on an old 32 bit system.

All three jobs run in docker containers that are pulled from dockerhub.
In the old travis setup, if the docker file changed, then the newer
docker file was used directly. This is not yet reflected in the github
actions, so we can't use pull requests to test changes in the docker
files, yet.

Moreover, the ci/build.py is really optimized towards being invoked only
once, as it was the case for the travis ci. With github actions, we will
need to invoke it multiple times per job (namely step by step), so
ci/build.py will need to change further in the future. I tried to be as
little invasive here as possible to keep the diff of ci/build.py small.

