### PR TITLE
Create new Floating namespace in floating.h

### DIFF
--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -64,7 +64,7 @@ static void rectlist_rotate(RectangleIdxVec& rects, int& idx, Direction dir) {
 
 //! fuzzily find a rectangle in the specified direction
 //! returns the found index in the original buffer
-int find_rectangle_in_direction(RectangleIdxVec& rects, int idx, Direction dir) {
+int Floating::find_rectangle_in_direction(RectangleIdxVec& rects, int idx, Direction dir) {
     rectlist_rotate(rects, idx, dir);
     return find_rectangle_right_of(rects, idx);
 }
@@ -101,7 +101,7 @@ static bool rectangle_is_right_of(Rectangle RC, Rectangle R2) {
     return true;
 }
 
-int find_rectangle_right_of(RectangleIdxVec rects, int idx) {
+int Floating::find_rectangle_right_of(RectangleIdxVec rects, int idx) {
     auto RC = rects[idx].second;
     int cx = RC.x + RC.width / 2;
     int cy = RC.y + RC.height / 2;
@@ -157,7 +157,7 @@ int find_rectangle_right_of(RectangleIdxVec rects, int idx) {
 }
 
 // returns the found index in the modified buffer
-int find_edge_in_direction(RectangleIdxVec& rects, int idx, Direction dir)
+int Floating::find_edge_in_direction(RectangleIdxVec& rects, int idx, Direction dir)
 {
     rectlist_rotate(rects, idx, dir);
     int found = find_edge_right_of(rects, idx);
@@ -177,7 +177,8 @@ int find_edge_in_direction(RectangleIdxVec& rects, int idx, Direction dir)
     rectlist_rotate(rects, found, dir);
     return found;
 }
-int find_edge_right_of(RectangleIdxVec rects, int idx) {
+
+int Floating::find_edge_right_of(RectangleIdxVec rects, int idx) {
     int xbound = rects[idx].second.x + rects[idx].second.width;
     int ylow = rects[idx].second.y;
     int yhigh = rects[idx].second.y + rects[idx].second.height;
@@ -212,7 +213,7 @@ int find_edge_right_of(RectangleIdxVec rects, int idx) {
 }
 
 
-bool floating_focus_direction(Direction dir) {
+bool Floating::focusDirection(Direction dir) {
     if (g_settings->monitors_locked()) { return false; }
     HSTag* tag = get_current_monitor()->tag;
     vector<Client*> clients;
@@ -245,7 +246,7 @@ bool floating_focus_direction(Direction dir) {
 //! when moving the given client on tag in the specified direction
 //! report the vector to travel until the collision happens. If curfocusrect
 //! is provided, use this as the geometry of 'curfocus'
-Point2D find_rectangle_collision_on_tag(HSTag* tag, Client* curfocus, Direction dir, Rectangle curfocusrect = {0,0,-1,-1}) {
+Point2D Floating::find_rectangle_collision_on_tag(HSTag* tag, Client* curfocus, Direction dir, Rectangle curfocusrect) {
     vector<Client*> clients;
     auto focusrect = curfocusrect
                 ? curfocusrect
@@ -313,7 +314,7 @@ Point2D find_rectangle_collision_on_tag(HSTag* tag, Client* curfocus, Direction 
     return {dx, dy};
 }
 
-bool floating_shift_direction(Direction dir) {
+bool Floating::shiftDirection(Direction dir) {
     if (g_settings->monitors_locked()) { return false; }
     HSTag* tag = get_current_monitor()->tag;
     Client* curfocus = tag->focusedClient();
@@ -359,7 +360,7 @@ static bool resize_by_delta(Client* client, Direction dir, int delta) {
     return true;
 }
 
-static bool grow_into_direction(HSTag* tag, Client* client, Direction dir) {
+bool Floating::grow_into_direction(HSTag* tag, Client* client, Direction dir) {
     Point2D delta = find_rectangle_collision_on_tag(tag, client, dir);
     if (delta == Point2D{0, 0}) {
         return false;
@@ -385,7 +386,7 @@ static bool grow_into_direction(HSTag* tag, Client* client, Direction dir) {
     return true;
 }
 
-static bool shrink_into_direction(Client* client, Direction dir) {
+bool Floating::shrink_into_direction(Client* client, Direction dir) {
     int delta_width = client->float_size_.width / -2;
     int delta_height = client->float_size_.height / -2;
     switch (dir) {
@@ -415,7 +416,7 @@ static bool shrink_into_direction(Client* client, Direction dir) {
     return false;
 }
 
-bool floating_resize_direction(HSTag* tag, Client* client, Direction dir)
+bool Floating::resizeDirection(HSTag* tag, Client* client, Direction dir)
 {
     if (g_settings->monitors_locked()) {
         return false;
@@ -442,7 +443,7 @@ bool floating_resize_direction(HSTag* tag, Client* client, Direction dir)
  * @param whether to consider only floating windows on 'tag' for the placement
  * @return the suggested position
  */
-Point2D floatingSmartPlacement(HSTag* tag, Client* client, Point2D area, int gap)
+Point2D Floating::smartPlacement(HSTag* tag, Client* client, Point2D area, int gap)
 {
     bool tagFloating = tag->floating();
     Rectangle clientOuter = client->outer_floating_rect();

--- a/src/floating.h
+++ b/src/floating.h
@@ -7,18 +7,29 @@
 class Client;
 class HSTag;
 
-// utilities
-int char_to_direction(char ch);
-int find_rectangle_in_direction(RectangleIdxVec& rects, int idx, Direction dir);
-int find_rectangle_right_of(RectangleIdxVec rects, int idx);
-int find_edge_in_direction(RectangleIdxVec& rects, int idx, Direction dir);
-int find_edge_right_of(RectangleIdxVec rects, int idx);
+/**
+ * @brief The Floating class collects algorithms related to
+ * the geometry of floating windows
+ */
+class Floating {
+public:
+    // utilities
+    static int find_rectangle_in_direction(RectangleIdxVec& rects, int idx, Direction dir);
+    static int find_rectangle_right_of(RectangleIdxVec rects, int idx);
+    static int find_edge_in_direction(RectangleIdxVec& rects, int idx, Direction dir);
+    static int find_edge_right_of(RectangleIdxVec rects, int idx);
 
-// actual implementations
-bool floating_focus_direction(Direction dir);
-bool floating_shift_direction(Direction dir);
-bool floating_resize_direction(HSTag* tag, Client* client, Direction dir);
+    // actual implementations
+    static bool focusDirection(Direction dir);
+    static bool shiftDirection(Direction dir);
+    static bool resizeDirection(HSTag* tag, Client* client, Direction dir);
 
-Point2D floatingSmartPlacement(HSTag* tag, Client* client, Point2D area, int gap);
+    static Point2D smartPlacement(HSTag* tag, Client* client, Point2D area, int gap);
+
+private:
+    static Point2D find_rectangle_collision_on_tag(HSTag* tag, Client* curfocus, Direction dir, Rectangle curfocusrect = {0,0,-1,-1});
+    static bool grow_into_direction(HSTag* tag, Client* client, Direction dir);
+    static bool shrink_into_direction(Client* client, Direction dir);
+};
 
 #endif

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -757,7 +757,7 @@ void Monitor::evaluateClientPlacement(Client* client, ClientPlacement placement)
         case ClientPlacement::Smart:
             {
                 Point2D area = getFloatingArea().dimensions();
-                Point2D new_tl = floatingSmartPlacement(tag, client,
+                Point2D new_tl = Floating::smartPlacement(tag, client,
                                              area, settings->snap_gap);
                 client->float_size_.x = new_tl.x;
                 client->float_size_.y = new_tl.y;

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -89,7 +89,7 @@ int MonitorManager::indexInDirection(Monitor* relativeTo, Direction dir) {
     for (Monitor* mon : *this) {
         rects.push_back(make_pair(mon->index(), mon->rect));
     }
-    int result = find_rectangle_in_direction(rects, int(relativeTo->index), dir);
+    int result = Floating::find_rectangle_in_direction(rects, int(relativeTo->index), dir);
     return result;
 }
 

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -289,7 +289,7 @@ int HSTag::focusInDirCommand(Input input, Output output)
     auto focusedFrame = frame->focusedFrame();
     bool neighbour_found = true;
     if (floating || floating_focused) {
-        neighbour_found = floating_focus_direction(direction);
+        neighbour_found = Floating::focusDirection(direction);
     } else {
         neighbour_found = frame->focusInDirection(direction, external_only);
         if (neighbour_found) {
@@ -342,7 +342,7 @@ int HSTag::shiftInDirCommand(Input input, Output output)
     Client* currentClient = focusedClient();
     if (currentClient && currentClient->is_client_floated()) {
         // try to move the floating window
-        bool success = floating_shift_direction(direction);
+        bool success = Floating::shiftDirection(direction);
         return success ? 0 : HERBST_FORBIDDEN;
     }
     // don't look for neighbours within the frame if 'external_only' is set
@@ -475,7 +475,7 @@ int HSTag::resizeCommand(Input input, Output output)
     }
     Client* client = focusedClient();
     if (client && client->is_client_floated()) {
-        if (!floating_resize_direction(this, client, direction)) {
+        if (!Floating::resizeDirection(this, client, direction)) {
             // no error message because this shouldn't happen anyway
             return HERBST_FORBIDDEN;
         }


### PR DESCRIPTION
This moves all floating functions into a common namespace called
Floating. If the function had a prefix floating_ then I already
converted the name to camelCase, otherwise I left the name as it was.

The namespace Floating is implemented as a class with static functions
because in the future, these may become non-static by using member
variables of the Floating class instead of the global hlwm state (as it
is now when calling get_current_monitor() or focus_client()).

This also removes the orphaned declaration char_to_direction().