### PR TITLE
Compare compiler binaries for ccache in ci

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -41,6 +41,11 @@ jobs:
           path: .tox-cache
           key: focal-tox
 
+      - name: inspect ccache 1
+        run: |
+          find ~/.ccache | grep 8/f/64 || true
+          find ~/.ccache | wc -l
+
       - name: Build
         run: |
           ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
@@ -48,6 +53,7 @@ jobs:
       - name: inspect ccache 2
         run: |
           find ~/.ccache | grep 8/f/64 || true
+          find ~/.ccache | wc -l
 
       - name: ccache log
         run: |
@@ -61,6 +67,7 @@ jobs:
       - name: inspect ccache 3
         run: |
           find ~/.ccache | grep 8/f/64 || true
+          find ~/.ccache | wc -l
 
       - name: ccache log
         run: |
@@ -111,6 +118,7 @@ jobs:
       - name: inspect ccache 1
         run: |
           find ~/.ccache | grep 8/f/64 || true
+          find ~/.ccache | wc -l
 
       - name: Build
         run: |
@@ -119,6 +127,7 @@ jobs:
       - name: inspect ccache 2
         run: |
           find ~/.ccache | grep 8/f/64 || true
+          find ~/.ccache | wc -l
 
       - name: ccache log
         run: |
@@ -132,6 +141,7 @@ jobs:
       - name: inspect ccache 3
         run: |
           find ~/.ccache | grep 8/f/64 || true
+          find ~/.ccache | wc -l
 
       - name: ccache log
         run: |
@@ -163,6 +173,7 @@ jobs:
           CXXFLAGS: -m32
           CFLAGS: -m32
         run: |
+          find ~/.ccache | wc -l
           ccache -z --max-size=500M
           # ccache too old for --show-config
           mkdir build
@@ -170,3 +181,4 @@ jobs:
           cmake -GNinja -DWITH_DOCUMENTATION=NO -DENABLE_CCACHE=YES ..
           ninja -v -k10
           ccache -s
+          find ~/.ccache | wc -l

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -21,6 +21,7 @@ jobs:
     container: hlwm/ci:focal
     env:
       HLWM_BUILDDIR: build
+      CCACHE_LOGFILE: /github/home/ccache.log
 
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
@@ -43,13 +44,23 @@ jobs:
         run: |
           ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
 
+      - name: ccache log
+        run: |
+          cat "$CCACHE_LOGFILE"
+          echo > "$CCACHE_LOGFILE"
+
       - name: Build 2nd time
         run: |
           ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
 
-      - name: Test
+      - name: ccache log
         run: |
-          ci/build.py --run-tests
+          cat "$CCACHE_LOGFILE"
+          echo > "$CCACHE_LOGFILE"
+
+      # - name: Test
+      #   run: |
+      #     ci/build.py --run-tests
 
       - name: Codecov report
         continue-on-error: true
@@ -63,6 +74,7 @@ jobs:
     container: hlwm/ci:focal
     env:
       HLWM_BUILDDIR: build
+      CCACHE_LOGFILE: /github/home/ccache.log
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -91,9 +103,19 @@ jobs:
         run: |
           ci/build.py --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
 
+      - name: ccache log
+        run: |
+          cat "$CCACHE_LOGFILE"
+          echo > "$CCACHE_LOGFILE"
+
       - name: Build 2nd time
         run: |
           ci/build.py --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
+
+      - name: ccache log
+        run: |
+          cat "$CCACHE_LOGFILE"
+          echo > "$CCACHE_LOGFILE"
 
       - name: Check includes using iwyu
         run: |

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: inspect ccache 1
         run: |
-          find ~/.ccache | grep 8/f/64 || true
+          find ~/.ccache | grep 8/2/aeeb3d || true
           find ~/.ccache | wc -l
 
       - name: Build
@@ -52,7 +52,7 @@ jobs:
 
       - name: inspect ccache 2
         run: |
-          find ~/.ccache | grep 8/f/64 || true
+          find ~/.ccache | grep 8/2/aeeb3d || true
           find ~/.ccache | wc -l
 
       - name: ccache log
@@ -66,7 +66,7 @@ jobs:
 
       - name: inspect ccache 3
         run: |
-          find ~/.ccache | grep 8/f/64 || true
+          find ~/.ccache | grep 8/2/aeeb3d || true
           find ~/.ccache | wc -l
 
       - name: ccache log

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -40,16 +40,17 @@ jobs:
           path: .tox-cache
           key: focal-tox
 
