### PR TITLE
Fix transparency of 32 bit client's border

### DIFF
--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -296,16 +296,18 @@ void Decoration::redraw()
     }
 }
 
-unsigned int Decoration::get_client_color(Color color) {
+unsigned long Decoration::get_client_color(Color color) {
     XColor xcol = color.toXColor();
     if (colormap) {
         /* get pixel value back appropriate for client */
         XAllocColor(g_display, colormap, &xcol);
-        return xcol.pixel;
+        // explicitly set the alpha-byte to 0xff (fully opaque)
+        return xcol.pixel | (0xffu << 24);
     } else {
         /* get pixel value back appropriate for main color map*/
         XAllocColor(g_display, DefaultColormap(g_display, g_screen), &xcol);
-        return xcol.pixel;
+        // explicitly set the alpha-byte to 0xff (fully opaque)
+        return xcol.pixel | (0xffu << 24);
     }
 }
 

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -36,7 +36,7 @@ public:
 private:
     void redrawPixmap();
     void updateFrameExtends();
-    unsigned int get_client_color(Color color);
+    unsigned long get_client_color(Color color);
 
     Window                  decwin = 0; // the decoration window
     const DecorationScheme* last_scheme = {};


### PR DESCRIPTION
When using a compositor (e.g. compton or picom), the border of some
windows is sometimes (undesirably) semitransparent for applications with
alpha settings (e.g. sakura or katarakt). This only happens for certain
graphics, I can reproduce it on intel graphics but not on nvidia
chipsets. The issue is probably that the highest significant byte of the
color is not initialized.

In the present patch, this byte is set to 0xff, thus fixing the
byte controling alpha-value to 'fully opaque'. This also used by dwm[1]
and wmutils[2] to fix this issue.

While at it, the return type of get_client_color() is turned into
'unsigned long' because this is the type of xcol.pixel.

This fixes #1173 / #992 

[1] https://dwm.suckless.org/patches/alpha/dwm-fixborders-6.2.diff
[2] https://github.com/wmutils/opt/issues/48#issuecomment-667541248