### PR TITLE
Remove nearly unused Object::addStaticChild()

### DIFF
--- a/src/byname.cpp
+++ b/src/byname.cpp
@@ -10,7 +10,7 @@ using std::string;
 ByName::ByName(Object& parent_)
     : parent(parent_)
 {
-    parent_.addStaticChild(this, "by-name");
+    parent_.addChild(this, "by-name");
     parent_.addHook(this);
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -243,12 +243,6 @@ void Object::printTree(Output output, string rootLabel) {
     tree_print_to(intface, output);
 }
 
-void Object::addStaticChild(Object* child, const string &name)
-{
-    children_[name] = child;
-    notifyHooks(HookEvent::CHILD_ADDED, name);
-}
-
 Attribute* Object::deepAttribute(const string &path) {
     std::ostringstream output;
     return deepAttribute(path, output);

--- a/src/object.h
+++ b/src/object.h
@@ -65,7 +65,6 @@ public:
     void addDynamicChild(std::function<Object*()> child, const std::string &name);
 
     void addChild(Object* child, const std::string &name);
-    void addStaticChild(Object* child, const std::string &name);
     void removeChild(const std::string &child);
 
     void addHook(Hook* hook);


### PR DESCRIPTION
It is only used by the ByName object and the implementation of
addStaticChild() was identical to addChild(). So, let us remove this
duplicate.