+      - name: inspect ccache 1
+        run: |
+          find ~/.ccache | grep 8/f/64
+
       - name: Build
         run: |
           ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
 
-      - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v2
-        with:
-          name: ccache-log.txt
-          path: /github/home/ccache.log
-          retention-days: 5
+      - name: inspect ccache 2
+        run: |
+          find ~/.ccache | grep 8/f/64
 
       - name: ccache log
         run: |
@@ -59,6 +60,10 @@ jobs:
       - name: Build 2nd time
         run: |
           ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
+
+      - name: inspect ccache 3
+        run: |
+          find ~/.ccache | grep 8/f/64
 
       - name: ccache log
         run: |

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -113,7 +113,7 @@ jobs:
           CFLAGS: -m32
         run: |
           ccache -z --max-size=500M
-          ccache -p
+          # ccache too old for --show-config
           mkdir build
           cd build
           cmake -GNinja -DWITH_DOCUMENTATION=NO -DENABLE_CCACHE=YES ..

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -41,10 +41,6 @@ jobs:
           path: .tox-cache
           key: focal-tox
 
-      - name: inspect ccache 1
-        run: |
-          find ~/.ccache | grep 8/f/64 || true
-
       - name: Build
         run: |
           ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
@@ -112,9 +108,17 @@ jobs:
         run: |
           ci/build.py --flake8
 
+      - name: inspect ccache 1
+        run: |
+          find ~/.ccache | grep 8/f/64 || true
+
       - name: Build
         run: |
           ci/build.py --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
+
+      - name: inspect ccache 2
+        run: |
+          find ~/.ccache | grep 8/f/64 || true
 
       - name: ccache log
         run: |
@@ -124,6 +128,10 @@ jobs:
       - name: Build 2nd time
         run: |
           ci/build.py --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
+
+      - name: inspect ccache 3
+        run: |
+          find ~/.ccache | grep 8/f/64 || true
 
       - name: ccache log
         run: |

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -43,6 +43,10 @@ jobs:
         run: |
           ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
 
+      - name: Build 2nd time
+        run: |
+          ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
+
       - name: Test
         run: |
           ci/build.py --run-tests
@@ -84,6 +88,10 @@ jobs:
           ci/build.py --flake8
 
       - name: Build
+        run: |
+          ci/build.py --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
+
+      - name: Build 2nd time
         run: |
           ci/build.py --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
 

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -113,6 +113,7 @@ jobs:
           CFLAGS: -m32
         run: |
           ccache -z --max-size=500M
+          ccache -p
           mkdir build
           cd build
           cmake -GNinja -DWITH_DOCUMENTATION=NO -DENABLE_CCACHE=YES ..

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       HLWM_BUILDDIR: build
       CCACHE_LOGFILE: /github/home/ccache.log
+      CCACHE_NOHASHDIR: 1
 
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
@@ -42,7 +43,7 @@ jobs:
 
       - name: inspect ccache 1
         run: |
-          find ~/.ccache | grep 8/f/64
+          find ~/.ccache | grep 8/f/64 || true
 
       - name: Build
         run: |
@@ -50,7 +51,7 @@ jobs:
 
       - name: inspect ccache 2
         run: |
-          find ~/.ccache | grep 8/f/64
+          find ~/.ccache | grep 8/f/64 || true
 
       - name: ccache log
         run: |
@@ -63,7 +64,7 @@ jobs:
 
       - name: inspect ccache 3
         run: |
-          find ~/.ccache | grep 8/f/64
+          find ~/.ccache | grep 8/f/64 || true
 
       - name: ccache log
         run: |

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -44,6 +44,13 @@ jobs:
         run: |
           ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile
 
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          name: ccache-log.txt
+          path: /github/home/ccache.log
+          retention-days: 5
+
       - name: ccache log
         run: |
           cat "$CCACHE_LOGFILE"

--- a/ci/build.py
+++ b/ci/build.py
@@ -50,7 +50,10 @@ if args.ccache:
     if conf.exists():
         conf.unlink()
 
-    # Set a reasonable size limit, and compare compiler based on content, not mtime
+    # Set a reasonable size limit, and compare compiler based on content, not mtime.
+    # Hash-verifying the compiler is required when building with
+    # clang-and-tidy.sh (because the script's mtime is not stable) and for
+    # other cases, the overhead is minimal):
     sp.check_call('ccache --max-size=500M -o compiler_check=content', shell=True)
 
     # Wipe stats before build
