### PR TITLE
Re-use pre-built doc in tarball builds

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -180,7 +180,8 @@ jobs:
           cd herbstluftwm-*/build/
           mkdir -v -p $DESTDIR
           ninja -v install
-          find $DESTDIR
+          # check that the man page has been installed:
+          find -printf '%P\n' $DESTDIR | grep 'herbstluftwm\.1'
 
   diff-objects:
     name: Diff object tree

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -152,8 +152,8 @@ jobs:
         run: |
           cd herbstluftwm-*/doc/
           echo Checking that generated file have at least 10 lines
-          [[ "$(wc -l hlwm-objects-gen.txt)" -gt 10 ]]
-          [[ "$(wc -l hlwm-doc.json)" -gt 10 ]]
+          test "$(wc -l hlwm-objects-gen.txt|cut -d' ' -f1)" -gt 10 || exit 1
+          test "$(wc -l hlwm-doc.json|cut -d' ' -f1)" -gt 10 || exit 1
 
       - name: Build
         env:

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -181,7 +181,7 @@ jobs:
           mkdir -v -p $DESTDIR
           ninja -v install
           # check that the man page has been installed:
-          find -printf '%P\n' $DESTDIR | grep 'herbstluftwm\.1'
+          find $DESTDIR -printf '%P\n' -name 'herbstluftwm.1'
 
   diff-objects:
     name: Diff object tree

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -181,7 +181,7 @@ jobs:
           mkdir -v -p $DESTDIR
           ninja -v install
           # check that the man page has been installed:
-          find $DESTDIR -printf '%P\n' -name 'herbstluftwm.1'
+          find $DESTDIR -name 'herbstluftwm.1' -printf '%P\n' | grep . # grep for the right exit-status
 
   diff-objects:
     name: Diff object tree

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -173,6 +173,15 @@ jobs:
           ccache -s
           find ~/.ccache | wc -l
 
+      - name: Install
+        env:
+          DESTDIR: ${{ github.workspace }}/install-herbstluftwm/
+        run: |
+          cd herbstluftwm-*/build/
+          mkdir -v -p $DESTDIR
+          ninja -v install
+          find $DESTDIR
+
   diff-objects:
     name: Diff object tree
     runs-on: ubuntu-latest

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -245,3 +245,10 @@ jobs:
           cd www/
           make 2> >(tee asciidoc-stderr.log)
           ! grep WARNING asciidoc-stderr.log # grep must not find warnings
+      - name: build source tarball
+        run: |
+          builddir=$BUILD ci/mktar.sh
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: herbstluftwm*.tar.gz

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -144,9 +144,16 @@ jobs:
           restore-keys: |
             ccache-gcc-ancient-
 
-      - name: List files
+      - name: Extract tarball
         run: |
-          find
+          tar xvf artifact/herbstluftwm*.tar.gz
+
+      - name: Sanity check tarball content
+        run: |
+          cd herbstluftwm-*/doc/
+          echo Checking that generated file have at least 10 lines
+          [[ "$(wc -l hlwm-objects-gen.txt)" -gt 10 ]]
+          [[ "$(wc -l hlwm-doc.json)" -gt 10 ]]
 
       - name: Build
         env:
@@ -155,14 +162,14 @@ jobs:
           CXXFLAGS: -m32
           CFLAGS: -m32
         run: |
+          cd herbstluftwm-*/
           find ~/.ccache | wc -l
           ccache -z --max-size=500M
           # ccache too old for --show-config
           mkdir build
           cd build
-          cmake -GNinja -DWITH_DOCUMENTATION=NO -DENABLE_CCACHE=YES ..
+          cmake -GNinja -DENABLE_CCACHE=YES ..
           ninja -v -k10
-          ninja -v doc_json
           ccache -s
           find ~/.ccache | wc -l
 

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -130,9 +130,11 @@ jobs:
     name: Build for 32bit with ancient GCC on Ubuntu 14.04
     runs-on: ubuntu-latest
     container: hlwm/ci:trusty
+    needs: build-doc  # using the tarball
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: Download source tarball
+        uses: actions/download-artifact@v2
+        # we do not specify a name, hence all artifacts are downloaded
 
       - uses: actions/cache@v1
         name: Cache ~/.ccache
@@ -141,6 +143,10 @@ jobs:
           key: ccache-gcc-ancient-${{ github.run_number }}
           restore-keys: |
             ccache-gcc-ancient-
