### PR TITLE
Make the lock_tag attribute writable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ Current git version
 
   * Client window titles (controlled by the theme attributes 'title_height',
     'title_color', 'title_font')
+  * The 'lock_tag' attribute is now writable.
 
 Release 0.9.1 on 2020-12-28
 ---------------------------

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -57,6 +57,7 @@ Monitor::Monitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, 
     pad_right.setWritable();
     pad_down.setWritable();
     pad_left.setWritable();
+    lock_tag.setWritable();
     for (auto i : {&pad_up, &pad_left, &pad_right, &pad_down}) {
         i->changed().connect(this, &Monitor::applyLayout);
     }

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -338,3 +338,64 @@ def test_cycle_monitor(hlwm, mon_num, focus_idx, delta, command):
 
     new_index = (focus_idx + int(delta) + mon_num) % mon_num
     assert hlwm.get_attr('monitors.focus.index') == str(new_index)
+
+
+@pytest.mark.parametrize("lock_tag_cmd", [
+    lambda index: ['lock_tag', str(index)],
+    lambda index: ['set_attr', f'monitors.{index}.lock_tag', 'on']
+])
+def test_lock_tag_switch_away(hlwm, lock_tag_cmd):
+    hlwm.call('add tag1')
+    hlwm.call('add tag2')
+    hlwm.call('set_monitors 800x600+0+0 800x600+800+0')
+    hlwm.call(lock_tag_cmd(0))
+    assert hlwm.attr.monitors[0].lock_tag() == hlwm.bool(True)
+
+    hlwm.call('focus_monitor 0')
+
+    # can not switch to another tag on the locked monitor
+    hlwm.call_xfail('use tag2') \
+        .expect_stderr('Could not change .*monitor 0 is locked')
+
+
+@pytest.mark.parametrize("locked", [True, False])
+def test_lock_tag_switch_to_locked(hlwm, locked):
+    hlwm.call('add tag1')
+    hlwm.call('add tag2')
+    hlwm.call('set_monitors 800x600+0+0 800x600+800+0')
+    hlwm.call('set swap_monitors_to_get_tag on')
+
+    hlwm.attr.monitors[0].lock_tag = hlwm.bool(locked)
+    hlwm.call('focus_monitor 1')
+
+    # being on monitor 1, try to focus the tag on monitor 0
+    tag_on_locked_monitor = hlwm.attr.monitors[0].tag()
+    hlwm.call(['use', tag_on_locked_monitor])
+
+    if locked:
+        # if the monitor was locked, then the tag stays
+        # on monitor 0
+        expected_monitor_index = '0'
+    else:
+        # otherwise, the tag is moved to monitor 1 because
+        # of swap_monitors_to_get_tag
+        expected_monitor_index = '1'
+    assert hlwm.attr.tags.focus.name() == tag_on_locked_monitor
+    assert hlwm.attr.monitors.focus.index() == expected_monitor_index
+
+
+def test_lock_tag_command_vs_attribute(hlwm):
+    hlwm.call('add anothertag')
+    hlwm.call('set_monitors 800x600+0+0 800x600+800+0')
+    hlwm.call('focus_monitor 1')
+
+    # no argument modifies the attribute of the focused monitor
+    hlwm.call('lock_tag')
+    assert hlwm.attr.monitors[1].lock_tag() == hlwm.bool(True)
+    hlwm.call('unlock_tag')
+    assert hlwm.attr.monitors[1].lock_tag() == hlwm.bool(False)
+
+    hlwm.call('lock_tag 0')
+    assert hlwm.attr.monitors[0].lock_tag() == hlwm.bool(True)
+    hlwm.call('unlock_tag 0')
+    assert hlwm.attr.monitors[0].lock_tag() == hlwm.bool(False)


### PR DESCRIPTION
For some reason, the lock_tag attribute was not writable (even in the
old source code at tag v0.7.2). In fact, the lock_tag and unlock_tag
commands do nothing except setting the attribute.

While at it, I've added a bunch of test cases for the lock_tag attribute
and the respective commands.