@@ -66,11 +69,6 @@ if args.cmake:
         'CXX': args.cxx,
         'CFLAGS': '--coverage -Werror -fsanitize=address,leak,undefined',
         'CXXFLAGS': '--coverage -Werror -fsanitize=address,leak,undefined',
-
-        # Hash-verifying the compiler is required when building with
-        # clang-and-tidy.sh (because the script's mtime is not stable) and for
-        # other cases, the overhead is minimal):
-        'CCACHE_COMPILERCHECK': 'content',
 
         # In case clang-and-tidy.sh is used for building, it will need this to call
         # clang-tidy:

--- a/ci/build.py
+++ b/ci/build.py
@@ -54,7 +54,7 @@ if args.ccache:
     # Hash-verifying the compiler is required when building with
     # clang-and-tidy.sh (because the script's mtime is not stable) and for
     # other cases, the overhead is minimal):
-    sp.check_call('ccache --max-size=500M -o compiler_check=content -o sloppiness=include_file_mtime,include_file_ctime', shell=True)
+    sp.check_call('ccache --max-size=500M -o compiler_check=content -o sloppiness=file_macro,locale,time_macros,include_file_mtime,include_file_ctime', shell=True)
 
     # Wipe stats before build
     sp.check_call('ccache -z', shell=True)

--- a/ci/build.py
+++ b/ci/build.py
@@ -86,6 +86,7 @@ if args.cmake:
     sp.check_call(['cmake', *cmake_args, repo], cwd=build_dir, env=build_env)
 
 if args.compile:
+    sp.check_call(['bash', '-c', 'time ninja -t clean'], cwd=build_dir, env=build_env)
     sp.check_call(['bash', '-c', 'time ninja -v -k 10'], cwd=build_dir, env=build_env)
 
 if args.ccache:

--- a/ci/build.py
+++ b/ci/build.py
@@ -54,7 +54,7 @@ if args.ccache:
     # Hash-verifying the compiler is required when building with
     # clang-and-tidy.sh (because the script's mtime is not stable) and for
     # other cases, the overhead is minimal):
-    sp.check_call('ccache --max-size=500M -o compiler_check=content', shell=True)
+    sp.check_call('ccache --max-size=500M -o compiler_check=content -o sloppiness=include_file_mtime,include_file_ctime', shell=True)
 
     # Wipe stats before build
     sp.check_call('ccache -z', shell=True)

--- a/ci/build.py
+++ b/ci/build.py
@@ -54,7 +54,7 @@ if args.ccache:
     # Hash-verifying the compiler is required when building with
     # clang-and-tidy.sh (because the script's mtime is not stable) and for
     # other cases, the overhead is minimal):
-    sp.check_call('ccache --max-size=500M -o compiler_check=content -o sloppiness=file_macro,locale,time_macros,include_file_mtime,include_file_ctime', shell=True)
+    sp.check_call('ccache --max-size=800M -o compiler_check=content -o sloppiness=file_macro,locale,time_macros,include_file_mtime,include_file_ctime -o hash_dir=false', shell=True)
 
     # Wipe stats before build
     sp.check_call('ccache -z', shell=True)

--- a/ci/build.py
+++ b/ci/build.py
@@ -50,10 +50,11 @@ if args.ccache:
     if conf.exists():
         conf.unlink()
 
-    # Set a reasonable size limit, and compare compiler based on content, not mtime.
+    # Set a reasonable size limit.
+    #
     # Hash-verifying the compiler is required when building with
     # clang-and-tidy.sh (because the script's mtime is not stable) and for
-    # other cases, the overhead is minimal):
+    # other cases, the overhead is minimal)
     sp.check_call('ccache --max-size=800M -o compiler_check=content -o sloppiness=file_macro,locale,time_macros,include_file_mtime,include_file_ctime -o hash_dir=false', shell=True)
 
     # Wipe stats before build

--- a/ci/build.py
+++ b/ci/build.py
@@ -49,8 +49,8 @@ if args.ccache:
     if conf.exists():
         conf.unlink()
 
-    # Set a reasonable size limit
-    sp.check_call('ccache --max-size=500M', shell=True)
+    # Set a reasonable size limit, and compare compiler based on content, not mtime
+    sp.check_call('ccache --max-size=500M -o compiler_check=content', shell=True)
 
     # Wipe stats before build
     sp.check_call('ccache -z', shell=True)


### PR DESCRIPTION
The ccache in the ci has a lot of cache misses. Maybe this comes from
the mtime of the compiler being different on each CI run. This now
compares the actualy compiler binary instead of the compiler's mtime.
Hopefully, this improves the cache hit rate.