### PR TITLE
Correctly interpret a panel's WM_STRUT

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,8 @@ Current git version
   * Client window titles (controlled by the theme attributes 'title_height',
     'title_color', 'title_font')
   * The 'lock_tag' attribute is now writable.
+  * Bug fixes:
+    - Detect panels that leave a bit of space between the panel and the monitor edge.
 
 Release 0.9.1 on 2020-12-28
 ---------------------------

--- a/src/panelmanager.cpp
+++ b/src/panelmanager.cpp
@@ -142,40 +142,34 @@ PanelManager::ReservedSpace PanelManager::computeReservedSpace(Rectangle mon)
         // we only reserve space for the panel if the panel defines
         // wmStrut_ or if the aspect ratio clearly indicates whether the
         // panel is horizontal or vertical
-        if (!p.wmStrut_.empty() || intersection.height > intersection.width) {
-            // vertical panels
-            if (intersection.x == mon.x) {
-                rs.left_ = intersection.width;
+        if (p.wmStrut_.empty()) {
+            // if the panel does not define wmStrut, then
+            // try to detect it automatically from the intersection
+            if (intersection.height > intersection.width) {
+                // vertical panels
+                if (intersection.x == mon.x) {
+                    rs.left_ = intersection.width;
+                }
+                if (intersection.br().x == mon.br().x) {
+                    rs.right_ = intersection.width;
+                }
             }
-            if (intersection.br().x == mon.br().x) {
-                rs.right_ = intersection.width;
+            if (intersection.height < intersection.width) {
+                // horizontal panels
+                if (intersection.y == mon.y) {
+                    rs.top_ = intersection.height;
+                }
+                if (intersection.br().y == mon.br().y) {
+                    rs.bottom_ = intersection.height;
+                }
             }
-        }
-        if (!p.wmStrut_.empty() || intersection.height < intersection.width) {
-            // horizontal panels
-            if (intersection.y == mon.y) {
-                rs.top_ = intersection.height;
-            }
-            if (intersection.br().y == mon.br().y) {
-                rs.bottom_ = intersection.height;
-            }
-        }
-        if (!p.wmStrut_.empty()) {
-            // if the panel explicitly defines wmStrut, then
-            // we only consider the sides for the reserved space
-            // that are explicitly mentioned in wmStrut
-            if (p[WmStrut::left] == 0) {
-                rs.left_ = 0;
-            }
-            if (p[WmStrut::right] == 0) {
-                rs.right_ = 0;
-            }
-            if (p[WmStrut::top] == 0) {
-                rs.top_ = 0;
-            }
-            if (p[WmStrut::bottom] == 0) {
-                rs.bottom_ = 0;
-            }
+        } else {
+            // if the panel explicitly defines wmStrut
+            // then simply use this
+            rs.left_ = p[WmStrut::left];
+            rs.right_ = p[WmStrut::right];
+            rs.top_ = p[WmStrut::top];
+            rs.bottom_ = p[WmStrut::bottom];
         }
         for (size_t i = 0; i < 4; i++) {
             rsTotal[i] = std::max(rsTotal[i], rs[i]);

--- a/src/panelmanager.cpp
+++ b/src/panelmanager.cpp
@@ -61,7 +61,7 @@ public:
                         0,
                         wmStrut(WmStrut::left_start_y),
                         wmStrut(WmStrut::left),
-                        wmStrut(WmStrut::left_start_y));
+                        wmStrut(WmStrut::left_end_y));
         }
         if (wmStrut(WmStrut::right) > 0) {
             // align with right edge
@@ -183,10 +183,6 @@ PanelManager::ReservedSpace PanelManager::computeReservedSpace(Rectangle mon)
             panelArea = p.size_;
         }
         Rectangle intersection = mon.intersectionWith(panelArea);
-        HSDebug("checking panel %lx\n", p.winid_);
-        HSDebug("rect mon: %s\n", Converter<Rectangle>::str(mon).c_str());
-        HSDebug("rect panel: %s\n", Converter<Rectangle>::str(panelArea).c_str());
-        HSDebug("intersection: %s\n", Converter<Rectangle>::str(intersection).c_str());
         if (!intersection) {
             // monitor does not intersect with panel at all
             continue;

--- a/src/panelmanager.cpp
+++ b/src/panelmanager.cpp
@@ -15,22 +15,64 @@ public:
     PanelManager& pm_;
     Rectangle size_;
     vector<long> wmStrut_ = {};
-    int operator[](PanelManager::WmStrut idx) const {
+    using WmStrut = PanelManager::WmStrut;
+
+    int wmStrut(WmStrut idx) const {
         size_t i = static_cast<size_t>(idx);
         if (i < wmStrut_.size()) {
             return static_cast<int>(wmStrut_[i]);
-        } else if (idx == PanelManager::WmStrut::left_end_y
-               || idx == PanelManager::WmStrut::right_end_y)
+        } else if (idx == WmStrut::left_end_y
+               || idx == WmStrut::right_end_y)
         {
             return pm_.rootWindowGeometry_.height;
-        } else if (idx == PanelManager::WmStrut::top_end_x
-               || idx == PanelManager::WmStrut::bottom_end_x)
+        } else if (idx == WmStrut::top_end_x
+               || idx == WmStrut::bottom_end_x)
         {
             return pm_.rootWindowGeometry_.width;
         } else {
             return 0;
         }
     }
+
+    /** report the panels geometry based on WM_STRUT
+     * The returned rectangle is guaranteed to touch
+     * an edge of the root window rectangle.
+     */
+    Rectangle wmStrutGeometry() const {
+        if (wmStrut(WmStrut::top) > 0) {
+            // align with top edge
+            return Rectangle::fromCorners(
+                        wmStrut(WmStrut::top_start_x),
+                        0,
+                        wmStrut(WmStrut::top_end_x),
+                        wmStrut(WmStrut::top));
+        }
+        if (wmStrut(WmStrut::bottom) > 0) {
+            // align with bottom edge
+            return Rectangle::fromCorners(
+                        wmStrut(WmStrut::bottom_start_x),
+                        pm_.rootWindowGeometry_.height - wmStrut(WmStrut::bottom),
+                        wmStrut(WmStrut::bottom_end_x),
+                        pm_.rootWindowGeometry_.height);
+        }
+        if (wmStrut(WmStrut::left) > 0) {
+            // align with left edge
+            return Rectangle::fromCorners(
+                        0,
+                        wmStrut(WmStrut::left_start_y),
+                        wmStrut(WmStrut::left),
+                        wmStrut(WmStrut::left_start_y));
+        }
+        if (wmStrut(WmStrut::right) > 0) {
+            // align with right edge
+            return Rectangle::fromCorners(
+                        pm_.rootWindowGeometry_.width - wmStrut(WmStrut::right),
+                        wmStrut(WmStrut::right_start_y),
+                        pm_.rootWindowGeometry_.width,
+                        wmStrut(WmStrut::right_end_y));
+        }
+        return {0, 0, 0, 0};
+    };
 };
 
 PanelManager::PanelManager(XConnection& xcon)
