### PR TITLE
Support proper utf8 strings in window titles

### DIFF
--- a/share/autostart
+++ b/share/autostart
@@ -121,6 +121,7 @@ hc set frame_transparent_width 5
 hc set frame_gap 4
 
 hc attr theme.title_height 15
+hc attr theme.title_font "-*-terminus-*-*-*-*-*-*-*-*-*-*-*-*"
 hc attr theme.active.color '#9fbc00'
 hc attr theme.normal.color '#454545'
 hc attr theme.urgent.color orange

--- a/share/autostart
+++ b/share/autostart
@@ -121,7 +121,7 @@ hc set frame_transparent_width 5
 hc set frame_gap 4
 
 hc attr theme.title_height 15
-hc attr theme.title_font "-*-terminus-*-*-*-*-*-*-*-*-*-*-*-*"
+hc attr theme.title_font '-*-fixed-medium-r-*-*-13-*-*-*-*-*-*-*'
 hc attr theme.active.color '#9fbc00'
 hc attr theme.normal.color '#454545'
 hc attr theme.urgent.color orange

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -380,13 +380,24 @@ void Decoration::redrawPixmap() {
                        inner.width,
                        inner.height - dec->last_actual_rect.height);
     }
-    if (s.title_height() > 0 && s.title_font->data().xFontStruct_) {
-        XSetForeground(g_display, gc, get_client_color(s.title_color));
-        XFontStruct* font = s.title_font->data().xFontStruct_;
-        int font_x_offset = s.padding_left() + s.border_width;
-        XSetFont(g_display, gc, font->fid);
-        XDrawString(g_display, pix, gc, font_x_offset, s.title_height(),
-                    client_->title_().c_str(), client_->title_().size());
+    if (s.title_height() > 0) {
+        FontData& fontData = s.title_font->data();
+        string title = client_->title_();
+        Point2D titlepos = {
+            static_cast<int>(s.padding_left() + s.border_width()),
+            static_cast<int>(s.title_height())
+        };
+        if (fontData.xFontSet_) {
+            XSetForeground(g_display, gc, get_client_color(s.title_color));
+            XmbDrawString(g_display, pix, fontData.xFontSet_, gc, titlepos.x, titlepos.y,
+                    title.c_str(), title.size());
+        } else if (fontData.xFontStruct_) {
+            XSetForeground(g_display, gc, get_client_color(s.title_color));
+            XFontStruct* font = s.title_font->data().xFontStruct_;
+            XSetFont(g_display, gc, font->fid);
+            XDrawString(g_display, pix, gc, titlepos.x, titlepos.y,
+                    title.c_str(), title.size());
+        }
     }
     // clean up
     XFreeGC(g_display, gc);

--- a/src/fontdata.cpp
+++ b/src/fontdata.cpp
@@ -1,14 +1,21 @@
 #include "fontdata.h"
 
+#include <sstream>
+
 #include "xconnection.h"
+#include "globals.h"
 
 using std::string;
+using std::stringstream;
 
 XConnection* FontData::s_xconnection = nullptr;
 
 FontData::~FontData() {
     if (xFontStruct_ && s_xconnection) {
         XFreeFont(s_xconnection->display(), xFontStruct_);
+    }
+    if (xFontSet_ && s_xconnection) {
+        XFreeFontSet(s_xconnection->display(), xFontSet_);
     }
 }
 
@@ -18,6 +25,36 @@ void FontData::initFromStr(const string& source)
     if (!s_xconnection) {
         throw std::invalid_argument("X connection not established yet!");
     }
+
+    // plain X fonts with unicode support
+    char** missingCharSetList = nullptr;
+    int missingCharSetCount = 0;
+    char* defString = nullptr;
+    xFontSet_ = XCreateFontSet(s_xconnection->display(), source.c_str(),
+                               &missingCharSetList, &missingCharSetCount,
+                               &defString);
+    stringstream msg;
+    if (missingCharSetCount > 0) {
+        msg << "The following charsets are unknown: ";
+        for (int i = 0; i < missingCharSetCount; i++) {
+            if (i != 0) {
+                msg << ", ";
+            }
+            msg << missingCharSetList[i];
+        }
+        XFreeStringList(missingCharSetList);
+    }
+    if (xFontSet_) {
+        if (missingCharSetCount > 0) {
+            HSWarning("When loading font \"%s\": %s\n", source.c_str(), msg.str().c_str());
+        }
+        return;
+    } else {
+        if (missingCharSetCount > 0) {
+            throw std::invalid_argument(msg.str());
+        }
+    }
+
     xFontStruct_ = XLoadQueryFont(s_xconnection->display(), source.c_str());
     if (!xFontStruct_) {
         throw std::invalid_argument(

--- a/src/fontdata.cpp
+++ b/src/fontdata.cpp
@@ -2,8 +2,8 @@
 
 #include <sstream>
 
-#include "xconnection.h"
 #include "globals.h"
+#include "xconnection.h"
 
 using std::string;
 using std::stringstream;

--- a/src/fontdata.h
+++ b/src/fontdata.h
@@ -4,6 +4,7 @@
 #include <string>
 
 class XConnection;
+struct _XOC;
 
 /**
  * @brief This class has two purposes: 1. Allow different
@@ -19,6 +20,7 @@ public:
     void initFromStr(const std::string& source);
 
     XFontStruct* xFontStruct_ = nullptr;
+    struct _XOC *xFontSet_ = nullptr; // _XOC* = XFontSet
 
     static XConnection* s_xconnection;
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <X11/X.h>
 #include <X11/Xlib.h>
 #include <getopt.h>
+#include <locale.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <csignal>
@@ -516,6 +517,10 @@ static void sigaction_signal(int signum, void (*handler)(int)) {
 int main(int argc, char* argv[]) {
     Globals g;
     parse_arguments(argc, argv, g);
+
+    if(!setlocale(LC_CTYPE, "") || !XSupportsLocale()) {
+        fputs("warning: no locale support\n", stderr);
+    }
     XConnection::setExitOnError(g.exitOnXlibError);
     XConnection* X = XConnection::connect();
     g_display = X->display();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -518,8 +518,8 @@ int main(int argc, char* argv[]) {
     Globals g;
     parse_arguments(argc, argv, g);
 
-    if(!setlocale(LC_CTYPE, "") || !XSupportsLocale()) {
-        fputs("warning: no locale support\n", stderr);
+    if (!setlocale(LC_CTYPE, "") || !XSupportsLocale()) {
+        std::cerr << "warning: no locale support" << endl;
     }
     XConnection::setExitOnError(g.exitOnXlibError);
     XConnection* X = XConnection::connect();

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -100,4 +100,4 @@ def test_font_type_existing_font(hlwm):
 def test_font_type_non_existing_font(hlwm):
     value = 'Some long font name that hopefully does not exist'
     hlwm.call_xfail(['set_attr', 'theme.title_font', value]) \
-        .expect_stderr(f"cannot allocate font.*'{value}'")
+        .expect_stderr(f"(cannot allocate font.*'{value}'|{value}.*The following charsets are unknown)")


### PR DESCRIPTION
This uses the XFontSet structure and XmbDrawString routines that are
capable of utf8 encoded strings. The setlocale() in the main is of great
importance, because otherwise, text drawing stops on the first non-ascii
character.

Unfortunately, XCreateFontSet() or XmbDrawString() seem to be
incompatible with the terminus font on my installation.

If the XCreateFontSet fails, then we fall back to plain XFontStruct and
XDrawString.