### PR TITLE
Do not call restack() on raiseSlice()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -366,6 +366,7 @@ int raise_command(int argc, char** argv, Output output) {
     auto client = get_client(argv[1]);
     if (client) {
         client->raise();
+        client->needsRelayout.emit(client->tag());
     } else {
         auto window = get_window(argv[1]);
         if (window) {

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -151,9 +151,6 @@ void Stack::raiseSlice(Slice* slice) {
         layers_[layer].raise(slice);
     }
     dirty = true;
-    // TODO: maybe only update the specific range and not the entire stack
-    // update
-    restack();
 }
 
 void Stack::markDirty() {


### PR DESCRIPTION
When raising a slice in a stack, one should not directly forward the
changes to the X-Server, because often raiseSlice() is called multiple
times in a row.

After removing restack() from Stack::raiseSlice(), I've ensured that the
X window order is updated in the end anyway by searching for its
invokations. The raiseSlice() function itself is only called by
Client::raise(), which is called by the following functions:

  - In focus_client(), applyLayout() is called immediately after
    raise().
  - In Monitor::applyLayout(), restack() is called after raise()
  - In HSTag::cycleAllCommand(), the signal needsRelayout is emitted
    after raise() is called.
  - In raise_command(), I'm emitting the signal needsRelayout to ensure
    that the restacking takes place. In tiling mode however, the then
    called applyLayout() ensures that focused tiling window is visible
    (which is a good thing!), hence undoing the actual 'raise'; this
    made test_raise_client_already_on_top() fail in tiling mode which
    thus had to be adjusted. Actually, the present change even fixes a
    bug: when calling 'raise' on a non-focused window in a max layout,
    the focused window will be covered by the unrightfully (but as
    requested) raised window -- which does not happen anymore as
    verified by the new test case.

This fixes #1143.