### PR TITLE
Update monitor paddings if auto_detect_panels changes

### DIFF
--- a/src/panelmanager.cpp
+++ b/src/panelmanager.cpp
@@ -102,6 +102,9 @@ void PanelManager::geometryChanged(Window win, Rectangle geometry)
 void PanelManager::injectDependencies(Settings* settings)
 {
     settings_ = settings;
+    settings_->auto_detect_panels.changed().connect([this]() {
+        panels_changed_.emit();
+    });
 }
 
 /**

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -2,6 +2,28 @@ import pytest
 from Xlib import Xatom
 
 
+@pytest.mark.parametrize("value", [True, False])
+def test_auto_detect_panels(hlwm, x11, value):
+    hlwm.attr.settings.auto_detect_panels = hlwm.bool(value)
+
+    x11.create_client(geometry=(0, 0, 800, 30),
+                      window_type='_NET_WM_WINDOW_TYPE_DOCK')
+    expected = [
+        '30 0 0 0',
+        '0 0 0 0',
+        '30 0 0 0',
+        '0 0 0 0',
+        '30 0 0 0',
+    ]
+    if value is False:
+        expected = expected[1:]  # drop first element
+
+    for e in expected:
+        assert hlwm.call('list_padding').stdout.strip() == e
+
+        hlwm.attr.settings.auto_detect_panels = 'toggle'
+
+
 @pytest.mark.parametrize("which_pad, pad_size, geometry", [
     ("pad_left", 10, (-1, 0, 11, 400)),
     ("pad_right", 20, (800 - 20, 23, 20, 400)),


### PR DESCRIPTION
Automatically update the padding attributes of every monitor if the
setting auto_detect_panels is changed.