### PR TITLE
Reserve space for panels without _NET_WM_STRUT

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ Current git version
   * New command 'mirror'
   * New command 'apply_tmp_rule'
   * The 'apply_rules' command now reports parse errors
+  * Reserve space for panels that do not set _NET_WM_STRUT e.g. conky windows
+    of type 'dock'.
   * Bug fixes:
     - When hiding windows, correctly set their WM_STATE to IconicState (we set
       it to Withdrawn state before, which means "unmanaged" and thus is wrong).

--- a/src/panelmanager.h
+++ b/src/panelmanager.h
@@ -37,13 +37,14 @@ public:
     void registerPanel(Window win);
     void unregisterPanel(Window win);
     void propertyChanged(Window win, Atom property);
+    void geometryChanged(Window win, Rectangle size);
     void injectDependencies(Settings* settings);
     ReservedSpace computeReservedSpace(Rectangle monitorDimension);
     Signal panels_changed_;
     void rootWindowChanged(int width, int height);
 private:
     friend Panel;
-    bool updateReservedSpace(Panel* p);
+    bool updateReservedSpace(Panel* p, Rectangle geometry);
 
     std::unordered_map<Window, Panel*> panels_;
     Atom atomWmStrut_;

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -98,6 +98,7 @@ struct Rectangle {
 
     bool operator<(const Rectangle& other) const;
     bool operator==(const Rectangle& other) const;
+    bool operator!=(const Rectangle& other) const { return !(this->operator==(other));}
 
     operator bool() const;
 

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -338,6 +338,9 @@ void XMainLoop::configurenotify(XConfigureEvent* event) {
             std::ostringstream void_output;
             root_->monitors->detectMonitorsCommand(input, void_output);
         }
+    } else {
+        Rectangle geometry = { event->x, event->y, event->width, event->height };
+        root_->panels->geometryChanged(event->window, geometry);
     }
     // HSDebug("name is: ConfigureNotify\n");
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -641,6 +641,7 @@ def x11(x11_connection):
                           wm_class=None,
                           window_type=None,
                           transient_for=None,
+                          pre_map=lambda wh: None,  # called before the window is mapped
                           ):
             w = self.root.create_window(
                 geometry[0],
@@ -679,6 +680,7 @@ def x11(x11_connection):
                                   32,
                                   [pid])
 
+            pre_map(w)
             w.map()
             self.display.sync()
             if sync_hlwm:

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -1,0 +1,65 @@
+import pytest
+from Xlib import Xatom
+
+
+@pytest.mark.parametrize("which_pad, pad_size, geometry", [
+    ("pad_left", 10, (-1, 0, 11, 400)),
+    ("pad_right", 20, (800 - 20, 23, 20, 400)),
+    ("pad_up", 40, (-5, 0, 805, 40)),
+    ("pad_down", 15, (4, 600 - 15, 200, 40)),
+    # cases where no pad is applied because the width/height ratio is ambiguous:
+    ("pad_left", 0, (0, 0, 40, 40)),
+    ("pad_down", 0, (800 - 40, 600 - 40, 40, 40)),
+])
+def test_panel_based_on_intersection(hlwm, x11, which_pad, pad_size, geometry):
+    # monitor 0 is affected by the panel, but the other monitor is not
+    hlwm.call('add othertag')
+    hlwm.call('set_monitors 800x600+0+0 800x600+800+0')
+    winhandle, _ = x11.create_client(geometry=geometry,
+                                     window_type='_NET_WM_WINDOW_TYPE_DOCK')
+
+    assert int(hlwm.attr.monitors[0][which_pad]()) == pad_size
+    for p in ["pad_left", "pad_right", "pad_up", "pad_down"]:
+        assert hlwm.attr.monitors[1][p]() == '0', \
+            "monitor 1 must never be affected"
+        if p == which_pad:
+            continue
+        assert hlwm.attr.monitors[0][p]() == '0'
+
+
+@pytest.mark.parametrize("which_pad, pad_size, geometry, wm_strut", [
+    ("pad_left", 20, (-1, 0, 21, 4), [20, 0, 0, 0]),
+    ("pad_right", 30, (800 - 30, -2, 40, 11), [0, 20, 0, 0]),
+    ("pad_up", 40, (0, 0, 30, 40), [0, 0, 40, 0]),
+    ("pad_down", 15, (80, 600 - 15, 2, 15), [0, 0, 0, 15]),
+])
+@pytest.mark.parametrize("strut_before_map", [True, False])
+def test_panel_based_on_wmstrut(hlwm, x11, which_pad, pad_size, geometry, wm_strut, strut_before_map):
+    # monitor 0 is affected by the panel, but the other monitor is not
+    hlwm.call('add othertag')
+    hlwm.call('set_monitors 800x600+0+0 800x600+800+0')
+
+    def set_wm_strut(winhandle):
+        xproperty = x11.display.intern_atom('_NET_WM_STRUT')
+        winhandle.change_property(xproperty, Xatom.CARDINAL, 32, wm_strut)
+
+    def noop(winhandle):
+        pass
+
+    winhandle, _ = x11.create_client(geometry=geometry,
+                                     window_type='_NET_WM_WINDOW_TYPE_DOCK',
+                                     pre_map=set_wm_strut if strut_before_map else noop,
+                                     )
+    if not strut_before_map:
+        set_wm_strut(winhandle)
+        # sync hlwm and x11
+        x11.display.sync()
+        hlwm.call('true')
+
+    assert int(hlwm.attr.monitors[0][which_pad]()) == pad_size
+    for p in ["pad_left", "pad_right", "pad_up", "pad_down"]:
+        assert hlwm.attr.monitors[1][p]() == '0', \
+            "monitor 1 must never be affected"
+        if p == which_pad:
+            continue
+        assert hlwm.attr.monitors[0][p]() == '0'


### PR DESCRIPTION
If a panel window has the type _NET_WM_WINDOW_TYPE_DOCK but does not
define in _NET_WM_STRUT from which borders of the screen it takes space,
then automatically detect it based on the window's geometry.

This also adds tests for the new functionality and also for the old
panel detection based on _NET_WM_STRUT