### PR TITLE
Make default colors more transparent and quiet

### DIFF
--- a/share/autostart
+++ b/share/autostart
@@ -118,10 +118,10 @@ hc keybind $Mod-i jumpto urgent
 # theme
 hc attr theme.tiling.reset 1
 hc attr theme.floating.reset 1
-hc set frame_border_active_color '#222222'
-hc set frame_border_normal_color '#101010'
-hc set frame_bg_normal_color '#565656'
-hc set frame_bg_active_color '#345F0C'
+hc set frame_border_active_color '#222222cc'
+hc set frame_border_normal_color '#101010cc'
+hc set frame_bg_normal_color '#565656aa'
+hc set frame_bg_active_color '#345F0Caa'
 hc set frame_border_width 1
 hc set always_show_frame on
 hc set frame_bg_transparent on
@@ -132,17 +132,26 @@ hc attr theme.title_height 15
 hc attr theme.title_font 'Dejavu Sans:pixelsize=12'  # example using Xft
 # hc attr theme.title_font '-*-fixed-medium-r-*-*-13-*-*-*-*-*-*-*'
 hc attr theme.padding_top 2  # space below the title's baseline (i.e. text depth)
-hc attr theme.active.color '#9fbc00'
-hc attr theme.normal.color '#454545'
-hc attr theme.urgent.color orange
+hc attr theme.active.color '#345F0Cef'
+hc attr theme.title_color '#ffffff'
+hc attr theme.normal.color '#323232dd'
+hc attr theme.urgent.color '#7811A1dd'
+hc attr theme.normal.title_color '#898989'
 hc attr theme.inner_width 1
 hc attr theme.inner_color black
 hc attr theme.border_width 3
 hc attr theme.floating.border_width 4
 hc attr theme.floating.outer_width 1
 hc attr theme.floating.outer_color black
-hc attr theme.active.inner_color '#3E4A00'
-hc attr theme.active.outer_color '#3E4A00'
+hc attr theme.active.inner_color '#789161'
+hc attr theme.urgent.inner_color '#9A65B0'
+hc attr theme.normal.inner_color '#606060'
+# copy inner color to outer_color
+for state in active urgent normal ; do
+    hc substitute C theme.${state}.inner_color \
+        attr theme.${state}.outer_color C
+done
+hc attr theme.active.outer_width 1
 hc attr theme.background_color '#141414'
 
 hc set window_gap 0


### PR DESCRIPTION
Stop using the #9fbc00 color as the default border color, since it is a
quite aggressive color. I loved this color, when it was introduced by
pwmt.org applications, but I've stopped using it in my own settings some
years ago and I have the impression that many people don't like it when
starting with hlwm (and the default hlwm config).

Instead, the border color now is the same (dark) green tone as in the
frame border, and is optimized such that it also looks nice with or
without transparency.
