### PR TITLE
Add 'help' command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,7 @@ Current git version
 
   * Client window titles (controlled by the theme attributes 'title_height',
     'title_color', 'title_font')
-  * New command 'help' for online help on the object tree
+  * New command 'help' for live documentation on the object tree
   * The 'lock_tag' attribute is now writable.
 
 Release 0.9.1 on 2020-12-28

--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ Current git version
 
   * Client window titles (controlled by the theme attributes 'title_height',
     'title_color', 'title_font')
+  * New command 'help' for online help on the object tree
   * The 'lock_tag' attribute is now writable.
 
 Release 0.9.1 on 2020-12-28

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -187,6 +187,9 @@ true::
 false::
     Ignores all arguments and always returns failure, i.e. 1.
 
+help ['OBJECT'|'ATTRIBUTE']::
+    Print help on a given object or attribute.
+
 list_commands::
     Lists all available commands.
 
@@ -1487,6 +1490,12 @@ true
 $ herbstclient set_attr tags.focus.floating false
 $ herbstclient attr tags.focus.floating
 false
+----
+
+More information on an attribute or object is given by the +help+ command:
+
+----
+$ herbstclient help clients.focus
 ----
 
 Just look around to get a feeling what is there. The detailed tree content is

--- a/src/entity.h
+++ b/src/entity.h
@@ -55,7 +55,7 @@ bool operator<(Type t1, Type t2);
 class HasDocumentation  {
 public:
     void setDoc(const char text[]) { doc_ = text; }
-    std::string doc() const { return doc_; };
+    std::string doc() const { return doc_ ? doc_ : ""; };
 private:
     /** we avoid the duplication of the doc string
      * with every instance of the owning class.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -224,6 +224,8 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                             &MetaCommands::get_attr_complete }},
         {"set_attr",       { meta_commands, &MetaCommands::set_attr_cmd,
                                             &MetaCommands::set_attr_complete }},
+        {"help",           { meta_commands, &MetaCommands::helpCommand,
+                                            &MetaCommands::helpCompletion }},
         {"attr",           { meta_commands, &MetaCommands::attr_cmd,
                                             &MetaCommands::attr_complete }},
         {"mktemp",         { tmp, &Tmp::mktemp,

--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -708,7 +708,11 @@ int MetaCommands::helpCommand(Input input, Output output)
 
 void MetaCommands::helpCompletion(Completion& complete)
 {
-    completeAttributePath(complete);
+    if (complete == 0) {
+        completeAttributePath(complete);
+    } else {
+        complete.none();
+    }
 }
 
 void MetaCommands::get_attr_complete(Completion& complete) {

--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -634,7 +634,7 @@ int MetaCommands::helpCommand(Input input, Output output)
     if (args.parsingAllFails(input, output)) {
         return args.exitCode();
     }
-    std::function<string(string)> header =
+    function<string(string)> header =
             [] (const string& text) {
         string buf = text + "\n";
         for (size_t i = 0; i < text.size(); i++) {

--- a/src/metacommands.h
+++ b/src/metacommands.h
@@ -60,6 +60,9 @@ public:
                             std::function<bool(Attribute*)> attributeFilter = {});
     void completeAttributePath(Completion& complete);
 
+    int helpCommand(Input input, Output output);
+    void helpCompletion(Completion& complete);
+
     int tryCommand(Input input, Output output);
     int silentCommand(Input input, Output output);
     int negateCommand(Input input, Output output);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -19,7 +19,7 @@ using std::shared_ptr;
 using std::string;
 using std::vector;
 
-ChildEntry::ChildEntry(Object& owner, const std::string& name)
+ChildEntry::ChildEntry(Object& owner, const string& name)
     : owner_(owner)
     , name_(name)
 {
@@ -188,7 +188,7 @@ void Object::removeChild(const string &child)
     children_.erase(child);
 }
 
-void Object::addChildDoc(const std::string& name, HasDocumentation* doc)
+void Object::addChildDoc(const string& name, HasDocumentation* doc)
 {
     childrenDoc_[name] = doc;
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -19,6 +19,13 @@ using std::shared_ptr;
 using std::string;
 using std::vector;
 
+ChildEntry::ChildEntry(Object& owner, const std::string& name)
+    : owner_(owner)
+    , name_(name)
+{
+    owner_.addChildDoc(name_, this);
+}
+
 pair<ArgList,string> Object::splitPath(const string &path) {
     vector<string> splitpath = ArgList(path, OBJECT_PATH_SEPARATOR).toVector();
     if (splitpath.empty()) {
@@ -179,6 +186,21 @@ void Object::removeChild(const string &child)
 {
     notifyHooks(HookEvent::CHILD_REMOVED, child);
     children_.erase(child);
+}
+
+void Object::addChildDoc(const std::string& name, HasDocumentation* doc)
+{
+    childrenDoc_[name] = doc;
+}
+
+const HasDocumentation* Object::childDoc(const string& child)
+{
+    auto it = childrenDoc_.find(child);
+    if (it != childrenDoc_.end()) {
+        return it->second;
+    } else {
+        return nullptr;
+    }
 }
 
 void Object::addHook(Hook* hook)

--- a/src/object.h
+++ b/src/object.h
@@ -25,12 +25,10 @@ class Object;
  */
 class ChildEntry : public HasDocumentation {
 protected:
-    ChildEntry(Object& owner, const std::string& name)
-        : owner_(owner)
-        , name_(name)
-    {}
+    ChildEntry(Object& owner, const std::string& name);
+    friend class Object;
     Object& owner_;
-    std::string name_;
+    const std::string name_;
 };
 
 enum class HookEvent {
@@ -83,6 +81,9 @@ public:
     void addChild(Object* child, const std::string &name);
     void removeChild(const std::string &child);
 
+    void addChildDoc(const std::string &name, HasDocumentation* doc);
+    const HasDocumentation* childDoc(const std::string& child);
+
     void addHook(Hook* hook);
     void removeHook(Hook* hook);
 
@@ -100,6 +101,7 @@ protected:
 
     std::map<std::string, std::function<Object*()>> childrenDynamic_;
     std::map<std::string, Object*> children_;
+    std::map<std::string, HasDocumentation*> childrenDoc_;
     std::vector<Hook*> hooks_;
 
     //DynamicAttribute nameAttribute_;

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -140,3 +140,29 @@ def test_attributes_and_children_are_documented(hlwm, clsname, object_path, json
         else:
             assert entry[-1] == ' ', "it's an attribute if it's no child"
             assert entry[0:-1] in json_doc['objects'][clsname]['attributes']
+
+
+@pytest.mark.parametrize('clsname,object_path', classname2examplepath)
+def test_help_on_attribute_vs_json(hlwm, clsname, object_path, json_doc):
+    path = object_path(hlwm)
+    attrs_doc = json_doc['objects'][clsname]['attributes']
+    for _, attr in attrs_doc.items():
+        attr_name = attr['name']
+        help_txt = hlwm.call(['help', f'{path}.{attr_name}'.lstrip('.')]).stdout
+
+        assert f"Attribute '{attr_name}'" in help_txt
+        doc = attr.get('doc', '')
+        assert doc in help_txt
+
+
+@pytest.mark.parametrize('clsname,object_path', classname2examplepath)
+def test_help_on_children_vs_json(hlwm, clsname, object_path, json_doc):
+    path = object_path(hlwm)
+    child_doc = json_doc['objects'][clsname]['children']
+    for _, child in child_doc.items():
+        name = child['name']
+        help_txt = hlwm.call(['help', f'{path}.{name}'.lstrip('.')]).stdout
+
+        if 'doc' in child:
+            assert f"Entry '{name}'" in help_txt
+            assert child['doc'] in help_txt

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -694,3 +694,52 @@ def test_dyn_attribute_invalid_argument(hlwm):
 def test_dyn_attribute_out_of_range(hlwm):
     hlwm.call_xfail('set_attr settings.window_border_inner_width 10000000000000000') \
         .expect_stderr('out of range: stoi')
+
+
+def test_help_trailing_period(hlwm):
+    with_period = hlwm.call('help clients.focus.').stdout
+    without_period = hlwm.call('help clients.focus').stdout
+
+    assert with_period == without_period
+
+
+def test_help_existence_note(hlwm):
+    # the doc if no client is focused
+    does_not_exist = hlwm.call('help clients.dragged').stdout
+
+    # the doc if some client is focused
+    hlwm.create_client()
+    does_exist = hlwm.call('help clients.focus').stdout
+
+    note = "Entry does not exist"
+
+    assert note not in does_exist
+    assert note in does_not_exist
+
+
+def test_help_root_object(hlwm):
+    help_txt = hlwm.call(['help', '']).stdout
+    assert "Object ''" in help_txt
+
+
+def test_help_root_attribute(hlwm):
+    hlwm.call('new_attr int my_foo 25')
+    help_txt = hlwm.call('help my_foo').stdout
+
+    assert 'Attribute' in help_txt
+    assert '25' in help_txt
+
+
+def test_help_on_objects(hlwm, path='', depth=8):
+    """test that running 'help' on all objects prints some
+    reasonable information
+    """
+    help_txt = hlwm.call(['help', path]).stdout
+    assert f"Object '{path}'" in help_txt
+
+    if depth < 0:
+        return
+
+    for child in hlwm.list_children(path):
+        newpath = (path + '.' + child).lstrip('.')
+        test_help_on_objects(hlwm, path=newpath, depth=depth - 1)


### PR DESCRIPTION
The 'help' command prints information on a given attribute or object.
The tests so far check that it prints something useful and matches it
against the 'doc' field in the json documentation.