### PR TITLE
Prepare Colors for alpha values

### DIFF
--- a/src/decoration.h
+++ b/src/decoration.h
@@ -10,6 +10,7 @@
 class Client;
 class Settings;
 class DecorationScheme;
+class XConnection;
 
 class Decoration {
 public:

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -10,7 +10,6 @@
 class Client;
 class Settings;
 class DecorationScheme;
-class XConnection;
 
 class Decoration {
 public:

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -11,7 +11,7 @@
 class Color {
 public:
     Color();
-    Color(XColor xcol);
+    Color(XColor xcol, unsigned short alpha = 0xff);
     Color(std::string name);
 
     static Color black();
@@ -27,7 +27,8 @@ public:
     bool operator==(const Color& other) const {
         return red_ == other.red_
             && green_ == other.green_
-            && blue_ == other.blue_;
+            && blue_ == other.blue_
+            && alpha_ == other.alpha_;
     };
     bool operator!=(const Color& other) const {
         return !operator==(other);
@@ -40,6 +41,7 @@ public:
     unsigned short red_ = 0;
     unsigned short green_ = 0;
     unsigned short blue_ = 0;
+    unsigned short alpha_ = 0xff; // 0 is fully transparent, 0xff is fully opaque
 
 private:
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,53 @@
+def test_color_rgb(hlwm):
+    hlwm.attr.theme.color = '#9fbc00'
+    assert hlwm.attr.theme.color() == '#9fbc00'
+
+
+def test_color_rgba(hlwm):
+    hlwm.attr.theme.color = '#9fbc0043'
+    assert hlwm.attr.theme.color() == '#9fbc0043'
+
+    hlwm.attr.theme.color = '#9fbc12ab'
+    assert hlwm.attr.theme.color() == '#9fbc12ab'
+    hlwm.call('compare theme.color = #9fbc12ab')
+    hlwm.call('compare theme.color != #9fbc12ba')
+    hlwm.call('compare theme.color != #9fbc13ab')
+
+    hlwm.attr.theme.color = '#9fbc3300'
+    assert hlwm.attr.theme.color() == '#9fbc3300'
+    hlwm.call('compare theme.color = #9fbc3300')
+    hlwm.call('compare theme.color != #9fbc33')
+
+    hlwm.attr.theme.color = '#9fbc00ff'
+    # no transparency is simplified to a normal rgb value:
+    assert hlwm.attr.theme.color() == '#9fbc00'
+    hlwm.call('compare theme.color = #9fbc00')
+    hlwm.call('compare theme.color = #9fbc00ff')
+    hlwm.call('compare theme.color != #9fbc00f0')
+
+
+def test_color_invalid(hlwm):
+    hlwm.call_xfail('set_attr theme.color #9xbc00') \
+        .expect_stderr('cannot allocate color')
+
+    hlwm.call_xfail('set_attr theme.color lilablassblau') \
+        .expect_stderr('cannot allocate color')
+
+    hlwm.call_xfail('set_attr theme.color #9fbc000') \
+        .expect_stderr('cannot allocate color')
+
+    hlwm.call_xfail('set_attr theme.color #9fbc00x') \
+        .expect_stderr('cannot allocate color')
+
+    hlwm.call_xfail('set_attr theme.color #9fbc00fg') \
+        .expect_stderr('invalid alpha')
+
+    hlwm.call_xfail('set_attr theme.color #9fbc00-3') \
+        .expect_stderr('invalid alpha')
+
+
+def test_color_names(hlwm):
+    colors = [('red', '#ff0000'), ('green', '#00ff00'), ('blue', '#0000ff')]
+    for name, rgb in colors:
+        hlwm.attr.theme.color = name
+        assert hlwm.attr.theme.color() == rgb


### PR DESCRIPTION
Extend Color by a alpha value and extend the parser and printer to print
colors in the #rrggbbaa format. The alpha value is not used anywhere at
the moment, but it will come in handy for decoration drawing.

Also, this adds a new test suite file dedicated to all the type parsers
and printers.