@@ -110,9 +152,9 @@ void PanelManager::injectDependencies(Settings* settings)
  */
 bool PanelManager::updateReservedSpace(Panel* p, Rectangle size)
 {
-    auto optionalWmStrut = xcon_.getWindowPropertyCardinal(p->winid_, atomWmStrut_);
+    auto optionalWmStrut = xcon_.getWindowPropertyCardinal(p->winid_, atomWmStrutPartial_);
     if (!optionalWmStrut) {
-        optionalWmStrut= xcon_.getWindowPropertyCardinal(p->winid_, atomWmStrutPartial_);
+        optionalWmStrut= xcon_.getWindowPropertyCardinal(p->winid_, atomWmStrut_);
     }
     vector<long> wmStrut = optionalWmStrut.value_or(vector<long>());
     if (p->wmStrut_ != wmStrut || p->size_ != size) {
@@ -134,7 +176,17 @@ PanelManager::ReservedSpace PanelManager::computeReservedSpace(Rectangle mon)
     for (auto it : panels_) {
         Panel& p = *(it.second);
         ReservedSpace rs;
-        Rectangle intersection = mon.intersectionWith(p.size_);
+        Rectangle panelArea = p.wmStrutGeometry();
+        if (!panelArea) {
+            // if the panel does not define WmStrut,
+            // then take it's window geometry
+            panelArea = p.size_;
+        }
+        Rectangle intersection = mon.intersectionWith(panelArea);
+        HSDebug("checking panel %lx\n", p.winid_);
+        HSDebug("rect mon: %s\n", Converter<Rectangle>::str(mon).c_str());
+        HSDebug("rect panel: %s\n", Converter<Rectangle>::str(panelArea).c_str());
+        HSDebug("intersection: %s\n", Converter<Rectangle>::str(intersection).c_str());
         if (!intersection) {
             // monitor does not intersect with panel at all
             continue;
@@ -142,34 +194,28 @@ PanelManager::ReservedSpace PanelManager::computeReservedSpace(Rectangle mon)
         // we only reserve space for the panel if the panel defines
         // wmStrut_ or if the aspect ratio clearly indicates whether the
         // panel is horizontal or vertical
+        bool verticalPanel = p.wmStrut(WmStrut::left) > 0 || p.wmStrut(WmStrut::right) > 0;
+        bool horizontalPanel = p.wmStrut(WmStrut::top) > 0 || p.wmStrut(WmStrut::bottom) > 0;
         if (p.wmStrut_.empty()) {
-            // if the panel does not define wmStrut, then
-            // try to detect it automatically from the intersection
-            if (intersection.height > intersection.width) {
-                // vertical panels
-                if (intersection.x == mon.x) {
-                    rs.left_ = intersection.width;
-                }
-                if (intersection.br().x == mon.br().x) {
-                    rs.right_ = intersection.width;
-                }
+            // only fall back to aspect ratio if wmStrut is undefined
+            verticalPanel = intersection.height > intersection.width;
+            horizontalPanel = intersection.height < intersection.width;
+        }
+        if (verticalPanel) {
+            if (intersection.x == mon.x && intersection.width < mon.width) {
+                rs.left_ = intersection.width;
             }
-            if (intersection.height < intersection.width) {
-                // horizontal panels
-                if (intersection.y == mon.y) {
-                    rs.top_ = intersection.height;
-                }
-                if (intersection.br().y == mon.br().y) {
-                    rs.bottom_ = intersection.height;
-                }
+            if (intersection.br().x == mon.br().x && intersection.width < mon.width) {
+                rs.right_ = intersection.width;
             }
-        } else {
-            // if the panel explicitly defines wmStrut
-            // then simply use this
-            rs.left_ = p[WmStrut::left];
-            rs.right_ = p[WmStrut::right];
-            rs.top_ = p[WmStrut::top];
-            rs.bottom_ = p[WmStrut::bottom];
+        }
+        if (horizontalPanel) {
+            if (intersection.y == mon.y && intersection.height < mon.height) {
+                rs.top_ = intersection.height;
+            }
+            if (intersection.br().y == mon.br().y && intersection.height < mon.height) {
+                rs.bottom_ = intersection.height;
+            }
         }
         for (size_t i = 0; i < 4; i++) {
             rsTotal[i] = std::max(rsTotal[i], rs[i]);

--- a/src/panelmanager.cpp
+++ b/src/panelmanager.cpp
@@ -198,6 +198,8 @@ PanelManager::ReservedSpace PanelManager::computeReservedSpace(Rectangle mon)
             horizontalPanel = intersection.height < intersection.width;
         }
         if (verticalPanel) {
+            // don't affect the monitor, if the intersection spans
+            // the entire monitor width.
             if (intersection.x == mon.x && intersection.width < mon.width) {
                 rs.left_ = intersection.width;
             }
@@ -206,6 +208,8 @@ PanelManager::ReservedSpace PanelManager::computeReservedSpace(Rectangle mon)
             }
         }
         if (horizontalPanel) {
+            // don't affect the monitor, if the intersection spans
+            // the entire monitor height.
             if (intersection.y == mon.y && intersection.height < mon.height) {
                 rs.top_ = intersection.height;
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -511,12 +511,21 @@ def hlwm_spawner(tmpdir):
 
 
 @pytest.fixture()
-def xvfb():
+def xvfb(request):
     # start an Xvfb server (don't start Xephyr because
     # Xephyr requires another runnig xserver already).
     # also we add '-noreset' such that the server is not reset
     # when the last client connection is closed.
-    with MultiscreenDisplay(server='Xvfb', extra_args=['-noreset']) as xserver:
+    #
+    # the optional parameter is the resolution. If you want another resolution,
+    # then annotate the test case with:
+    #
+    #    @pytest.mark.parametrize("xvfb", [(1280, 1024)], indirect=True)
+    #
+    screens = [(800, 600)]
+    if hasattr(request, 'param'):
+        screens = [request.param]
+    with MultiscreenDisplay(server='Xvfb', screens=screens, extra_args=['-noreset']) as xserver:
         os.environ['DISPLAY'] = xserver.display
         yield xserver
 

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -1,7 +1,6 @@
 import pytest
 from Xlib import Xatom
-import conftest
-from conftest import MultiscreenDisplay
+
 
 class NET_WM_STRUT_PARTIAL:
     # the enum from _NET_WM_STRUT_PARTIAL in EWMH
@@ -18,6 +17,7 @@ class NET_WM_STRUT_PARTIAL:
     top_end_x = 9
     bottom_start_x = 10
     bottom_end_x = 11
+
 
 @pytest.mark.parametrize("which_pad, pad_size, geometry", [
     ("pad_left", 10, (-1, 0, 11, 400)),


### PR DESCRIPTION
The entries of WM_STRUT need to be interpreted with respect to the
borders of the root window (not of the monitor). The present change now
translates WM_STRUT into a rectangle which is then used to allocate
space at the monitor edge.

Only if WM_STRUT is empty, the geometry of the panel window is used as
the rectangle.

Formerly, we ignored WM_STRUT and always used the panel window, which
broke the support for panels that deliberately leave some space around
the panel. I originally took the window geometry, because 1. it was
easier (but as it turned out wronger) than computing the rectangle from
WM_STRUT and 2. this check for the case where the panel geometry and the
WM_STRUT were contradictory, as in #815.

This fixes #1110.
