### PR TITLE
Migrate tag_status to new GlobalCommands module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(herbstluftwm PRIVATE
     frameparser.h frameparser.cpp
     frametree.h frametree.cpp
     globals.h
+    globalcommands.cpp globalcommands.h
     hlwmcommon.cpp hlwmcommon.h
     hook.cpp hook.h
     indexingobject.h

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -88,7 +88,6 @@ struct {
     { "dump",           3,  no_completion },
     { "load",           3,  no_completion },
     { "load",           2,  first_parameter_is_tag },
-    { "tag_status",     2,  no_completion },
     { "object_tree",    2,  no_completion },
 };
 
@@ -144,7 +143,6 @@ struct {
     { "name_monitor",   EQ, 1,  complete_against_monitors, 0 },
     { "monitor_rect",   EQ, 1,  complete_against_monitors, 0 },
     { "pad",            EQ, 1,  complete_against_monitors, 0 },
-    { "tag_status",     EQ, 1,  complete_against_monitors, 0 },
 };
 
 // Implementation of CommandBinding

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -1,9 +1,9 @@
 #include "globalcommands.h"
 
 #include "argparse.h"
-#include "root.h"
 #include "monitor.h"
 #include "monitormanager.h"
+#include "root.h"
 #include "tag.h"
 #include "tagmanager.h"
 

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -1,0 +1,67 @@
+#include "globalcommands.h"
+
+#include "argparse.h"
+#include "root.h"
+#include "monitor.h"
+#include "monitormanager.h"
+#include "tag.h"
+#include "tagmanager.h"
+
+using std::string;
+
+GlobalCommands::GlobalCommands(Root& root)
+    : root_(root)
+{
+}
+
+int GlobalCommands::tagStatusCommand(Input input, Output output)
+{
+    string monitorStr = "";
+    ArgParse argparse = ArgParse().optional(monitorStr);
+    if (argparse.parsingAllFails(input, output)) {
+        return argparse.exitCode();
+    }
+    Monitor* monitor = root_.monitors->byString(monitorStr);
+    if (!monitor) {
+        output << input.command() << ": Monitor \"" << monitorStr << "\" not found!\n";
+        return HERBST_INVALID_ARGUMENT;
+    }
+    tag_update_flags();
+    output << '\t';
+    for (size_t i = 0; i < root_.tags->size(); i++) {
+        HSTag* tag = root_.tags->byIdx(i);
+        // print flags
+        char c = '.';
+        if (tag->flags & TAG_FLAG_USED) {
+            c = ':';
+        }
+        Monitor* tag_monitor = root_.monitors->byTag(tag);
+        if (tag_monitor == monitor) {
+            c = '+';
+            if (monitor == get_current_monitor()) {
+                c = '#';
+            }
+        } else if (tag_monitor) {
+            c = '-';
+            if (get_current_monitor() == tag_monitor) {
+                c = '%';
+            }
+        }
+        if (tag->flags & TAG_FLAG_URGENT) {
+            c = '!';
+        }
+        output << c;
+        output << *tag->name;
+        output << '\t';
+    }
+    return 0;
+}
+
+void GlobalCommands::tagStatusCompletion(Completion& complete)
+{
+    if (complete == 0) {
+        root_.monitors->completeMonitorName(complete);
+    } else {
+        complete.none();
+    }
+}

--- a/src/globalcommands.h
+++ b/src/globalcommands.h
@@ -1,0 +1,25 @@
+#ifndef GLOBALCOMMANDS_H
+#define GLOBALCOMMANDS_H
+
+#include "commandio.h"
+
+class Root;
+
+/**
+ * @brief The GlobalCommands class collects commands
+ * that affect the global state of hlwm and that inspect
+ * its structure. Hence, this requires a Root reference
+ * (in contrast to MetaCommands which only require a
+ * reference of type Object)
+ */
+class GlobalCommands
+{
+public:
+    GlobalCommands(Root& root);
+    int tagStatusCommand(Input input, Output output);
+    void tagStatusCompletion(Completion& complete);
+private:
+    Root& root_;
+};
+
+#endif // GLOBALCOMMANDS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,7 +157,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
         {"pseudotile",     {clients, &ClientManager::pseudotile_cmd,
                                      &ClientManager::pseudotile_complete}},
         {"tag_status",     {global_cmds, &GlobalCommands::tagStatusCommand,
-                                          &GlobalCommands::tagStatusCompletion}},
+                                         &GlobalCommands::tagStatusCompletion}},
         {"merge_tag",      BIND_OBJECT(tags, removeTag)},
         {"rename",         BIND_OBJECT(tags, tag_rename_command) },
         {"move",           BIND_OBJECT(tags, tag_move_window_command) },

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include "ewmh.h"
 #include "fontdata.h"
 #include "frametree.h"