+
+      - name: List files
+        run: |
+          find
 
       - name: Build
         env:

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@
 
 VERSION = $(shell cat VERSION)
 
-TARFILE = herbstluftwm-$(VERSION).tar
-
-.PHONY: all all-nodoc doc tar
+.PHONY: all all-nodoc doc
 
 BUILDDIR = build
 
@@ -18,13 +16,3 @@ $(BUILDDIR):
 
 clean:
 	rm -r $(BUILDDIR)/
-
-doc: $(BUILDDIR)
-	cd $(BUILDDIR)/doc && $(MAKE)
-
-tar: doc
-	git archive --prefix=herbstluftwm-$(VERSION)/ -o $(TARFILE) HEAD
-	tar --transform="flags=r;s,$(BUILDDIR),herbstluftwm-$(VERSION),"  --owner=0 --group=0 \
-		-uvf $(TARFILE) $(BUILDDIR)/doc/*.{html,json} $(BUILDDIR)/doc/*.[1-9]
-	gzip $(TARFILE)
-	gpg --detach-sign $(TARFILE).gz

--- a/ci/mktar.sh
+++ b/ci/mktar.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+# create a source tarball including pre-built documentation
+builddir=${builddir:-build}
+version=${version:-$(git describe|sed 's,^v,,')}
+tarname=${tarname:-herbstluftwm-$version}
+
+::() {
+    echo -e "\e[1;33m:: \e[0;32m$*\e[0m" >&2
+    "$@"
+}
+
+# we first create a .tar file and then gzip it because otherwise
+# we can't add additional files to the tar
+
+# take the git source files
+:: git archive --prefix=$tarname/ -o ${tarname}.tar HEAD
+
+# add compiled documentation
+:: tar --transform="flags=r;s,${builddir}/,${tarname}/,"  \
+    --owner=0 --group=0 \
+    -uvf ${tarname}.tar ${builddir}/doc/*.{html,json,[1-9]}
+
+:: gzip ${tarname}.tar
+
+echo To sign the tarball, run: gpg --detach-sign ${tarname}.tar.gz >&2

--- a/ci/mktar.sh
+++ b/ci/mktar.sh
@@ -3,8 +3,9 @@
 set -e
 
 # create a source tarball including pre-built documentation
-builddir=${builddir:-build}
-version=${version:-$(git describe|sed 's,^v,,')}
+gitroot=${gitroot:-$(git rev-parse --show-toplevel)}
+builddir=${builddir:-"${gitroot}/build/"}
+version=${version:-$(< "${gitroot}/VERSION")}
 tarname=${tarname:-herbstluftwm-$version}
 
 ::() {
@@ -16,13 +17,13 @@ tarname=${tarname:-herbstluftwm-$version}
 # we can't add additional files to the tar
 
 # take the git source files
-:: git archive --prefix=$tarname/ -o ${tarname}.tar HEAD
+:: git archive --prefix="$tarname/" -o "${tarname}".tar HEAD
 
 # add compiled documentation
 :: tar --transform="flags=r;s,${builddir}/,${tarname}/,"  \
     --owner=0 --group=0 \
-    -uvf ${tarname}.tar ${builddir}/doc/*.{html,json,[1-9]}
+    -uvf "${tarname}.tar" "${builddir}"/doc/*.{html,json,[1-9]}
 
-:: gzip ${tarname}.tar
+:: gzip "${tarname}.tar"
 
-echo To sign the tarball, run: gpg --detach-sign ${tarname}.tar.gz >&2
+echo To sign the tarball, run: gpg --detach-sign "${tarname}.tar.gz" >&2

--- a/ci/mktar.sh
+++ b/ci/mktar.sh
@@ -22,7 +22,7 @@ tarname=${tarname:-herbstluftwm-$version}
 # add compiled documentation
 :: tar --transform="flags=r;s,${builddir}/,${tarname}/,"  \
     --owner=0 --group=0 \
-    -uvf "${tarname}.tar" "${builddir}"/doc/*.{html,json,[1-9]}
+    -uvf "${tarname}.tar" "${builddir}"/doc/{*.{html,json,[1-9]},*-gen.txt}
 
 :: gzip "${tarname}.tar"
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -38,12 +38,12 @@ function(gen_object_asciidoc jsonfile destfile)
     set(absjson "${CMAKE_CURRENT_BINARY_DIR}/${jsonfile}")
     add_custom_target(gen_object_asciidoc DEPENDS ${dst} doc_json)
     if (COPY_DOCUMENTATION)
-        # the object doc is not installed, so also is not shipped
-        # in the source tarball, so let us just pretend it's in the build directory
+        set(dst_prebuilt "${CMAKE_CURRENT_SOURCE_DIR}/${destfile}")
         add_custom_command(
             OUTPUT ${dst}
-            COMMAND ${CMAKE_COMMAND} -E touch ${dst}
-            COMMENT "Touching ${dst}"
+            COMMAND ${CMAKE_COMMAND} -E copy ${dst_prebuilt} ${dst}
+            DEPENDS ${dst_prebuilt}
+            COMMENT "Using pre-built ${dst_prebuilt}"
             )
     else()
         add_custom_command(

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,16 +1,35 @@
 option(WITH_DOCUMENTATION "Build with documentation" ON)
 
+# don't rebuilt but instead only copy the documentation if hlwm-doc.json exists
+# in the source directory
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/hlwm-doc.json")
+    set(doc_exists_in_src ON)
+else()
+    set(doc_exists_in_src OFF)
+endif()
+option(COPY_DOCUMENTATION "Use pre-built documentation (only available in tarballs)" ${doc_exists_in_src})
+
 add_custom_target("all_doc")
 
 function(gen_json_doc destfile)
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${destfile}.json")
     AUX_SOURCE_DIRECTORY("${CMAKE_CURRENT_SOURCE_DIR}/../src" CPPSRC)
     add_custom_target("doc_json" DEPENDS ${dst})
-    add_custom_command(
-        OUTPUT ${dst}
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py" --sourcedir "${CMAKE_CURRENT_SOURCE_DIR}/../src" --json > ${dst}
-        DEPENDS ${CPPSRC} "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py"
-        )
+    if (COPY_DOCUMENTATION)
+        set(dst_prebuilt "${CMAKE_CURRENT_SOURCE_DIR}/${destfile}.json")
+        add_custom_command(
+            OUTPUT ${dst}
+            COMMAND ${CMAKE_COMMAND} -E copy ${dst_prebuilt} ${dst}
+            DEPENDS ${dst_prebuilt}
+            COMMENT "Using pre-built ${dst_prebuilt}"
+            )
+    else()
+        add_custom_command(
+            OUTPUT ${dst}
+            COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py" --sourcedir "${CMAKE_CURRENT_SOURCE_DIR}/../src" --json > ${dst}
+            DEPENDS ${CPPSRC} "${CMAKE_CURRENT_SOURCE_DIR}/gendoc.py"
+            )
+    endif()
     install(FILES ${dst} DESTINATION ${DOCDIR} OPTIONAL)
 endfunction()
 
@@ -18,11 +37,21 @@ function(gen_object_asciidoc jsonfile destfile)
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${destfile}")
     set(absjson "${CMAKE_CURRENT_BINARY_DIR}/${jsonfile}")
     add_custom_target(gen_object_asciidoc DEPENDS ${dst} doc_json)
-    add_custom_command(
-        OUTPUT ${dst}
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/format-doc.py" ${absjson} > ${dst}
-        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/format-doc.py" ${absjson}
-        )
+    if (COPY_DOCUMENTATION)
+        # the object doc is not installed, so also is not shipped
+        # in the source tarball, so let us just pretend it's in the build directory
+        add_custom_command(
+            OUTPUT ${dst}
+            COMMAND ${CMAKE_COMMAND} -E touch ${dst}
+            COMMENT "Touching ${dst}"
+            )
+    else()
+        add_custom_command(
+            OUTPUT ${dst}
+            COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/format-doc.py" ${absjson} > ${dst}
+            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/format-doc.py" ${absjson}
+            )
+    endif()
 endfunction()
 
 function(gen_manpage sourcefile man_nr)
@@ -36,18 +65,28 @@ function(gen_manpage sourcefile man_nr)
     # multiple times when make is invoked with -j8
     add_custom_target("doc_man_${sourcefile}" ALL DEPENDS ${dst} gen_object_asciidoc)
     add_dependencies(all_doc "doc_man_${sourcefile}")
-    add_custom_command(
-        OUTPUT ${dst}
-        COMMAND ${ASCIIDOC_A2X}
-                --no-xmllint
-                -f manpage
-                -a \"herbstluftwmversion=herbstluftwm ${VERSION}\"
-                -a \"date=${BUILD_DATE}\"
-                -a \"builddir=${CMAKE_CURRENT_BINARY_DIR}\"
-                --destination-dir="${CMAKE_CURRENT_BINARY_DIR}"
-                ${src}
-        DEPENDS ${ARGN}
-        )
+    if (COPY_DOCUMENTATION)
+        set(dst_prebuilt "${CMAKE_CURRENT_SOURCE_DIR}/${sourcefile}.${man_nr}")
+        add_custom_command(
+            OUTPUT ${dst}
+            COMMAND ${CMAKE_COMMAND} -E copy ${dst_prebuilt} ${dst}
+            DEPENDS ${dst_prebuilt}
+            COMMENT "Using pre-built ${dst_prebuilt}"
+            )
+    else()
+        add_custom_command(
+            OUTPUT ${dst}
+            COMMAND ${ASCIIDOC_A2X}
+                    --no-xmllint
+                    -f manpage
+                    -a \"herbstluftwmversion=herbstluftwm ${VERSION}\"
+                    -a \"date=${BUILD_DATE}\"
+                    -a \"builddir=${CMAKE_CURRENT_BINARY_DIR}\"
+                    --destination-dir="${CMAKE_CURRENT_BINARY_DIR}"
+                    ${src}
+            DEPENDS ${ARGN}
+            )
+    endif()
     install(FILES ${dst} DESTINATION "${MANDIR}/man${man_nr}")
 endfunction()
 
@@ -62,15 +101,25 @@ function(gen_html sourcefile)
     # 'herbstluftwm' needs it
     add_custom_target("doc_html_${sourcefile}" ALL DEPENDS ${dst} gen_object_asciidoc)
     add_dependencies(all_doc "doc_html_${sourcefile}")
-    add_custom_command(
-        OUTPUT ${dst}
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
-        COMMAND ${ASCIIDOC}
-                    -o ${dst}
-                    -a \"builddir=${CMAKE_CURRENT_BINARY_DIR}\"
-                    ${src}
-        DEPENDS ${src} ${ARGN}
-        )
+    if (COPY_DOCUMENTATION)
+        set(dst_prebuilt "${CMAKE_CURRENT_SOURCE_DIR}/${sourcefile}.html")
+        add_custom_command(
+            OUTPUT ${dst}
+            COMMAND ${CMAKE_COMMAND} -E copy ${dst_prebuilt} ${dst}
+            DEPENDS ${dst_prebuilt}
+            COMMENT "Using pre-built ${dst_prebuilt}"
+            )
+    else()
+        add_custom_command(
+            OUTPUT ${dst}
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
+            COMMAND ${ASCIIDOC}
+                        -o ${dst}
+                        -a \"builddir=${CMAKE_CURRENT_BINARY_DIR}\"
+                        ${src}
+            DEPENDS ${src} ${ARGN}
+            )
+    endif()
     install(FILES ${dst} DESTINATION ${DOCDIR})
 endfunction()
 
@@ -80,8 +129,10 @@ endfunction()
 gen_json_doc(hlwm-doc)
 
 if (WITH_DOCUMENTATION)
-    find_program(ASCIIDOC_A2X NAMES a2x DOC "Path to AsciiDoc a2x command")
-    find_program(ASCIIDOC NAMES asciidoc DOC "Path to AsciiDoc command")
+    if (NOT COPY_DOCUMENTATION)
+        find_program(ASCIIDOC_A2X NAMES a2x DOC "Path to AsciiDoc a2x command")
+        find_program(ASCIIDOC NAMES asciidoc DOC "Path to AsciiDoc command")
+    endif()
 
     gen_manpage(herbstclient 1)
     gen_manpage(herbstluftwm 1 "${CMAKE_CURRENT_BINARY_DIR}/hlwm-objects-gen.txt")


### PR DESCRIPTION
In source tarballs, the built documentation is already shipped along
with the tarball. The CMakeLists of doc now detects a prebuilt
documentation, and in this case simply copies the documentation to the
build directory (without requiring asciidoc to be installed).

This implies that one does not need to (and in fact should not) disable
`WITH_DOCUMENTATION` when building a tarball without having asciidoc
installed.

In the CI job for the docs, the tarball is now built and tested. In the
ancient ubuntu build, this tarball is used instead of the source from
the git repo. To be sure that everything worked, the job verifies that
the man page has been installed to the DESTDIR.
