### PR TITLE
Minor improvements in CI

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -2,6 +2,8 @@ name: HLWM CI
 
 on:
   push:
+    branches:
+    - master
     paths-ignore:
     - '.mergify.yml'
     - 'share/**'
@@ -17,6 +19,8 @@ jobs:
     # Set the type of machine to run on
     runs-on: ubuntu-latest
     container: hlwm/ci:focal
+    env:
+      HLWM_BUILDDIR: build
 
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
@@ -37,11 +41,11 @@ jobs:
 
       - name: Build
         run: |
-          ci/build.py --build-dir=build --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
+          ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
 
       - name: Test
         run: |
-          ci/build.py --build-dir=build --run-tests
+          ci/build.py --run-tests
 
       - name: Codecov report
         continue-on-error: true
@@ -53,6 +57,8 @@ jobs:
     name: Build with Clang, run linters and static analyzers
     runs-on: ubuntu-latest
     container: hlwm/ci:focal
+    env:
+      HLWM_BUILDDIR: build
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -71,19 +77,19 @@ jobs:
 
       - name: Check usage of std-prefix
         run: |
-          ci/build.py --build-dir=build --check-using-std
+          ci/build.py --check-using-std
 
       - name: Check python using flake8
         run: |
-          ci/build.py --build-dir=build --flake8
+          ci/build.py --flake8
 
       - name: Build
         run: |
-          ci/build.py --build-dir=build --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
+          ci/build.py --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
 
       - name: Check includes using iwyu
         run: |
-          ci/build.py --build-dir=build --iwyu
+          ci/build.py --iwyu
 
   build-old-32bit:
     name: Build for 32bit with ancient GCC on Ubuntu 14.04

--- a/ci/Dockerfile.ci-focal
+++ b/ci/Dockerfile.ci-focal
@@ -5,8 +5,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     ccache \
     clang-10 \
     clang-tidy-10 \
+    curl \
     cmake \
     g++-9 \
+    git \
     iwyu \
     lcov \
     libx11-dev \
@@ -17,6 +19,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     pkg-config \
     python3.8 \
     tox \
+    wget \
     x11-xserver-utils \
     xdotool \
     xterm \

--- a/ci/build.py
+++ b/ci/build.py
@@ -18,7 +18,8 @@ def tox(tox_args, build_dir):
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--build-dir', type=str, required=True)
+parser.add_argument('--build-dir', type=str,
+                    default=os.environ.get('HLWM_BUILDDIR', None))
 parser.add_argument('--build-type', type=str, choices=('Release', 'Debug'))
 parser.add_argument('--cmake', action='store_true')
 parser.add_argument('--compile', action='store_true')


### PR DESCRIPTION
To avoid cpu and user time, I'm combining multiple smaller changes:

  - The build directory is now passed via environment variables
    and thus does not need to be specificed in every step
  - Only pushing to 'master' triggers the workflow, because otherwise,
    every pull request triggers the workflow twice: as a pull request
    and for the branch (the latter is run on the repository containing
    the branch, not necessarily herbstluftwm/herbstluftwm)
  - The 'current ubuntu' dockerfiles now includes git, curl, and wget.