### PR TITLE
Add test cases for the 'shift' command

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -757,6 +757,9 @@ int frame_move_window_command(int argc, char** argv, Output output) {
 
             // layout was changed, so update it
             get_current_monitor()->applyLayout();
+        } else if (!client) {
+            output << argv[0] << ": No client focused\n";
+            return HERBST_FORBIDDEN;
         } else {
             output << argv[0] << ": No neighbour found\n";
             return HERBST_FORBIDDEN;


### PR DESCRIPTION
This adds tests for the functionality of the 'shift' command and also
clarifies the error message if no client is focused (the message was "No
neighbour found" before).