### PR TITLE
Add colors to the object doc

### DIFF
--- a/doc/format-doc.py
+++ b/doc/format-doc.py
@@ -139,14 +139,14 @@ class ObjectDocPrinter:
         reference_cls_doc = self.reference_to_class_doc(clsname, path)
         if reference_cls_doc is not None:
             identifier, text = reference_cls_doc
-            print(f'(see <<{identifier},{text}>>)')
+            print(f'For attributes and children, see <<{identifier},{text}>>')
             return
         # otherwise, print it here:
         identifier = self.class_doc_id(clsname)
         depth = len(path)
 
         objdoc = self.jsondoc['objects'][clsname]
-        print(f'[[{identifier}]]')
+        print(f'[[{identifier}]]', end='' if depth > 1 else '\n')
         if 'doc' in objdoc:
             if depth > 1:
                 print(multiline_for_bulletitem(objdoc['doc']))
@@ -172,10 +172,12 @@ class ObjectDocPrinter:
             # both in html and in the man page output
             print(f"{ws_prefix}{bulletprefix}* '[datatype]#{attr['type']}#' *+[entryname]#{attr['name']}#+*{default_val}{docstr}")
         for _, child in objdoc['children'].items():
-            docstr = ': ' + child['doc'].strip() if 'doc' in child else ''
+            docstr = child['doc'].strip() if 'doc' in child else ''
             # class_doc = self.jsondoc['objects'][child['type']].get('doc', '')
-            if len(docstr) > 0 and not docstr.endswith('.'):
-                docstr += '.'
+            if len(docstr) > 0:
+                if not docstr.endswith('.'):
+                    docstr += '.'
+                docstr += ' '
             if depth > 0:
                 # add multiple format indicators, as for the
                 # attribute name above
@@ -189,7 +191,7 @@ class ObjectDocPrinter:
                 # at the moment
                 continue
             if child['type'] not in self.abstractclass:
-                print(f"{ws_prefix}{bulletprefix}{bullet} {itemname} {docstr} ", end='')
+                print(f"{ws_prefix}{bulletprefix}{bullet} {itemname}: {docstr}", end='')
                 self.run(child['type'], path=path + [child['name']])
             else:
                 for _, subclass in self.jsondoc['objects'].items():

--- a/doc/format-doc.py
+++ b/doc/format-doc.py
@@ -161,21 +161,25 @@ class ObjectDocPrinter:
             ws_prefix = depth * ' ' + '   '  # whitespace prefix
         for _, attr in objdoc['attributes'].items():
             if attr['default_value'] is not None:
-                default_val = '= ' + escape_string_value(attr['default_value'])
+                default_val = ' [defaultvalue]#= ' + escape_string_value(attr['default_value']) + '#'
             else:
                 default_val = ''
             if attr.get('doc', None) is not None:
-                docstr = attr.get('doc', None)
+                docstr = ': ' + attr.get('doc', None)
             else:
                 docstr = ''
-            print(f"{ws_prefix}{bulletprefix}* {attr['type']} +{attr['name']}+ {default_val} {docstr}")
+            # add multiple formats to the entry name such that the colors work
+            # both in html and in the man page output
+            print(f"{ws_prefix}{bulletprefix}* '[datatype]#{attr['type']}#' *+[entryname]#{attr['name']}#+*{default_val}{docstr}")
         for _, child in objdoc['children'].items():
             docstr = ': ' + child['doc'].strip() if 'doc' in child else ''
             # class_doc = self.jsondoc['objects'][child['type']].get('doc', '')
             if len(docstr) > 0 and not docstr.endswith('.'):
                 docstr += '.'
             if depth > 0:
-                itemname = f"+{child['name']}+"
+                # add multiple format indicators, as for the
+                # attribute name above
+                itemname = f"*+[entryname]#{child['name']}#+*"
                 bullet = '*'
             else:
                 itemname = f"{child['name']}"

--- a/www/main.css
+++ b/www/main.css
@@ -194,9 +194,22 @@ a:visited {
     font-weight: bold;
 }
 
-.code {
+code {
     font-family: monospace;
-    color: black;
+    color: #700718;
+}
+
+.entryname {
+    font-weight: normal;
+}
+
+.datatype {
+    color: #077024;
+    font-style: normal;
+}
+
+.defaultvalue {
+    color: #727272;
 }
 
 .screenshot img {


### PR DESCRIPTION
This adds colors to the attribute names and types and child names in the
object doc. Also, this inserts a colon between the attribute
specification and the doc string.

Moreover, 'code' is an html tag not a class, so main.css had to be
adjusted.