### PR TITLE
Make CI steps more fine-grained

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -45,19 +45,17 @@ jobs:
           path: .tox-cache
           key: focal-tox
 
-      - name: Inspect ccache after restore
+      - name: CMake
         run: |
-          find ~/.ccache | grep 8/2/aeeb3d || true
-          find ~/.ccache | wc -l
+          ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache
 
-      - name: Build
+      - name: Compile
         run: |
-          ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache --compile --install
+          ci/build.py --compile
 
-      - name: Inspect ccache after build
+      - name: Install to temp directory
         run: |
-          find ~/.ccache | grep 8/2/aeeb3d || true
-          find ~/.ccache | wc -l
+          ci/build.py --install
 
       - name: ccache log
         run: |
@@ -98,11 +96,6 @@ jobs:
           path: .tox-cache
           key: focal-tox # same name as in build-test-current
 
-      - name: Inspect ccache after restore
-        run: |
-          find ~/.ccache | grep 8/f/64 || true
-          find ~/.ccache | wc -l
-
       - name: Check usage of std-prefix
         run: |
           ci/build.py --check-using-std
@@ -111,14 +104,13 @@ jobs:
         run: |
           ci/build.py --flake8
 
-      - name: Build
+      - name: CMake
         run: |
-          ci/build.py --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache --compile
+          ci/build.py --cmake --cxx=$PWD/ci/clang++-and-tidy.sh --cc=$PWD/ci/clang-and-tidy.sh --build-type=Debug --ccache=$HOME/.ccache
 
-      - name: Inspect after build
+      - name: Compile
         run: |
-          find ~/.ccache | grep 8/f/64 || true
-          find ~/.ccache | wc -l
+          ci/build.py --compile
 
       - name: ccache log
         run: |

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -57,6 +57,10 @@ jobs:
         run: |
           ci/build.py --install
 
+      - name: ccache statistics
+        run: |
+          ccache -s
+
       - name: ccache log
         run: |
           cat "$CCACHE_LOGFILE"
@@ -111,6 +115,10 @@ jobs:
       - name: Compile
         run: |
           ci/build.py --compile
+
+      - name: ccache statistics
+        run: |
+          ccache -s
 
       - name: ccache log
         run: |

--- a/ci/build.py
+++ b/ci/build.py
@@ -101,9 +101,6 @@ if args.compile:
 if args.install:
     sp.check_call(['bash', '-c', 'DESTDIR=$(mktemp -d) ninja -v install'], cwd=build_dir)
 
-if args.ccache:
-    sp.check_call(['ccache', '-s'])
-
 if args.iwyu:
     # Check lexicographical order of #include directives (cheap pre-check)
     fix_include = sp.run('fix_include --dry_run --sort_only --reorder */*.{h,cpp,c}', cwd=repo, shell=True, executable='bash', stdout=sp.PIPE)

--- a/ci/build.py
+++ b/ci/build.py
@@ -75,10 +75,6 @@ if args.cmake:
         'CXX': args.cxx,
         'CFLAGS': '--coverage -Werror -fsanitize=address,leak,undefined',
         'CXXFLAGS': '--coverage -Werror -fsanitize=address,leak,undefined',
-
-        # In case clang-and-tidy.sh is used for building, it will need this to call
-        # clang-tidy:
-        'CLANG_TIDY_BUILD_DIR': str(build_dir),
     })
 
     cmake_args = [
@@ -88,17 +84,22 @@ if args.cmake:
         f'-DWITH_DOCUMENTATION={"YES" if args.build_docs else "NO"}',
         f'-DENABLE_CCACHE={"YES" if args.ccache else "NO"}',
     ]
-
     sp.check_call(['cmake', *cmake_args, repo], cwd=build_dir, env=build_env)
 
 if args.clean:
-    sp.check_call(['bash', '-c', 'time ninja -t clean'], cwd=build_dir, env=build_env)
+    sp.check_call(['bash', '-c', 'time ninja -t clean'], cwd=build_dir)
 
 if args.compile:
-    sp.check_call(['bash', '-c', 'time ninja -v -k 10'], cwd=build_dir, env=build_env)
+    env = os.environ.copy()
+    env.update({
+        # In case clang-and-tidy.sh is used for building, it will need this to call
+        # clang-tidy:
+        'CLANG_TIDY_BUILD_DIR': str(build_dir),
+    })
+    sp.check_call(['bash', '-c', 'time ninja -v -k 10'], cwd=build_dir, env=env)
 
 if args.install:
-    sp.check_call(['bash', '-c', 'DESTDIR=$(mktemp -d) ninja -v install'], cwd=build_dir, env=build_env)
+    sp.check_call(['bash', '-c', 'DESTDIR=$(mktemp -d) ninja -v install'], cwd=build_dir)
 
 if args.ccache:
     sp.check_call(['ccache', '-s'])


### PR DESCRIPTION
This splits the build step in the github action workflow into smaller
steps of cmake, compilation, and installation. Since we now understand
how the cache in github actions work (cf #1075), I've removed the
printf-debug steps.

The --cxx etc flags define environment variables, and they should only
be used during cmake, but not during the ninja compilation. Hence, it
should be sufficient to pass build_env to cmake. The only environment
variable relevant during the build process is CLANG_TIDY_BUILD_DIR which
is now only set in the `build.py --compile` step.