### PR TITLE
stack: Remove unused methods

### DIFF
--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -135,25 +135,10 @@ void Stack::extractWindows(bool real_clients, function<void(Window)> yield) {
     }
 }
 
-void Stack::restack() {
-    if (!dirty) {
-        return;
-    }
-    vector<Window> buf;
-    extractWindows(false, [&buf](Window w) { buf.push_back(w); });
-    XRestackWindows(g_display, buf.data(), buf.size());
-    dirty = false;
-    Ewmh::get().updateClientListStacking();
-}
-
 void Stack::raiseSlice(Slice* slice) {
     for (auto layer : slice->layers) {
         layers_[layer].raise(slice);
     }
-    dirty = true;
-}
-
-void Stack::markDirty() {
     dirty = true;
 }
 

--- a/src/stack.h
+++ b/src/stack.h
@@ -60,14 +60,12 @@ public:
     void insertSlice(Slice* elem);
     void removeSlice(Slice* elem);
     void raiseSlice(Slice* slice);
-    void markDirty();
     void sliceAddLayer(Slice* slice, HSLayer layer, bool insertOnTop = true);
     void sliceRemoveLayer(Slice* slice, HSLayer layer);
     bool isLayerEmpty(HSLayer layer);
     void clearLayer(HSLayer layer);
 
     void extractWindows(bool real_clients, std::function<void(Window)> yield);
-    void restack();
 
     PlainStack<Slice*> layers_[LAYER_COUNT];
 


### PR DESCRIPTION
Coverage and grep indicate that those methods are not used anymore.