### PR TITLE
Make tag.*.tiling.focused_frame a FrameLeaf

### DIFF
--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -383,7 +383,7 @@ shared_ptr<FrameLeaf> FrameTree::findEmptyFrameNearFocusGeometrically(shared_ptr
     return closestFrame;
 }
 
-Frame* FrameTree::focusedFramePlainPtr()
+FrameLeaf* FrameTree::focusedFramePlainPtr()
 {
     auto shared = focusedFrame();
     if (shared) {

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -82,12 +82,12 @@ public:
 public: // soon to be come private:
     std::shared_ptr<Frame> root_;
     Link_<Frame> rootLink_;
-    DynChild_<Frame> focused_frame_;
+    DynChild_<FrameLeaf> focused_frame_;
     //! replace a node in the frame tree, either modifying old's parent or the root_
     void replaceNode(std::shared_ptr<Frame> old, std::shared_ptr<Frame> replacement);
 private:
     static std::shared_ptr<FrameLeaf> findEmptyFrameNearFocusGeometrically(std::shared_ptr<Frame> subtree);
-    Frame* focusedFramePlainPtr();
+    FrameLeaf* focusedFramePlainPtr();
     //! cycle the frames within the current tree
     void cycle_frame(std::function<size_t(size_t,size_t)> indexAndLenToIndex);
     void cycle_frame(int delta);


### PR DESCRIPTION
The focused frame is always a frame leaf, so the DynChild_ should also
have this type. This just improves the type-safety and hlwm-doc.json.