+#include "globalcommands.h"
 #include "globals.h"
 #include "hook.h"
 #include "ipc-protocol.h"
@@ -59,7 +60,6 @@ static XMainLoop* g_main_loop = nullptr;
 
 int quit();
 int version(Output output);
-int print_tag_status_command(int argc, char** argv, Output output);
 void execute_autostart_file();
 int raise_command(int argc, char** argv, Output output);
 int spawn(int argc, char** argv);
@@ -70,6 +70,7 @@ int jumpto_command(int argc, char** argv, Output output);
 
 unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
     MetaCommands* meta_commands = root->meta_commands.get();
+    GlobalCommands* global_cmds = root->global_commands.get();
 
     ClientManager* clients = root->clients();
     KeyManager *keys = root->keys();
@@ -155,7 +156,8 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                      &ClientManager::fullscreen_complete}},
         {"pseudotile",     {clients, &ClientManager::pseudotile_cmd,
                                      &ClientManager::pseudotile_complete}},
-        {"tag_status",     print_tag_status_command},
+        {"tag_status",     {global_cmds, &GlobalCommands::tagStatusCommand,
+                                          &GlobalCommands::tagStatusCompletion}},
         {"merge_tag",      BIND_OBJECT(tags, removeTag)},
         {"rename",         BIND_OBJECT(tags, tag_rename_command) },
         {"move",           BIND_OBJECT(tags, tag_move_window_command) },
@@ -253,48 +255,6 @@ int version(Output output) {
     output << "Released under the Simplified BSD License" << endl;
     for (const auto& d : MonitorDetection::detectors()) {
         output << d.name_ << " support: " << (d.detect_ ? "on" : "off") << endl;
-    }
-    return 0;
-}
-
-int print_tag_status_command(int argc, char** argv, Output output) {
-    Monitor* monitor;
-    if (argc >= 2) {
-        monitor = string_to_monitor(argv[1]);
-    } else {
-        monitor = get_current_monitor();
-    }
-    if (!monitor) {
-        output << argv[0] << ": Monitor \"" << argv[1] << "\" not found!\n";
-        return HERBST_INVALID_ARGUMENT;
-    }
-    tag_update_flags();
-    output << '\t';
-    for (int i = 0; i < tag_get_count(); i++) {
-        HSTag* tag = get_tag_by_index(i);
-        // print flags
-        char c = '.';
-        if (tag->flags & TAG_FLAG_USED) {
-            c = ':';
-        }
-        Monitor *tag_monitor = find_monitor_with_tag(tag);
-        if (tag_monitor == monitor) {
-            c = '+';
-            if (monitor == get_current_monitor()) {
-                c = '#';
-            }
-        } else if (tag_monitor) {
-            c = '-';
-            if (get_current_monitor() == tag_monitor) {
-                c = '%';
-            }
-        }
-        if (tag->flags & TAG_FLAG_URGENT) {
-            c = '!';
-        }
-        output << c;
-        output << *tag->name;
-        output << '\t';
     }
     return 0;
 }

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -5,6 +5,7 @@
 #include "client.h"
 #include "clientmanager.h"
 #include "ewmh.h"
+#include "globalcommands.h"
 #include "hlwmcommon.h"
 #include "keymanager.h"
 #include "layout.h"
@@ -38,6 +39,7 @@ Root::Root(Globals g, XConnection& xconnection, IpcServer& ipcServer)
     , watchers(*this, "watchers")
     , globals(g)
     , meta_commands(make_unique<MetaCommands>(*this))
