### PR TITLE
Explicitly invoke example.py from bindings

### DIFF
--- a/tests/test_python_binds.py
+++ b/tests/test_python_binds.py
@@ -2,11 +2,15 @@ import pytest
 import os.path
 import subprocess
 import sys
+import os
+import conftest
 
 
 def test_example(hlwm):
     # test the example.py shipped with the bindings
     example_py = os.path.join(os.path.dirname(__file__), '..', 'python', 'herbstluftwm', 'example.py')
+    # make 'herbstclient' binary available in the PATH
+    os.environ['PATH'] = conftest.BINDIR + ':' + os.environ['PATH']
     assert subprocess.call([sys.executable, example_py]) == 0
 
 

--- a/tests/test_python_binds.py
+++ b/tests/test_python_binds.py
@@ -1,10 +1,13 @@
 import pytest
-import herbstluftwm.example
+import os.path
+import subprocess
+import sys
 
 
 def test_example(hlwm):
     # test the example.py shipped with the bindings
-    herbstluftwm.example.main(hlwm)
+    example_py = os.path.join(os.path.dirname(__file__), '..', 'python', 'herbstluftwm', 'example.py')
+    assert subprocess.call([sys.executable, example_py]) == 0
 
 
 def test_attr_get(hlwm):


### PR DESCRIPTION
Instead of importing it, just invoke example.py as one would from the
command line. Also this will make it easier to adjust the path (#1136).