### PR TITLE
Only build json doc on WITH_DOCUMENTATION

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -158,6 +158,6 @@ jobs:
           cd build
           cmake -GNinja -DWITH_DOCUMENTATION=NO -DENABLE_CCACHE=YES ..
           ninja -v -k10
-          ninja -v doc_json
+          ninja -v -t doc_json
           ccache -s
           find ~/.ccache | wc -l

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -158,6 +158,6 @@ jobs:
           cd build
           cmake -GNinja -DWITH_DOCUMENTATION=NO -DENABLE_CCACHE=YES ..
           ninja -v -k10
-          ninja -v -t doc_json
+          ninja -v doc_json
           ccache -s
           find ~/.ccache | wc -l

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -158,5 +158,6 @@ jobs:
           cd build
           cmake -GNinja -DWITH_DOCUMENTATION=NO -DENABLE_CCACHE=YES ..
           ninja -v -k10
+          ninja -v doc_json
           ccache -s
           find ~/.ccache | wc -l

--- a/INSTALL
+++ b/INSTALL
@@ -55,8 +55,10 @@ variables which you can set on the initial cmake call and alter with ccmake:
     CMAKE_INSTALL_SYSCONF_PREFIX = $(DESTDIR)/etc/  # path to etc directory
 
 Individual paths for special files can be set with the *DIR variables, typically
-relative to CMAKE_INSTALL_PREFIX. If you are building package, you would
-typically build regularly, and install with DESTDIR=./path/to/fakeroot.
+relative to CMAKE_INSTALL_PREFIX. If you are building a package, you would
+typically build regularly, and install with DESTDIR=./path/to/fakeroot. If you
+are building from a source tarball, you can disable WITH_DOCUMENTATION because
+the built documentation is already contained in the tarball.
 
     mkdir build && cd build
     cmake ..

--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,7 @@ Current git version
   * New command 'mirror'
   * New command 'apply_tmp_rule'
   * The 'apply_rules' command now reports parse errors
+  * Only build json object doc if WITH_DOCUMENTATION is activated
   * Bug fixes:
     - When hiding windows, correctly set their WM_STATE to IconicState (we set
       it to Withdrawn state before, which means "unmanaged" and thus is wrong).

--- a/ci/build.py
+++ b/ci/build.py
@@ -134,7 +134,7 @@ if args.flake8:
 
 if args.run_tests:
     # make sure, json doc exists
-    sp.check_call(['bash', '-c', 'time ninja -t doc_json'], cwd=build_dir, env=build_env)
+    sp.check_call(['bash', '-c', 'time ninja -t doc_json'], cwd=build_dir)
 
     # Suppress warnings about known memory leaks:
     os.environ['LSAN_OPTIONS'] = f"suppressions={repo}/ci/lsan-suppressions.txt"

--- a/ci/build.py
+++ b/ci/build.py
@@ -134,7 +134,7 @@ if args.flake8:
 
 if args.run_tests:
     # make sure, json doc exists
-    sp.check_call(['bash', '-c', 'time ninja -t doc_json'], cwd=build_dir)
+    sp.check_call(['bash', '-c', 'time ninja doc_json'], cwd=build_dir)
 
     # Suppress warnings about known memory leaks:
     os.environ['LSAN_OPTIONS'] = f"suppressions={repo}/ci/lsan-suppressions.txt"

--- a/ci/build.py
+++ b/ci/build.py
@@ -133,6 +133,9 @@ if args.flake8:
     tox('-e flake8', build_dir)
 
 if args.run_tests:
+    # make sure, json doc exists
+    sp.check_call(['bash', '-c', 'time ninja -t doc_json'], cwd=build_dir, env=build_env)
+
     # Suppress warnings about known memory leaks:
     os.environ['LSAN_OPTIONS'] = f"suppressions={repo}/ci/lsan-suppressions.txt"
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -3,7 +3,7 @@ option(WITH_DOCUMENTATION "Build with documentation" ON)
 function(gen_json_doc destfile)
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${destfile}.json")
     AUX_SOURCE_DIRECTORY("${CMAKE_CURRENT_SOURCE_DIR}/../src" CPPSRC)
-    add_custom_target("doc_json" ALL DEPENDS ${dst})
+    add_custom_target("doc_json" DEPENDS ${dst})
     add_custom_command(
         OUTPUT ${dst}
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py" --sourcedir "${CMAKE_CURRENT_SOURCE_DIR}/../src" --json > ${dst}
@@ -61,7 +61,12 @@ if (WITH_DOCUMENTATION)
     gen_html(herbstluftwm)
     gen_html(herbstluftwm-tutorial)
 
-    gen_json_doc(hlwm-doc)
+    # mark the doc_json target as mandatory
+    add_custom_target("doc_json_mandatory" ALL DEPENDS "doc_json")
 endif()
+
+# always create a doc_json target, but only make it mandatory
+# if WITH_DOCUMENTATION is set
+gen_json_doc(hlwm-doc)
 
 # vim: et:ts=4:sw=4

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -9,7 +9,7 @@ function(gen_json_doc destfile)
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py" --sourcedir "${CMAKE_CURRENT_SOURCE_DIR}/../src" --json > ${dst}
         DEPENDS ${CPPSRC} "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py"
         )
-    install(FILES ${dst} DESTINATION ${DOCDIR})
+    install(FILES ${dst} DESTINATION ${DOCDIR} OPTIONAL)
 endfunction()
 
 function(gen_manpage sourcefile man_nr)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -49,8 +49,6 @@ function(gen_html sourcefile)
     install(FILES ${dst} DESTINATION ${DOCDIR})
 endfunction()
 
-gen_json_doc(hlwm-doc)
-
 if (WITH_DOCUMENTATION)
     find_program(ASCIIDOC_A2X NAMES a2x DOC "Path to AsciiDoc a2x command")
     find_program(ASCIIDOC NAMES asciidoc DOC "Path to AsciiDoc command")
@@ -62,6 +60,8 @@ if (WITH_DOCUMENTATION)
     gen_html(herbstclient)
     gen_html(herbstluftwm)
     gen_html(herbstluftwm-tutorial)
+
+    gen_json_doc(hlwm-doc)
 endif()
 
 # vim: et:ts=4:sw=4


### PR DESCRIPTION
Since tarballs contain the json doc anyway treat the json doc as the
other man pages and only build them if WITH_DOCUMENTATION is activated.
This avoids python as a build dependency for the tarballs.

If WITH_DOCUMENTATION is not set, then we still create an optional make
target which is called in the CI.

Also this marks the installation of the json doc optional, meaning that
it is installed if it has been generated.
