### PR TITLE
Print parse errors for apply rule commands

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@ Current git version
   * New child object 'focused_frame' for the tiling object of each tag object.
   * New command 'mirror'
   * New command 'apply_tmp_rule'
+  * The 'apply_rules' command now reports parse errors
   * Bug fixes:
     - When hiding windows, correctly set their WM_STATE to IconicState (we set
       it to Withdrawn state before, which means "unmanaged" and thus is wrong).

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -2,6 +2,7 @@
 
 #include <X11/Xlib.h>
 #include <algorithm>
+#include <iostream>
 #include <string>
 
 #include "attribute.h"
@@ -158,7 +159,7 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
     if (additionalRules) {
         additionalRules(changes);
     }
-    changes = Root::get()->rules()->evaluateRules(client, changes);
+    changes = Root::get()->rules()->evaluateRules(client, std::cerr, changes);
     if (!changes.manage || force_unmanage) {
         // map it... just to be sure
         XMapWindow(g_display, win);
@@ -343,7 +344,7 @@ int ClientManager::applyRules(Client* client, Output output, bool changeFocus)
 {
     ClientChanges changes;
     changes.focus = client == focus();
-    changes = Root::get()->rules()->evaluateRules(client, changes);
+    changes = Root::get()->rules()->evaluateRules(client, output, changes);
     if (!changeFocus) {
         changes.focus = false;
     }
@@ -445,7 +446,7 @@ int ClientManager::applyTmpRuleCmd(Input input, Output output)
         Client* client = it.second;
         ClientChanges changes;
         changes.focus = client == focus();
-        rule.evaluate(client, changes);
+        rule.evaluate(client, changes, output);
         if (applyTo->size() > 1) {
             // if we apply the rule to more than one
             // client, then we leave the focus where it was

--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -230,12 +230,12 @@ void RuleManager::addRuleCompletion(Completion& complete) {
 
 
 //! Evaluate rules against a given client
-ClientChanges RuleManager::evaluateRules(Client* client, ClientChanges changes) {
+ClientChanges RuleManager::evaluateRules(Client* client, Output output, ClientChanges changes) {
     // go through all rules and remove those that expired.
     // Here, we use erase + remove_if because it uses a Forward Iterator
     // and so it is ensured that the rules are evaluated in the correct order.
     auto forEachRule = [&](unique_ptr<Rule>& rule) {
-        rule->evaluate(client, changes);
+        rule->evaluate(client, changes, output);
         return rule->expired();
     };
     rules_.erase(std::remove_if(rules_.begin(), rules_.end(), forEachRule),

--- a/src/rulemanager.h
+++ b/src/rulemanager.h
@@ -13,7 +13,7 @@ public:
     int unruleCommand(Input input, Output output);
     void unruleCompletion(Completion& complete);
     int listRulesCommand(Output output);
-    ClientChanges evaluateRules(Client* client, ClientChanges changes = {});
+    ClientChanges evaluateRules(Client* client, Output output, ClientChanges changes = {});
     static int parseRule(Input input, Output output, Rule& rule, bool& prepend);
 
 private:

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -5,7 +5,6 @@
 
 #include "client.h"
 #include "ewmh.h"
-#include "globals.h"
 #include "hook.h"
 #include "root.h"
 #include "utils.h"
@@ -147,7 +146,7 @@ Rule::Rule() {
  * @param the resulting changes
  * @return whether the rule matched.
  */
-bool Rule::evaluate(Client* client, ClientChanges& changes)
+bool Rule::evaluate(Client* client, ClientChanges& changes, Output output)
 {
     bool rule_match = true; // if entire rule matches
 
@@ -180,10 +179,9 @@ bool Rule::evaluate(Client* client, ClientChanges& changes)
             try {
                 Consequence::appliers.at(cons.name)(&cons, client, &changes);
             } catch (std::exception& e) {
-                HSWarning("Invalid argument \"%s\" for rule consequence \"%s\": %s\n",
-                  cons.value.c_str(),
-                  cons.name.c_str(),
-                  e.what());
+                output << "Invalid argument \"" << cons.value
+                       << "\" for rule consequence \"" << cons.name << "\": "
+                       << e.what() << "\n";
             }
         }
     }

--- a/src/rules.h
+++ b/src/rules.h
@@ -137,7 +137,7 @@ public:
     bool expired() {
         return expired_;
     };
-    bool evaluate(Client* client, ClientChanges& changes);
+    bool evaluate(Client* client, ClientChanges& changes, Output output);
 
     std::string label;
     std::vector<Condition> conditions;


### PR DESCRIPTION
The commands apply_tmp_rule and apply_rules now print parser error
messages to their output which is forwarded to the invoking
herbstclient. This makes debugging rules easier.

However, on new clients, the error message is still printed to
herbstluftwm's stderr.