+    , global_commands(make_unique<GlobalCommands>(*this))
     , X(xconnection)
     , ipcServer_(ipcServer)
     , panels(make_unique<PanelManager>(xconnection))

--- a/src/root.h
+++ b/src/root.h
@@ -11,6 +11,7 @@
 class ClientManager; // IWYU pragma: keep
 class Ewmh;
 class FrameLeaf;
+class GlobalCommands;
 class HlwmCommon;
 class IpcServer;
 class KeyManager; // IWYU pragma: keep
@@ -61,6 +62,7 @@ public:
 
     Globals globals;
     std::unique_ptr<MetaCommands> meta_commands; // Using "pimpl" to avoid include
+    std::unique_ptr<GlobalCommands> global_commands; // Using "pimpl" to avoid include
     XConnection& X;
     IpcServer& ipcServer_;
     //! Temporary member. In the long run, ewmh should get its information

--- a/tests/test_global_commands.py
+++ b/tests/test_global_commands.py
@@ -1,0 +1,46 @@
+def test_tag_status_invalid_monitor(hlwm):
+    hlwm.call_xfail('tag_status foobar') \
+        .expect_stderr('Monitor "foobar" not found!')
+
+
+def test_tag_status_one_monitor(hlwm, x11):
+    hlwm.call('add foobar')
+    hlwm.call('add baz')
+    hlwm.call('add qux')
+    hlwm.create_client()
+    hlwm.call('move baz')
+    winid, _ = hlwm.create_client()
+    hlwm.call('move qux')
+    x11.make_window_urgent(x11.window(winid))
+
+    assert hlwm.call('tag_status').stdout == "\t#default\t.foobar\t:baz\t!qux\t"
+
+
+def test_tag_status_multi_monitor(hlwm):
+    hlwm.call('chain , add othermon , add d1 , add d2 , add d3')
+    hlwm.create_client()
+
+    hlwm.call('add_monitor 800x600 othermon')
+    hlwm.call('focus_monitor 1')
+
+    assert hlwm.call('tag_status').stdout == hlwm.call('tag_status 1').stdout
+    assert hlwm.call('tag_status 0').stdout == '\t+default\t%othermon\t.d1\t.d2\t.d3\t'
+    assert hlwm.call('tag_status 1').stdout == '\t-default\t#othermon\t.d1\t.d2\t.d3\t'
+
+
+def test_tag_status_completion(hlwm):
+    monname = 'monitor_name'
+    assert '0' in hlwm.complete('tag_status')
+    assert '1' not in hlwm.complete('tag_status')
+    assert monname not in hlwm.complete('tag_status')
+
+    hlwm.call('add othertag')
+    hlwm.call('add_monitor 800x600')
+
+    assert '0' in hlwm.complete('tag_status')
+    assert '1' in hlwm.complete('tag_status')
+    assert monname not in hlwm.complete('tag_status')
+
+    hlwm.attr.monitors[1].name = monname
+
+    assert monname in hlwm.complete('tag_status')

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -548,24 +548,6 @@ def test_integer_out_of_range(hlwm):
                 .expect_stderr('out of range')
 
 
-def test_tag_status_invalid_monitor(hlwm):
-    hlwm.call_xfail('tag_status foobar') \
-        .expect_stderr('Monitor "foobar" not found!')
-
-
-def test_tag_status(hlwm, x11):
-    hlwm.call('add foobar')
-    hlwm.call('add baz')
-    hlwm.call('add qux')
-    hlwm.create_client()
-    hlwm.call('move baz')
-    winid, _ = hlwm.create_client()
-    hlwm.call('move qux')
-    x11.make_window_urgent(x11.window(winid))
-
-    assert hlwm.call('tag_status').stdout == "\t#default\t.foobar\t:baz\t!qux\t"
-
-
 def test_jumpto_invalid_client(hlwm):
     hlwm.call_xfail('jumpto foobar') \
         .expect_stderr('Could not find client "foobar".')


### PR DESCRIPTION
The GlobalCommands module collects commands that modify the global state
of hlwm and need multiple subsystems (e.g. monitors and tags).

As an example, the tag_status command is migrated, and it's test suite
is moved to the new test_global_commands.py and slightly extended.