### PR TITLE
Document inheritance in json doc

### DIFF
--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -557,6 +557,8 @@ class ObjectInformation:
                 'classname': clsname,
                 'children': ObjectInformation.sorted_dict(children),
                 'attributes': ObjectInformation.sorted_dict(attributes),
+                # list the superclasses of clsname that are objects themselves:
+                'inherits-from': [s for s in supers if 'Object' in superclasses[s] and s != 'Object'],
             }
         return {'objects': ObjectInformation.sorted_dict(result)}  # only generate object doc so far
 


### PR DESCRIPTION
The class inheritance is relevant for the json doc, because the
FrameTree has children of type `Frame`, and a `Frame` can be a
`FrameSplit` or a `FrameLeaf`.

I have no explicit test for this, but of course the test suite already
tests for the existence of the inherited attributes.