### PR TITLE
Fix parallelism in cmake file for doc

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -5,8 +5,7 @@ add_custom_target("all_doc")
 function(gen_json_doc destfile)
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${destfile}.json")
     AUX_SOURCE_DIRECTORY("${CMAKE_CURRENT_SOURCE_DIR}/../src" CPPSRC)
-    add_custom_target("doc_json" DEPENDS ${dst})
-    add_dependencies(all_doc doc_json)
+    add_custom_target(gen_json_doc DEPENDS ${dst})
     add_custom_command(
         OUTPUT ${dst}
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py" --sourcedir "${CMAKE_CURRENT_SOURCE_DIR}/../src" --json > ${dst}
@@ -18,8 +17,7 @@ endfunction()
 function(gen_object_asciidoc jsonfile destfile)
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${destfile}")
     set(absjson "${CMAKE_CURRENT_BINARY_DIR}/${jsonfile}")
-    add_custom_target(doc_asciidoc_objects DEPENDS ${dst})
-    add_dependencies(all_doc doc_asciidoc_objects)
+    add_custom_target(gen_object_asciidoc DEPENDS ${dst} gen_json_doc)
     add_custom_command(
         OUTPUT ${dst}
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/format-doc.py" ${absjson} > ${dst}
@@ -29,26 +27,26 @@ endfunction()
 
 function(gen_manpage sourcefile man_nr)
     # additional arguments (${ARGN}) are passed as DEPENDS to the asciidoc command
-    set(src_orig "${CMAKE_CURRENT_SOURCE_DIR}/${sourcefile}.txt")
-    set(src "${CMAKE_CURRENT_BINARY_DIR}/${sourcefile}.txt")
+    set(src "${CMAKE_CURRENT_SOURCE_DIR}/${sourcefile}.txt")
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${sourcefile}.${man_nr}")
     STRING(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)
 
-    add_custom_target("doc_man_${sourcefile}" ALL DEPENDS ${dst})
+    # as a hack, every man page depends on gen_object_asciidoc, even though only
+    # 'herbstluftwm' needs it. We do this to avoid that hlwm-doc.json is built
+    # multiple times when make is invoked with -j8
+    add_custom_target("doc_man_${sourcefile}" ALL DEPENDS ${dst} gen_object_asciidoc)
     add_dependencies(all_doc "doc_man_${sourcefile}")
     add_custom_command(
         OUTPUT ${dst}
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
-        # asciidoc doesn't support destination directory for manpages
-        COMMAND ${CMAKE_COMMAND} -E copy ${src_orig} ${src}
         COMMAND ${ASCIIDOC_A2X}
                 --no-xmllint
                 -f manpage
                 -a \"herbstluftwmversion=herbstluftwm ${VERSION}\"
                 -a \"date=${BUILD_DATE}\"
                 -a \"builddir=${CMAKE_CURRENT_BINARY_DIR}\"
+                --destination-dir="${CMAKE_CURRENT_BINARY_DIR}"
                 ${src}
-        DEPENDS ${src_orig} ${ARGN}
+        DEPENDS ${ARGN}
         )
     install(FILES ${dst} DESTINATION "${MANDIR}/man${man_nr}")
 endfunction()
@@ -58,7 +56,11 @@ function(gen_html sourcefile)
     set(src "${CMAKE_CURRENT_SOURCE_DIR}/${sourcefile}.txt")
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${sourcefile}.html")
 
-    add_custom_target("doc_html_${sourcefile}" ALL DEPENDS ${dst})
+    # as a hack, every html doc depends on gen_object_asciidoc, even though only
+    # 'herbstluftwm' needs it. We do this to avoid that hlwm-doc.json is built
+    # multiple times when make is invoked with -j8
+    # 'herbstluftwm' needs it
+    add_custom_target("doc_html_${sourcefile}" ALL DEPENDS ${dst} gen_object_asciidoc)
     add_dependencies(all_doc "doc_html_${sourcefile}")
     add_custom_command(
         OUTPUT ${dst}
@@ -72,13 +74,12 @@ function(gen_html sourcefile)
     install(FILES ${dst} DESTINATION ${DOCDIR})
 endfunction()
 
-# always create a doc_json target, but only make it mandatory
-# if WITH_DOCUMENTATION is set
-gen_json_doc(hlwm-doc)
 
 if (WITH_DOCUMENTATION)
     find_program(ASCIIDOC_A2X NAMES a2x DOC "Path to AsciiDoc a2x command")
     find_program(ASCIIDOC NAMES asciidoc DOC "Path to AsciiDoc command")
+
+    gen_json_doc(hlwm-doc)
 
     gen_manpage(herbstclient 1)
     gen_manpage(herbstluftwm 1 "${CMAKE_CURRENT_BINARY_DIR}/hlwm-objects-gen.txt")
@@ -89,9 +90,6 @@ if (WITH_DOCUMENTATION)
     gen_html(herbstluftwm-tutorial)
 
     gen_object_asciidoc("hlwm-doc.json" "hlwm-objects-gen.txt")
-
-    # mark the doc_json target as mandatory
-    add_custom_target("doc_json_mandatory" ALL DEPENDS "doc_json")
 endif()
 
 # vim: et:ts=4:sw=4

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -5,7 +5,7 @@ add_custom_target("all_doc")
 function(gen_json_doc destfile)
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${destfile}.json")
     AUX_SOURCE_DIRECTORY("${CMAKE_CURRENT_SOURCE_DIR}/../src" CPPSRC)
-    add_custom_target(doc_json DEPENDS ${dst})
+    add_custom_target("doc_json" DEPENDS ${dst})
     add_custom_command(
         OUTPUT ${dst}
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py" --sourcedir "${CMAKE_CURRENT_SOURCE_DIR}/../src" --json > ${dst}
@@ -75,11 +75,13 @@ function(gen_html sourcefile)
 endfunction()
 
 
+# always create a doc_json target, but only make it mandatory
+# if WITH_DOCUMENTATION is set
+gen_json_doc(hlwm-doc)
+
 if (WITH_DOCUMENTATION)
     find_program(ASCIIDOC_A2X NAMES a2x DOC "Path to AsciiDoc a2x command")
     find_program(ASCIIDOC NAMES asciidoc DOC "Path to AsciiDoc command")
-
-    gen_json_doc(hlwm-doc)
 
     gen_manpage(herbstclient 1)
     gen_manpage(herbstluftwm 1 "${CMAKE_CURRENT_BINARY_DIR}/hlwm-objects-gen.txt")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -5,7 +5,7 @@ add_custom_target("all_doc")
 function(gen_json_doc destfile)
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${destfile}.json")
     AUX_SOURCE_DIRECTORY("${CMAKE_CURRENT_SOURCE_DIR}/../src" CPPSRC)
-    add_custom_target(gen_json_doc DEPENDS ${dst})
+    add_custom_target(doc_json DEPENDS ${dst})
     add_custom_command(
         OUTPUT ${dst}
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py" --sourcedir "${CMAKE_CURRENT_SOURCE_DIR}/../src" --json > ${dst}
@@ -17,7 +17,7 @@ endfunction()
 function(gen_object_asciidoc jsonfile destfile)
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${destfile}")
     set(absjson "${CMAKE_CURRENT_BINARY_DIR}/${jsonfile}")
-    add_custom_target(gen_object_asciidoc DEPENDS ${dst} gen_json_doc)
+    add_custom_target(gen_object_asciidoc DEPENDS ${dst} doc_json)
     add_custom_command(
         OUTPUT ${dst}
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/format-doc.py" ${absjson} > ${dst}


### PR DESCRIPTION
The intermediate generated files hlwm-doc.json and hlwm-object-doc.txt
were built multiple times when running 'make -j8' which regularly led to
build failures (run 'touch ../../src/clientmanager.cpp && make -j8' from
build/doc multiple times to reproduce, also note that the two mentioned
files are generated twice).

I first thought that the race condition leading to build failures was
fixed in de44c9ab19b5 (#1155), but the issue still existed.

I don't know whether this is by design of cmake or a bug in cmake.
Nevertheless, the present change works around this issue by creating
named targets for the files hlwm-doc.json and hlwm-object-doc.txt
because now, cmake recognizes the shared dependencies and only builds
them once (even with make -j8).

While at it, I've avoided that the asciidoc source files are copied to
the build directory by passing the --destination-dir to a2x. (Not sure
whether this is a new feature of a2x or whether this simply was missed
when the cmake config was originally written).