### PR TITLE
CI: Use i386 pkg-config on trusty

### DIFF
--- a/ci/Dockerfile.ci-trusty
+++ b/ci/Dockerfile.ci-trusty
@@ -17,7 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libxml2-utils \
     libxrandr-dev:i386 \
     ninja-build \
-    pkg-config \
+    pkg-config:i386 \
     xterm \
     xvfb \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hopefully fixes problems with CMake/pkg-config not finding some libs.