### PR TITLE
Let objects have documentation

### DIFF
--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -418,6 +418,7 @@ class ObjectInformation:
         self.member2info = {}  # mapping (classname,member) to ChildInformation or AttributeInformation
         self.member2init = {}  # mapping (classname,member) to its initializer list
         self.member2doc = {}  # mapping (classname,member) to its doc string
+        self.class2doc = {}  # mapping classname to its doc string
 
     def base_class(self, subclass, baseclass):
         if subclass not in self.base_classes:
@@ -470,6 +471,10 @@ class ObjectInformation:
     def member_doc(self, classname: str, cpp_name: str, doc: str):
         """set the doc string of a member variable of a class"""
         self.member2doc[(classname, cpp_name)] = doc
+
+    def class_doc(self, classname: str, doc: str):
+        """set the doc string of a class"""
+        self.class2doc[classname] = doc
 
     def superclasses_transitive(self):
         """return a set of a dict mapping a class to the set
@@ -581,6 +586,8 @@ class ObjectInformation:
                 # list the superclasses of clsname that are objects themselves:
                 'inherits-from': [s for s in supers if 'Object' in superclasses[s] and s != 'Object'],
             }
+            if clsname in self.class2doc:
+                result[clsname]['doc'] = self.class2doc[clsname]
         return {'objects': ObjectInformation.sorted_dict(result)}  # only generate object doc so far
 
 
@@ -712,6 +719,10 @@ class TokTreeInfoExtrator:
                 doc_tokens = parameters.value.enclosed_tokens
                 doc_string = ast.literal_eval(' '.join(doc_tokens))
                 self.objInfo.member_doc(classname, arg1.value, doc_string)
+            elif stream.try_match('setDoc', parameters, ';'):
+                doc_tokens = parameters.value.enclosed_tokens
+                doc_string = ast.literal_eval(' '.join(doc_tokens))
+                self.objInfo.class_doc(classname, doc_string)
             elif stream.try_match(arg1, '.', 'setWritable', parameters, ';'):
                 attr = self.objInfo.attribute_info(classname, arg1.value)
                 attr.writable = True

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -97,6 +97,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     init_from_X();
     visible_.setDoc("whether this client is rendered currently");
     parent_frame_.setDoc("the frame contaning this client if the client is tiled");
+    setDoc("a managed window");
 }
 
 void Client::init_from_X() {

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -35,6 +35,8 @@ ClientManager::ClientManager()
     , settings(nullptr)
     , ewmh(nullptr)
 {
+    setDoc("The managed windows. For every (managed) window id there "
+           "is an entry here.");
     focus.setDoc("the focused client (only exists if a client is focused)");
     dragged.setDoc("the object of a client which is currently dragged"
                    " by the mouse, if any. See the documentation of the"

--- a/src/entity.h
+++ b/src/entity.h
@@ -55,7 +55,7 @@ bool operator<(Type t1, Type t2);
 class HasDocumentation  {
 public:
     void setDoc(const char text[]) { doc_ = text; }
-    std::string doc() const { return doc_; };
+    std::string doc() const { return doc_ ? doc_ : ""; };
 private:
     /** we avoid the duplication of the doc string
      * with every instance of the owning class.

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -63,6 +63,15 @@ void Object::wireActions(vector<Action*> actions)
 
 void Object::ls(Output out)
 {
+    string docString = doc();
+    if (!docString.empty()) {
+        // print doc string and ensure that there is an empty line
+        // afterwards
+        out << docString << "\n";
+        if ('\n' != *docString.rbegin()) {
+            out << "\n";
+        }
+    }
     const auto& children = this->children();
     out << children.size() << (children.size() == 1 ? " child" : " children")
         << (!children.empty() ? ":" : ".") << endl;

--- a/src/object.h
+++ b/src/object.h
@@ -39,7 +39,7 @@ enum class HookEvent {
     ATTRIBUTE_CHANGED
 };
 
-class Object {
+class Object : public HasDocumentation {
 
 public:
     Object() = default;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -135,6 +135,10 @@ Settings::Settings()
     for (auto i : attributes()) {
         i.second->setWritable();
     }
+    setDoc(
+        "This has an attribute for each setting. Many settings are "
+        "wrappers around attributes and only exist for compatibility."
+    );
 }
 
 void Settings::injectDependencies(Root* root) {

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -19,6 +19,26 @@ Theme::Theme()
     active.makeProxyFor({&tiling.active, &floating.active});
     normal.makeProxyFor({&tiling.normal, &floating.normal});
     urgent.makeProxyFor({&tiling.urgent, &floating.urgent});
+
+    setDoc(
+          "    inner_color/inner_width\n"
+          "          ╻        outer_color/outer_width\n"
+          "          │                  ╻\n"
+          "          │                  │\n"
+          "    ┌────╴│╶─────────────────┷─────┐ ⎫ border_width\n"
+          "    │     │      color             │ ⎬     +\n"
+          "    │  ┌──┷─────────────────────┐  │ ⎭ padding_top\n"
+          "    │  │====================....│  │\n"
+          "    │  │== window content ==....│  │\n"
+          "    │  │====================..╾──────── background_color\n"
+          "    │  │........................│  │\n"
+          "    │  └────────────────────────┘  │ ⎱ border_width +\n"
+          "    └──────────────────────────────┘ ⎰ padding_bottom\n"
+          "\n"
+          "Setting an attribute of the theme object just propagates the "
+          "value to the respective attribute of the tiling and the floating "
+          "object."
+    );
 }
 
 DecorationScheme::DecorationScheme()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,10 +194,10 @@ class HlwmBridge(herbstluftwm.Herbstluftwm):
         # regexes for list_children:
 
         children_re = \
-            re.compile(r'^[0-9]* (child|children)[\\.:]((\n  [^\n]*)*)')
+            re.compile(r'[0-9]* (child|children)[\\.:]((\n  [^\n]*)*)')
         line_re = re.compile('^  (.*)\\.$')
         output = self.call(['attr', object_path]).stdout
-        section_match = children_re.match(output)
+        section_match = children_re.search(output)
         assert section_match
         children = []
         for i in section_match.group(2).split('\n')[1:]:

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -156,7 +156,7 @@ def test_class_doc(hlwm, clsname, object_path, json_doc):
         assert re.match(r'1 child:|[0-9]* children[\.:]$', attr_output.splitlines()[0])
 
 
-@pytest.mark.parametrize('clsname,object_path', classname2examplepath)   
+@pytest.mark.parametrize('clsname,object_path', classname2examplepath)
 def test_help_on_attribute_vs_json(hlwm, clsname, object_path, json_doc):
     path = object_path(hlwm)
     attrs_doc = json_doc['objects'][clsname]['attributes']

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -140,3 +140,17 @@ def test_attributes_and_children_are_documented(hlwm, clsname, object_path, json
         else:
             assert entry[-1] == ' ', "it's an attribute if it's no child"
             assert entry[0:-1] in json_doc['objects'][clsname]['attributes']
+
+
+@pytest.mark.parametrize('clsname,object_path', classname2examplepath)
+def test_class_doc(hlwm, clsname, object_path, json_doc):
+    path = object_path(hlwm)
+    attr_output = hlwm.call(['attr', path]).stdout
+
+    object_doc = json_doc['objects'][clsname].get('doc', None)
+    if object_doc is not None:
+        assert attr_output.startswith(object_doc)
+    else:
+        # if no class doc is in the json file, then there
+        # is indeed none:
+        assert re.match(r'1 child:|[0-9]* children[\.:]$', attr_output.splitlines()[0])


### PR DESCRIPTION
This makes Object inherit from HasDocumentation and parses the
respective calls to setDoc() into the json document. The attr command
now prints this object documentation, and this allows us to add test
cases that it matches the doc in the json file.

Note that the object documentation is something different than the
documentation on these "child entries" because e.g. the documentation on
clients.focus is "the focused client" whereas the documentation on
Client is that it represents "a managed window".