### PR TITLE
Fix references to removed BUGS file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_subdirectory(doc)
 add_subdirectory(share)
 
 ## install everything that was not installed from subdirectories
-install(FILES BUGS NEWS DESTINATION ${DOCDIR})
+install(FILES NEWS DESTINATION ${DOCDIR})
 install(FILES LICENSE DESTINATION ${LICENSEDIR})
 install(DIRECTORY scripts/ DESTINATION ${DOCDIR}/examples USE_SOURCE_PERMISSIONS)
 

--- a/INSTALL
+++ b/INSTALL
@@ -30,10 +30,9 @@ Optional run-time dependencies:
     - dmenu (used in some example scripts)
 
 ==== Help/Support/Bugs ====
-A list of known bugs is listed in BUGS. If you found other bugs or want to
-request features then open an issue on github.com/herbstluftwm/herbstluftwm or
-contact the mailing list. (The subscription process is explained in the HACKING
-file).
+If you found a bug or want to request features then open an issue on
+https://github.com/herbstluftwm/herbstluftwm/issues or contact the mailing list.
+(The subscription process is explained in the HACKING file).
 
 Mailing list: hlwm@lists.herbstluftwm.org
 

--- a/doc/herbstclient.txt
+++ b/doc/herbstclient.txt
@@ -81,7 +81,7 @@ other::
 
 BUGS
 ----
-See the *herbstluftwm* distribution BUGS file.
+See the *herbstluftwm* Github issues: https://github.com/herbstluftwm/herbstluftwm/issues
 
 COMMUNITY
 ---------

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1751,7 +1751,7 @@ Returns *0* on success. Returns +EXIT_FAILURE+ if it cannot startup or if
 
 BUGS
 ----
-See the *herbstluftwm* distribution BUGS file.
+See the *herbstluftwm* Github issues: https://github.com/herbstluftwm/herbstluftwm/issues
 
 COMMUNITY
 ---------

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -206,7 +206,7 @@ void Client::window_focus() {
 
     if (this != lastfocus) {
         /* FIXME: this is a workaround because window_focus always is called
-         * twice.  see BUGS for more information
+         * twice.
          *
          * only emit the hook if the focus *really* changes */
         // unfocus last one


### PR DESCRIPTION
Unbreaks install and removes all other references as reported in #1093.
Rather reference the Github issues page everywhere.