### PR TITLE
Avoid redundancy by introducing a ChildEntry class

### DIFF
--- a/src/child.h
+++ b/src/child.h
@@ -54,9 +54,9 @@ public:
     // owner is the 'parent' object
     // 'name' is the name of the child pointer
     template<typename... Args>
-    ChildMember_(Object& owner_, const std::string& name_, Args&&... args)
+    ChildMember_(Object& owner, const std::string& name, Args&&... args)
         : T(std::forward<Args>(args)...)
-        , ChildEntry(owner_, name_)
+        , ChildEntry(owner, name)
     {
         owner_.addChild(static_cast<T*>(this), name_);
     }

--- a/src/child.h
+++ b/src/child.h
@@ -13,20 +13,19 @@
  * accordingly.
  */
 template<typename T>
-class Child_ : public HasDocumentation {
+class Child_ : public ChildEntry {
 public:
     // owner is the 'parent' object
     // 'name' is the name of the child pointer
-    Child_(Object& owner_, const std::string& name_)
-        : owner(owner_)
-        , name(name_)
+    Child_(Object& owner, const std::string& name)
+        : ChildEntry(owner, name)
     { }
 
     template<typename... Args>
     void init(Args&&... args)
     {
         pointer_ = std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-        owner.addChild(pointer_.get(), name);
+        owner_.addChild(pointer_.get(), name_);
     }
 
     void reset() {
@@ -40,8 +39,6 @@ public:
         return pointer_.get();
     }
 private:
-    Object& owner;
-    std::string name;
     std::unique_ptr<T> pointer_ = nullptr;
 };
 
@@ -52,33 +49,29 @@ private:
  * would use a member of type T.
  */
 template<typename T>
-class ChildMember_ : public T {
+class ChildMember_ : public T, public ChildEntry  {
 public:
     // owner is the 'parent' object
     // 'name' is the name of the child pointer
     template<typename... Args>
     ChildMember_(Object& owner_, const std::string& name_, Args&&... args)
         : T(std::forward<Args>(args)...)
-        , owner(owner_)
-        , name(name_)
+        , ChildEntry(owner_, name_)
     {
-        owner.addChild(static_cast<T*>(this), name_);
+        owner_.addChild(static_cast<T*>(this), name_);
     }
-
-private:
-    Object& owner;
-    std::string name;
 };
 
 template<typename T>
-class DynChild_ : public HasDocumentation {
+class DynChild_ : public ChildEntry {
 public:
     // A dynamic child is a callback function that dynamically
     // returns an object of a certain type.
     template <typename Owner>
     DynChild_(Owner& owner, const std::string &name, T* (Owner::*getter)())
+        : ChildEntry(owner, name)
     {
-        owner.addDynamicChild( [&owner,getter] { return (owner.*getter)(); }, name);
+        owner_.addDynamicChild( [&owner,getter] { return (owner.*getter)(); }, name);
     }
 };
 

--- a/src/link.h
+++ b/src/link.h
@@ -10,12 +10,11 @@
  * automatically.
  */
 template<typename T>
-class Link_ : public HasDocumentation {
+class Link_ : public ChildEntry {
 public:
     // 'name' is the name of the child pointer
     Link_(Object& parent, std::string name)
-        : parent_(parent)
-        , name_(name)
+        : ChildEntry(parent, name)
     { }
     void operator=(T* new_value) {
         if (new_value == pointer) {
@@ -24,9 +23,9 @@ public:
         }
         pointer = new_value;
         if (pointer) {
-            parent_.addChild(pointer, name_);
+            owner_.addChild(pointer, name_);
         } else {
-            parent_.removeChild(name_);
+            owner_.removeChild(name_);
         }
         changed_.emit(new_value);
     }
@@ -38,8 +37,6 @@ public:
         return pointer;
     }
 private:
-    Object& parent_;
-    std::string name_;
     Signal_<T*> changed_;
     T* pointer = nullptr;
 };

--- a/src/object.h
+++ b/src/object.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "entity.h"
 #include "types.h"
 
 #define OBJECT_PATH_SEPARATOR '.'
@@ -16,6 +17,21 @@
 class Attribute;
 class Action;
 class Hook;
+class Object;
+
+/*! a child object entry of an object is like the subdirectory of
+ * a directory. In addition, we have documentation, what this entry
+ * is good for.
+ */
+class ChildEntry : public HasDocumentation {
+protected:
+    ChildEntry(Object& owner, const std::string& name)
+        : owner_(owner)
+        , name_(name)
+    {}
+    Object& owner_;
+    std::string name_;
+};
 
 enum class HookEvent {
     CHILD_ADDED,


### PR DESCRIPTION
The ChildEntry class combines what Child_, ChildMember_, DynChild_, and
Link_ have in common: a owner, an entry name, and documentation.
This ChildEntry can then be used to have a uniform interface for adding
and removing child entries from an object.

While at it, I also make the member variable names have a `_` suffix
and the function parameters have no suffix.
