### PR TITLE
Also run github actions on pull_requests

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
     - '.mergify.yml'
     - 'share/**'
-  pull_requests:
+  pull_request:
     paths-ignore:
     - '.mergify.yml'
     - 'share/**'

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -1,8 +1,11 @@
 name: HLWM CI
 
-# on: [push, pull_request]
 on:
   push:
+    paths-ignore:
+    - '.mergify.yml'
+    - 'share/**'
+  pull_requests:
     paths-ignore:
     - '.mergify.yml'
     - 'share/**'


### PR DESCRIPTION
It seems that in #1068 the github actions are run on the fork a pull
reqests contributor, and this does not activate the required status
checks for mergify. Let us try to add 'run on pull request' to solve
this.