### PR TITLE
Fix frame objects in 'mirror' and 'rotate'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,7 @@ Current git version
       monitors.
     - Correctly handling minimized clients when removing a tag.
     - Preserve stacking order when changing the floating state of a tag
+    - Update frame objects correctly in the commands 'mirror' and 'rotate'
   * New dependencies: xft, freetype
 
 Release 0.9.1 on 2020-12-28

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -228,7 +228,7 @@ int FrameTree::rotateCommand() {
                 case SplitAlign::horizontal:
                     s->align_ = SplitAlign::vertical;
                     s->selection_ = s->selection_ ? 0 : 1;
-                    swap(s->a_, s->b_);
+                    s->swapChildren();
                     s->fraction_ = FixPrecDec::fromInteger(1) - s->fraction_;
                     break;
             }
@@ -264,7 +264,7 @@ int FrameTree::mirrorCommand(Input input, Output output)
                 || (dir == MD::Vertical && s->align_ == SplitAlign::vertical);
             if (mirror) {
                 s->selection_ = s->selection_ ? 0 : 1;
-                swap(s->a_, s->b_);
+                s->swapChildren();
                 s->fraction_ = FixPrecDec::fromInteger(1) - s->fraction_;
             }
         };

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1213,11 +1213,16 @@ def test_focused_frame_child(hlwm):
 
 
 def verify_frame_indices(hlwm, root='tags.focus.tiling.root', index=[]):
+    """traverse all frame objects under the given 'root' frame object
+    and verify that their 'index' attribute has the correct value according to
+    their path in the frame tree.
+    """
     path = root.rstrip('.') + '.' + '.'.join(index)
     assert hlwm.get_attr(path.rstrip('.') + '.index') == ''.join(index)
     if '0' in hlwm.list_children(path):
+        # if 'path' is a frame split object
         verify_frame_indices(hlwm, root=root, index=index + ['0'])
-        verify_frame_indices(hlwm, root=root, index=index + ['0'])
+        verify_frame_indices(hlwm, root=root, index=index + ['1'])
 
 
 @pytest.mark.parametrize("old,new", [

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1212,6 +1212,14 @@ def test_focused_frame_child(hlwm):
         assert hlwm.get_attr('tags.0.tiling.focused_frame.index') == focused_index
 
 
+def verify_frame_indices(hlwm, root='tags.focus.tiling.root', index=[]):
+    path = root.rstrip('.') + '.' + '.'.join(index)
+    assert hlwm.get_attr(path.rstrip('.') + '.index') == ''.join(index)
+    if '0' in hlwm.list_children(path):
+        verify_frame_indices(hlwm, root=root, index=index + ['0'])
+        verify_frame_indices(hlwm, root=root, index=index + ['0'])
+
+
 @pytest.mark.parametrize("old,new", [
     ('(split vertical:0.4:0 {a} {b})', '(split vertical:0.6:1 {b} {a})'),
     ('(split horizontal:0.3:0 {a} {b})', '(split horizontal:0.7:1 {b} {a})'),
@@ -1231,6 +1239,7 @@ def test_mirror_horizontal_or_vertical_one_split(hlwm, old, new, mode):
     else:
         expected = new.format(a=frame_a, b=frame_b)
     assert hlwm.call('dump').stdout == expected
+    verify_frame_indices(hlwm)
 
 
 @pytest.mark.parametrize("num_splits", [1, 2, 3, 4])
@@ -1242,6 +1251,7 @@ def test_mirror_vs_rotate(hlwm, num_splits):
 
     # compute the effect of rotating by 180 degrees
     hlwm.call('chain , rotate , rotate')
+    verify_frame_indices(hlwm)
     layout_after_rotate = hlwm.call('dump').stdout
     # restore original layout
     hlwm.call(['load', layout])
@@ -1250,6 +1260,7 @@ def test_mirror_vs_rotate(hlwm, num_splits):
     # flipping both horizontally and vertically
     hlwm.call('mirror both')
     assert layout_after_rotate == hlwm.call('dump').stdout
+    verify_frame_indices(hlwm)
 
 
 @pytest.mark.parametrize("direction, frameindex", [


### PR DESCRIPTION
The commands 'mirror' and 'rotate' updated the child frame pointers
explicitly without updating the pointers for the frame objects. Which
caused the frame object tree to be wrong.

The present change fixes this and adds a test for it.

Thanks to @astier for an excellent bug report on this!

Fixes #1151.