### PR TITLE
Respect VERSION in CI build of docs

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -248,6 +248,7 @@ jobs:
         run: |
           cat > CMakeLists.txt <<EOF
           project(Herbstluftwm)
+          file(STRINGS VERSION VERSION) # read file 'VERSION'
           set(DOCDIR /tmp/)
           set(MANDIR /tmp/)
           add_subdirectory(doc)


### PR DESCRIPTION
In the minimalist CMakeLists for the ci build of the docs, the VERSION
file was not yet considered. However, it is needed for the footnote at
the end of the man pages.