### PR TITLE
Add 'parent_frame' entry for each client

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,7 +12,7 @@ Current git version
     order of existing tags.
   * New child object 'focused_client' for each tag object.
   * New child object 'focused_frame' for the tiling object of each tag object.
-  * New child object 'frame' for each client providing the frame the client sits in
+  * New child object 'parent_frame' for each client providing the frame the client sits in
   * New command 'mirror'
   * New command 'apply_tmp_rule'
   * The 'apply_rules' command now reports parse errors

--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ Current git version
     order of existing tags.
   * New child object 'focused_client' for each tag object.
   * New child object 'focused_frame' for the tiling object of each tag object.
+  * New child object 'frame' for each client providing the frame the client sits in
   * New command 'mirror'
   * New command 'apply_tmp_rule'
   * The 'apply_rules' command now reports parse errors

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -43,7 +43,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , minimized_(this,  "minimized", false)
     , title_(this,  "title", "")
     , tag_str_(this,  "tag", &Client::tagName)
-    , frame_(*this,  "frame", &Client::containingFrame)
+    , parent_frame_(*this,  "parent_frame", &Client::parentFrame)
     , window_id_str(this,  "winid", "")
     , keyMask_(this,  "keymask", RegexStr::fromStr(""))
     , keysInactive_(this,  "keys_inactive", RegexStr::fromStr(""))
@@ -96,7 +96,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
 
     init_from_X();
     visible_.setDoc("whether this client is rendered currently");
-    frame_.setDoc("the frame contaning this client if the client is tiled");
+    parent_frame_.setDoc("the frame contaning this client if the client is tiled");
 }
 
 void Client::init_from_X() {
@@ -584,7 +584,7 @@ string Client::getWindowInstance()
     return ewmh.X().getInstance(window_);
 }
 
