### PR TITLE
Add minimization keybinding to default autostart

### DIFF
--- a/share/autostart
+++ b/share/autostart
@@ -85,6 +85,7 @@ hc keybind $Mod-r remove
 hc keybind $Mod-s floating toggle
 hc keybind $Mod-f fullscreen toggle
 hc keybind $Mod-Shift-f set_attr clients.focus.floating toggle
+hc keybind $Mod-Shift-m set_attr clients.focus.minimized true
 hc keybind $Mod-p pseudotile toggle
 # The following cycles through the available layouts within a frame, but skips
 # layouts, if the layout change wouldn't affect the actual window positions.


### PR DESCRIPTION
#1032 added this feature and had that nice keybind command in the commit message.
It fits perfectly into the default autostart.