### PR TITLE
Add attribute watchers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ Current git version
   * Client window titles (controlled by the theme attributes 'title_height',
     'title_color', 'title_font')
   * The 'lock_tag' attribute is now writable.
+  * New 'watch' command that emits hooks when attribute values change.
   * New dependencies: xft, freetype
 
 Release 0.9.1 on 2020-12-28

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -835,6 +835,11 @@ new_attr *bool*|*color*|*int*|*string*|*uint* 'PATH' ['VALUE']::
     with +my_+. If 'VALUE' is supplied, then it is written to the attribute (if
     this fails the attribute still remains).
 
+[[watch]]watch 'PATH'::
+    Watch the value of the given attribute 'PATH'. Whenever the value changes
+    from 'OLDVALUE' to 'NEWVALUE', a hook is emitted: +
+    +attribute_changed+ 'PATH' 'NEWVALUE' 'OLDVALUE'
+
 remove_attr 'PATH'::
     Removes the user defined attribute 'PATH'.
 
@@ -1659,6 +1664,11 @@ On special events, herbstluftwm emits some hooks (with parameters). You can
 receive or wait for them with link:herbstclient.html[*herbstclient*(1)]. Also custom hooks can be
 emitted with the *emit_hook* command. The following hooks are emitted by
 herbstluftwm itself:
+
+attribute_changed 'PATH' 'NEWVALUE' 'OLDVALUE'::
+    The attribute 'PATH' was changed from 'OLDVALUE' to 'NEWVALUE'. Requires
+    that the attribute 'PATH' has been passed to <<watch,the +watch+ command>>
+    before.
 
 fullscreen [on|off] 'WINID'::
     The fullscreen state of window 'WINID' was changed to [on|off].

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -838,7 +838,7 @@ new_attr *bool*|*color*|*int*|*string*|*uint* 'PATH' ['VALUE']::
 [[watch]]watch 'PATH'::
     Watch the value of the given attribute 'PATH'. Whenever the value changes
     from 'OLDVALUE' to 'NEWVALUE', a hook is emitted: +
-    +attribute_changed+ 'PATH' 'NEWVALUE' 'OLDVALUE'
+    +attribute_changed+ 'PATH' 'OLDVALUE' 'NEWVALUE'
 
 remove_attr 'PATH'::
     Removes the user defined attribute 'PATH'.
@@ -1665,7 +1665,7 @@ receive or wait for them with link:herbstclient.html[*herbstclient*(1)]. Also cu
 emitted with the *emit_hook* command. The following hooks are emitted by
 herbstluftwm itself:
 
-attribute_changed 'PATH' 'NEWVALUE' 'OLDVALUE'::
+attribute_changed 'PATH' 'OLDVALUE' 'NEWVALUE'::
     The attribute 'PATH' was changed from 'OLDVALUE' to 'NEWVALUE'. Requires
     that the attribute 'PATH' has been passed to <<watch,the +watch+ command>>
     before.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(herbstluftwm PRIVATE
     tmp.cpp tmp.h
     types.cpp types.h
     utils.cpp utils.h
+    watchers.h watchers.cpp
     x11-types.cpp x11-types.h
     x11-utils.cpp x11-utils.h
     xconnection.cpp xconnection.h

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 #include "tagmanager.h"
 #include "tmp.h"
 #include "utils.h"
+#include "watchers.h"
 #include "xconnection.h"
 #include "xmainloop.h"
 
@@ -77,6 +78,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
     Settings* settings = root->settings();
     TagManager* tags = root->tags();
     Tmp* tmp = root->tmp();
+    Watchers* watchers = root->watchers();
 
     std::initializer_list<pair<const string,CommandBinding>> init =
     {
@@ -226,6 +228,8 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                             &MetaCommands::set_attr_complete }},
         {"attr",           { meta_commands, &MetaCommands::attr_cmd,
                                             &MetaCommands::attr_complete }},
+        {"watch",          { watchers, &Watchers::watchCommand,
+                                       &Watchers::watchCompletion }},
         {"mktemp",         { tmp, &Tmp::mktemp,
                                   &Tmp::mktempComplete }},
     };

--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -598,7 +598,8 @@ void MetaCommands::compare_complete(Completion &complete) {
 }
 
 
