### PR TITLE
Use pkg-config for library detection

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,5 +1,14 @@
 ## get project dependencies
 # Xlib
-find_package(X11 REQUIRED)
+find_package(PkgConfig)
+
+pkg_check_modules(X11 x11)
+pkg_check_modules(XRANDR xrandr)
+pkg_check_modules(XINERAMA xinerama)
+pkg_check_modules(XEXT xext)
+
+# for xft support:
+pkg_check_modules(XFT xft)
+pkg_check_modules(FREETYPE freetype2)
 
 # vim: et:ts=4:sw=4

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -2,13 +2,13 @@
 # Xlib
 find_package(PkgConfig)
 
-pkg_check_modules(X11 x11)
-pkg_check_modules(XRANDR xrandr)
+pkg_check_modules(X11 REQUIRED x11)
+pkg_check_modules(XRANDR REQUIRED xrandr)
 pkg_check_modules(XINERAMA xinerama)
-pkg_check_modules(XEXT xext)
+pkg_check_modules(XEXT REQUIRED xext)
 
 # for xft support:
-pkg_check_modules(XFT xft)
-pkg_check_modules(FREETYPE freetype2)
+pkg_check_modules(XFT REQUIRED xft)
+pkg_check_modules(FREETYPE REQUIRED freetype2)
 
 # vim: et:ts=4:sw=4

--- a/ipc-client/CMakeLists.txt
+++ b/ipc-client/CMakeLists.txt
@@ -17,9 +17,9 @@ set_target_properties(herbstclient PROPERTIES
 
 # dependencies X11
 target_include_directories(herbstclient SYSTEM PUBLIC
-    ${X11_X11_INCLUDE_PATH})
+    ${X11_INCLUDE_DIRS})
 target_link_libraries(herbstclient PUBLIC
-    ${X11_X11_LIB})
+    ${X11_LIBRARIES})
 
 # communicate version string
 export_version(main.c)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,14 +85,26 @@ cmake_dependent_option(WITH_XINERAMA "Use multi-monitor support via xinerama" ON
 
 if (WITH_XINERAMA)
     set_property(SOURCE monitordetection.cpp APPEND PROPERTY COMPILE_DEFINITIONS XINERAMA)
-    target_link_libraries(herbstluftwm PRIVATE ${X11_Xinerama_LIB})
+    target_link_libraries(herbstluftwm PRIVATE ${XINERAMA_LIBRARIES})
 endif()
 
 ## dependencies X11 (link to Xext for XShape())
 target_include_directories(herbstluftwm SYSTEM PUBLIC
-    ${X11_X11_INCLUDE_PATH} ${X11_Xinerama_INCLUDE_PATH} ${X11_Xrandr_INCLUDE_PATH})
+    ${FREETYPE_INCLUDE_DIRS}
+    ${X11_INCLUDE_DIRS}
+    ${XFT_INCLUDE_DIRS}
+    ${XEXT_INCLUDE_DIRS}
+    ${XINERAMA_INCLUDE_DIRS}
+    ${XRANDR_INCLUDE_DIRS}
+    )
 target_link_libraries(herbstluftwm PUBLIC
-    ${X11_X11_LIB} ${X11_Xext_LIB} ${X11_Xrandr_LIB})
+    ${FREETYPE_LIBRARIES}
+    ${X11_LIBRARIES}
+    ${XEXT_LIBRARIES}
+    ${XFT_LIBRARIES}
+    ${XINERAMA_LIBRARIES}
+    ${XRANDR_LIBRARIES}
+    )
 
 ## export variables to the code
 # version string

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,7 @@ set_target_properties(herbstluftwm PROPERTIES
 ## options
 include(CMakeDependentOption)
 cmake_dependent_option(WITH_XINERAMA "Use multi-monitor support via xinerama" ON
-    "X11_Xinerama_FOUND" OFF)
+    "XINERAMA_FOUND" OFF)
 
 if (WITH_XINERAMA)
     set_property(SOURCE monitordetection.cpp APPEND PROPERTY COMPILE_DEFINITIONS XINERAMA)


### PR DESCRIPTION
Instead of using the FindX11.cmake module that comes with cmake, we now
use pkg-config for the compiler and linker flags. This allows us to
explicitly state which libraries we use. For FindX11.cmake it just
tried to detect what's there, with little output. for pkg-config, cmake
now clearly prints which libraries are found, and which are missing.

This also adds the libraries freetype and xft that will be necessary
for xft font rendering.