### PR TITLE
Make cache names unique

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -33,7 +33,9 @@ jobs:
         name: Cache ~/.ccache
         with:
           path: ~/.ccache
-          key: focal-ccache
+          key: focal-gcc-ccache-${{ github.run_number }}
+          restore-keys: |
+            focal-gcc-ccache-
 
       - uses: actions/cache@v1
         name: Cache .tox-cache
@@ -84,7 +86,9 @@ jobs:
         name: Cache ~/.ccache
         with:
           path: ~/.ccache
-          key: focal-clang-ccache # different name than in build-test-current
+          key: focal-clang-ccache-${{ github.run_number }}
+          restore-keys: |
+            focal-clang-ccache-
 
       - uses: actions/cache@v1
         name: Cache .tox-cache
@@ -134,7 +138,9 @@ jobs:
         name: Cache ~/.ccache
         with:
           path: ~/.ccache
-          key: ccache-gcc-4.8 # different name than in build-test-current
+          key: ccache-gcc-ancient-${{ github.run_number }}
+          restore-keys: |
+            ccache-gcc-ancient-
 
       - name: Build
         env:

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           path: ~/.ccache
           key: focal-gcc-ccache-${{ github.run_number }}
+          # since the every new gha run gets a new key, we need to search
+          # for existing cache entries more sloppily:
           restore-keys: |
             focal-gcc-ccache-
 


### PR DESCRIPTION
Cache entries are never updated, so we need to change the cache keys
every time in order to update the entries.