-FrameLeaf* Client::containingFrame()
+FrameLeaf* Client::parentFrame()
 {
     if (is_client_floated()) {
         return nullptr;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -9,10 +9,12 @@
 #include "clientmanager.h"
 #include "decoration.h"
 #include "ewmh.h"
+#include "frametree.h"
 #include "globals.h"
 #include "hook.h"
 #include "ipc-protocol.h"
 #include "keymanager.h"
+#include "layout.h"
 #include "monitor.h"
 #include "monitormanager.h"
 #include "mousemanager.h"
@@ -41,6 +43,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , minimized_(this,  "minimized", false)
     , title_(this,  "title", "")
     , tag_str_(this,  "tag", &Client::tagName)
+    , frame_(*this,  "frame", &Client::containingFrame)
     , window_id_str(this,  "winid", "")
     , keyMask_(this,  "keymask", RegexStr::fromStr(""))
     , keysInactive_(this,  "keys_inactive", RegexStr::fromStr(""))
@@ -92,6 +95,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
 
     init_from_X();
     visible_.setDoc("whether this client is rendered currently");
+    frame_.setDoc("the frame contaning this client if the client is tiled");
 }
 
 void Client::init_from_X() {
@@ -577,6 +581,15 @@ string Client::getWindowClass()
 string Client::getWindowInstance()
 {
     return ewmh.X().getInstance(window_);
+}
+
+FrameLeaf* Client::containingFrame()
+{
+    if (is_client_floated()) {
+        return nullptr;
+    } else {
+        return tag_->frame->findFrameWithClient(this).get();
+    }
 }
 
 void Client::requestRedraw()

--- a/src/client.h
+++ b/src/client.h
@@ -62,7 +62,7 @@ public:
     Attribute_<bool> minimized_;
     Attribute_<std::string> title_;  // or also called window title; this is never NULL
     DynAttribute_<std::string> tag_str_;
-    DynChild_<FrameLeaf> frame_;
+    DynChild_<FrameLeaf> parent_frame_;
     Attribute_<std::string> window_id_str;
     Attribute_<RegexStr> keyMask_; // regex for key bindings that are active on this window
     Attribute_<RegexStr> keysInactive_; // regex for key bindings that are inactive on this window
@@ -128,7 +128,7 @@ private:
     std::string getWindowClass();
     std::string getWindowInstance();
     std::string triggerRelayoutMonitor();
-    FrameLeaf* containingFrame();
+    FrameLeaf* parentFrame();
     void requestRedraw();
     friend Decoration;
     ClientManager& manager;

--- a/src/client.h
+++ b/src/client.h
@@ -5,6 +5,7 @@
 #include <X11/Xlib.h>
 
 #include "attribute_.h"
+#include "child.h"
 #include "object.h"
 #include "regexstr.h"
 #include "theme.h"
@@ -14,6 +15,7 @@
 class Decoration;
 class DecTriple;
 class Ewmh;
+class FrameLeaf;
 class Slice;
 class HSTag;
 class Monitor;
@@ -60,6 +62,7 @@ public:
     Attribute_<bool> minimized_;
     Attribute_<std::string> title_;  // or also called window title; this is never NULL
     DynAttribute_<std::string> tag_str_;
+    DynChild_<FrameLeaf> frame_;
     Attribute_<std::string> window_id_str;
     Attribute_<RegexStr> keyMask_; // regex for key bindings that are active on this window
     Attribute_<RegexStr> keysInactive_; // regex for key bindings that are inactive on this window
@@ -125,6 +128,7 @@ private:
     std::string getWindowClass();
     std::string getWindowInstance();
     std::string triggerRelayoutMonitor();
+    FrameLeaf* containingFrame();
     void requestRedraw();
     friend Decoration;
     ClientManager& manager;

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -284,36 +284,36 @@ def test_minimize_only_floating_client(hlwm):
     assert hlwm.get_attr('tags.focus.floating_focused') == 'false'
 
 
-def test_frame_attribute_one_split(hlwm):
+def test_parent_frame_attribute_one_split(hlwm):
     c1, c2 = hlwm.create_clients(2)
     hlwm.call('split explode')
 
-    assert hlwm.attr.clients[c1].frame.index() == '0'
-    assert hlwm.attr.clients[c2].frame.index() == '1'
+    assert hlwm.attr.clients[c1].parent_frame.index() == '0'
+    assert hlwm.attr.clients[c2].parent_frame.index() == '1'
 
 
-def test_frame_attribute_no_split(hlwm):
+def test_parent_frame_attribute_no_split(hlwm):
     c1, c2 = hlwm.create_clients(2)
 
-    assert hlwm.attr.clients[c1].frame.index() == ''
-    assert hlwm.attr.clients[c2].frame.index() == ''
+    assert hlwm.attr.clients[c1].parent_frame.index() == ''
+    assert hlwm.attr.clients[c2].parent_frame.index() == ''
 
 
-def test_frame_attribute_window_floating(hlwm):
+def test_parent_frame_attribute_window_floating(hlwm):
     winid, _ = hlwm.create_client()
     # do it in a loop to verify that we don't have typos in the assert
     for value in ['on', 'off']:
         hlwm.attr.clients[winid].floating = value
 
-        assert ('frame' in hlwm.list_children(f'clients.{winid}')) \
+        assert ('parent_frame' in hlwm.list_children(f'clients.{winid}')) \
             == (value == 'off')
 
 
-def test_frame_attribute_tag_floating(hlwm):
+def test_parent_frame_attribute_tag_floating(hlwm):
     winid, _ = hlwm.create_client()
     # do it in a loop to verify that we don't have typos in the assert
     for value in ['on', 'off']:
         hlwm.attr.tags.focus.floating = value
 
-        assert ('frame' in hlwm.list_children(f'clients.{winid}')) \
+        assert ('parent_frame' in hlwm.list_children(f'clients.{winid}')) \
             == (value == 'off')

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -282,3 +282,38 @@ def test_minimize_only_floating_client(hlwm):
     hlwm.call(f'set_attr clients.{winid}.minimized on')
 
     assert hlwm.get_attr('tags.focus.floating_focused') == 'false'
+
+
+def test_frame_attribute_one_split(hlwm):
+    c1, c2 = hlwm.create_clients(2)
+    hlwm.call('split explode')
+
+    assert hlwm.attr.clients[c1].frame.index() == '0'
+    assert hlwm.attr.clients[c2].frame.index() == '1'
+
+
+def test_frame_attribute_no_split(hlwm):
+    c1, c2 = hlwm.create_clients(2)
+
+    assert hlwm.attr.clients[c1].frame.index() == ''
+    assert hlwm.attr.clients[c2].frame.index() == ''
+
+
+def test_frame_attribute_window_floating(hlwm):
+    winid, _ = hlwm.create_client()
+    # do it in a loop to verify that we don't have typos in the assert
+    for value in ['on', 'off']:
+        hlwm.attr.clients[winid].floating = value
+
+        assert ('frame' in hlwm.list_children(f'clients.{winid}')) \
+            == (value == 'off')
+
+
+def test_frame_attribute_tag_floating(hlwm):
+    winid, _ = hlwm.create_client()
+    # do it in a loop to verify that we don't have typos in the assert
+    for value in ['on', 'off']:
+        hlwm.attr.tags.focus.floating = value
+
+        assert ('frame' in hlwm.list_children(f'clients.{winid}')) \
+            == (value == 'off')


### PR DESCRIPTION
The 'parent_frame' child of a client provides the frame object that
holds the client.

This fixes #6.
