### PR TITLE
Move the tiling part of 'shift' to FrameTree

### DIFF
--- a/src/frametree.h
+++ b/src/frametree.h
@@ -40,6 +40,7 @@ public:
     //! focus a frame within its tree
     static void focusFrame(std::shared_ptr<Frame> frame);
     bool focusInDirection(Direction dir, bool externalOnly);
+    bool shiftInDirection(Direction direction, bool externalOnly);
     //! return a frame in the tree that holds the client
     std::shared_ptr<FrameLeaf> findFrameWithClient(Client* client);
 


### PR DESCRIPTION
In order to pave the way for #1066, move all the frame-specific code of
the `shift` command to the FrameTree class (where it actually belongs).

No tests are needed because test_layout.py has already enough tests for
the `shift` command.