### PR TITLE
Fix typo in xftwidth

### DIFF
--- a/share/panel.sh
+++ b/share/panel.sh
@@ -31,7 +31,7 @@ if which textwidth &> /dev/null ; then
 elif which dzen2-textwidth &> /dev/null ; then
     textwidth="dzen2-textwidth";
 elif which xftwidth &> /dev/null ; then # For guix
-    textwidth="xtfwidth";
+    textwidth="xftwidth";
 else
     echo "This script requires the textwidth tool of the dzen2 project."
     exit 1


### PR DESCRIPTION
Insert the correct name of the xftwidth textwidth replacement. Now the
content of $textwidth matches the argument to `which`.

Thanks to Bohdan Potměkleč (tiosgz) for reporting. This fixes #1117.