-void MetaCommands::completeObjectPath(Completion& complete, bool attributes,
+void MetaCommands::completeObjectPath(Completion& complete, Object* rootObject,
+                                      bool attributes,
                                       function<bool(Attribute*)> attributeFilter)
 {
     ArgList objectPathArgs = std::get<0>(Object::splitPath(complete.needle()));
@@ -606,7 +607,7 @@ void MetaCommands::completeObjectPath(Completion& complete, bool attributes,
     if (!objectPath.empty()) {
         objectPath += OBJECT_PATH_SEPARATOR;
     }
-    Object* object = root.child(objectPathArgs);
+    Object* object = rootObject->child(objectPathArgs);
     if (!object) {
         return;
     }
@@ -621,6 +622,12 @@ void MetaCommands::completeObjectPath(Completion& complete, bool attributes,
     for (auto& it : object->children()) {
         complete.partial(objectPath + it.first + OBJECT_PATH_SEPARATOR);
     }
+}
+
+void MetaCommands::completeObjectPath(Completion& complete, bool attributes,
+                                      function<bool(Attribute*)> attributeFilter)
+{
+    MetaCommands::completeObjectPath(complete, &root, attributes, attributeFilter);
 }
 
 void MetaCommands::completeAttributePath(Completion& complete) {

--- a/src/metacommands.h
+++ b/src/metacommands.h
@@ -56,6 +56,9 @@ public:
     void compare_complete(Completion& complete);
     static Attribute* newAttributeWithType(std::string typestr, std::string attr_name, Output output);
     static void completeAttributeType(Completion& complete);
+    static void completeObjectPath(Completion& complete, Object* rootObject,
+                                   bool attributes = false,
+                                   std::function<bool(Attribute*)> attributeFilter = {});
     void completeObjectPath(Completion& complete, bool attributes = false,
                             std::function<bool(Attribute*)> attributeFilter = {});
     void completeAttributePath(Completion& complete);

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -20,6 +20,7 @@
 #include "theme.h"
 #include "tmp.h"
 #include "utils.h"
+#include "watchers.h"
 
 using std::shared_ptr;
 
@@ -36,6 +37,7 @@ Root::Root(Globals g, XConnection& xconnection, IpcServer& ipcServer)
     , tags(*this, "tags")
     , theme(*this, "theme")
     , tmp(*this, TMP_OBJECT_PATH)
+    , watchers(*this, "watchers")
     , globals(g)
     , meta_commands(make_unique<MetaCommands>(*this))
     , X(xconnection)
@@ -54,6 +56,7 @@ Root::Root(Globals g, XConnection& xconnection, IpcServer& ipcServer)
     tags.init();
     theme.init();
     tmp.init();
+    watchers.init();
 
     // inject dependencies where needed
     ewmh->injectDependencies(this);
@@ -63,6 +66,7 @@ Root::Root(Globals g, XConnection& xconnection, IpcServer& ipcServer)
     monitors->injectDependencies(settings(), tags(), panels.get());
     mouse->injectDependencies(clients(), monitors());
     panels->injectDependencies(settings());
+    watchers->injectDependencies(this);
 
     // set temporary globals
     ::global_tags = tags();

--- a/src/root.h
+++ b/src/root.h
@@ -24,6 +24,7 @@ class Settings; // IWYU pragma: keep
 class TagManager; // IWYU pragma: keep
 class Theme; // IWYU pragma: keep
 class Tmp; // IWYU pragma: keep
+class Watchers;
 class XConnection;
 
 class Globals {
@@ -57,6 +58,7 @@ public:
     Child_<TagManager> tags;
     Child_<Theme> theme;
     Child_<Tmp> tmp;
+    Child_<Watchers> watchers;
 
     Globals globals;
     std::unique_ptr<MetaCommands> meta_commands; // Using "pimpl" to avoid include

--- a/src/watchers.cpp
+++ b/src/watchers.cpp
@@ -1,0 +1,61 @@
+#include "watchers.h"
+
+#include "argparse.h"
+#include "hook.h"
+#include "metacommands.h"
+#include "object.h"
+#include "completion.h"
+
+using std::string;
+using std::vector;
+
+Watchers::Watchers()
+    : count_(this, "count", &Watchers::count)
+{
+    count_.setDoc("the number of attributes that are watched");
+}
+
+void Watchers::injectDependencies(Object* root)
+{
+    root_ = root;
+}
+
+void Watchers::scanForChanges()
+{
+    for (auto& it :  lastValue_) {
+        Attribute* attr = root_->deepAttribute(it.first);
+        std::string newValue = "";
+        if (attr) {
+            newValue = attr->str();
+        }
+        if (newValue != it.second) {
+            hook_emit({"attribute_changed", it.first, newValue, it.second});
+            it.second = newValue;
+        }
+    }
+}
+
+int Watchers::watchCommand(Input input, Output output)
+{
+    string path;
+    ArgParse args = ArgParse().mandatory(path);
+    if (args.parsingAllFails(input, output)) {
+        return args.exitCode();
+    }
+    std::string value = "";
+    Attribute* attr = root_->deepAttribute(path);
+    if (attr) {
+        value = attr->str();
+    }
+    lastValue_[path] = value;
+    return 0;
+}
+
+void Watchers::watchCompletion(Completion& complete)
+{
+    if (complete == 0) {
+        MetaCommands::completeObjectPath(complete, root_, true);
+    } else {
+        complete.none();
+    }
+}

--- a/src/watchers.cpp
+++ b/src/watchers.cpp
@@ -1,10 +1,10 @@
 #include "watchers.h"
 
 #include "argparse.h"
+#include "completion.h"
 #include "hook.h"
 #include "metacommands.h"
 #include "object.h"
-#include "completion.h"
 
 using std::string;
 using std::vector;

--- a/src/watchers.cpp
+++ b/src/watchers.cpp
@@ -29,7 +29,7 @@ void Watchers::scanForChanges()
             newValue = attr->str();
         }
         if (newValue != it.second) {
-            hook_emit({"attribute_changed", it.first, newValue, it.second});
+            hook_emit({"attribute_changed", it.first, it.second, newValue});
             it.second = newValue;
         }
     }

--- a/src/watchers.cpp
+++ b/src/watchers.cpp
@@ -24,7 +24,7 @@ void Watchers::scanForChanges()
 {
     for (auto& it :  lastValue_) {
         Attribute* attr = root_->deepAttribute(it.first);
-        std::string newValue = "";
+        string newValue = "";
         if (attr) {
             newValue = attr->str();
         }
@@ -42,7 +42,7 @@ int Watchers::watchCommand(Input input, Output output)
     if (args.parsingAllFails(input, output)) {
         return args.exitCode();
     }
-    std::string value = "";
+    string value = "";
     Attribute* attr = root_->deepAttribute(path);
     if (attr) {
         value = attr->str();

--- a/src/watchers.h
+++ b/src/watchers.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "attribute_.h"
+#include "object.h"
+#include "types.h"
+
+class Completion;
+
+class Watchers : public Object {
+public:
+    Watchers();
+    void injectDependencies(Object* root);
+    void scanForChanges();
+
+    DynAttribute_<unsigned long> count_;
+
+    int watchCommand(Input input, Output output);
+    void watchCompletion(Completion& complete);
+private:
+    unsigned long count() const { return lastValue_.size(); }
+    Object* root_ = nullptr;
+    std::map<std::string, std::string> lastValue_;
+};

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -27,6 +27,7 @@
 #include "tag.h"
 #include "tagmanager.h"
 #include "utils.h"
+#include "watchers.h"
 #include "xconnection.h"
 
 using std::function;
@@ -169,6 +170,7 @@ void XMainLoop::run() {
             if (handler != nullptr) {
                 (this ->* handler)(&event);
             }
+            root_->watchers->scanForChanges();
             XSync(X_.display(), False);
         }
     }

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -1,0 +1,64 @@
+
+
+def test_watchers_count(hlwm):
+    assert hlwm.attr.watchers.count() == '0'
+    hlwm.call('watch clients.focus.title')
+    assert hlwm.attr.watchers.count() == '1'
+    hlwm.call('watch clients.focus.title')
+    assert hlwm.attr.watchers.count() == '1'
+
+
+def test_watchers_basic_change1(hlwm, hc_idle):
+    attr = 'tags.focus.frame_count'
+    hlwm.call(['watch', attr])
+
+    hlwm.call('split explode')
+
+    assert hc_idle.hooks() == [['attribute_changed', attr, '1', '2']]
+
+
+def test_watchers_basic_change2(hlwm, hc_idle):
+    attr = 'tags.focus.tiling.focused_frame.algorithm'
+    hlwm.call('set_layout max')
+
+    hlwm.call(['watch', attr])
+    hlwm.call('set_layout grid')
+
+    assert hc_idle.hooks() == [['attribute_changed', attr, 'max', 'grid']]
+
+
+def test_watchers_not_yet_existing_attribute(hlwm, hc_idle):
+    hlwm.call('watch tags.1.name')
+
+    hlwm.call('add foo')
+
+    expected_hook = ['attribute_changed', 'tags.1.name', '', 'foo']
+    assert expected_hook in hc_idle.hooks()
+
+
+def test_watchers_attribute_disappears(hlwm, hc_idle):
+    hlwm.call('watch tags.by-name.default.name')
+
+    hlwm.call('rename default othername')
+
+    expected_hook = ['attribute_changed', 'tags.by-name.default.name', 'default', '']
+    assert expected_hook in hc_idle.hooks()
+
+
+def test_watchers_custom_attribute_create(hlwm, hc_idle):
+    hlwm.call('watch tags.my_var')
+
+    hlwm.call('new_attr int tags.my_var 40')
+
+    expected_hook = ['attribute_changed', 'tags.my_var', '', '40']
+    assert hc_idle.hooks() == [expected_hook]
+
+
+def test_watchers_custom_attribute_remove(hlwm, hc_idle):
+    hlwm.call('new_attr int monitors.my_var -37')
+    hlwm.call('watch monitors.my_var')
+
+    hlwm.call('remove_attr monitors.my_var')
+
+    expected_hook = ['attribute_changed', 'monitors.my_var', '-37', '']
+    assert hc_idle.hooks() == [expected_hook]


### PR DESCRIPTION
This implements a commonly requested feature allowing to be notified
when an attribute changes. The implementation just saves the value of
the watched attributes and periodically checks if the value has been
changed.

There is still room for optimization: One optimization is to replace the
plain map from string to string to a more advanced structure that speeds
up scanForChanges(); another is to use the signals where possible.

This fixes #1098. Also, this implements the missing piece of #71.