### PR TITLE
Support true transparency in all decorations

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ Current git version
   * Colors contain alpha-values (format #RRGGBBAA)
   * Bug fixes:
     - Fix mistakenly transparent borders of argb clients
+  * New dependency: xrender
 
 Release 0.9.2 on 2021-02-17
 ---------------------------

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ older versions.
 Current git version
 -------------------
 
+  * True transparency support for frame and client decorations (requires a
+    compositor like picom, compton, or xcompmgr)
+  * Colors contain alpha-values (format #RRGGBBAA)
   * Bug fixes:
     - Fix mistakenly transparent borders of argb clients
 

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -7,6 +7,9 @@ pkg_check_modules(XRANDR REQUIRED xrandr)
 pkg_check_modules(XINERAMA xinerama)
 pkg_check_modules(XEXT REQUIRED xext)
 
+# for transparency support
+pkg_check_modules(XRENDER REQUIRED xrender)
+
 # for xft support:
 pkg_check_modules(XFT REQUIRED xft)
 pkg_check_modules(FREETYPE REQUIRED freetype2)

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -33,6 +33,8 @@ of available <<COMMANDS,*COMMANDS*>> is listed below.
     *--exit-on-xerror*::
         Make herbstluftwm exit whenever xlib reports an error. This may only
         be activated for automated testing and never for actual sessions.
+    *--no-transparency*::
+        Disable true transparency.
     *--no-tag-import*::
         Do not preserve the tags (virtual desktops) from a previous running
         window manager.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,7 @@ target_include_directories(herbstluftwm SYSTEM PUBLIC
     ${XEXT_INCLUDE_DIRS}
     ${XINERAMA_INCLUDE_DIRS}
     ${XRANDR_INCLUDE_DIRS}
+    ${XRENDER_INCLUDE_DIRS}
     )
 target_link_libraries(herbstluftwm PUBLIC
     ${FREETYPE_LIBRARIES}
@@ -105,6 +106,7 @@ target_link_libraries(herbstluftwm PUBLIC
     ${XFT_LIBRARIES}
     ${XINERAMA_LIBRARIES}
     ${XRANDR_LIBRARIES}
+    ${XRENDER_LIBRARIES}
     )
 
 ## export variables to the code

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -432,12 +432,14 @@ void execute_autostart_file() {
 
 static void parse_arguments(int argc, char** argv, Globals& g) {
     int exit_on_xerror = g.exitOnXlibError;
+    int noTransparency = !g.trueTransparency;
     int no_tag_import = 0;
     struct option long_options[] = {
         {"version",         0, nullptr, 'v'},
         {"help",            0, nullptr, 'h'},
         {"autostart",       1, nullptr, 'c'},
         {"locked",          0, nullptr, 'l'},
+        {"no-transparency", 0, &noTransparency, 1},
         {"exit-on-xerror",  0, &exit_on_xerror, 1},
         {"no-tag-import",   0, &no_tag_import, 1},
         {"verbose",         0, &g_verbose, 1},
@@ -494,6 +496,7 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
     }
     g.exitOnXlibError = exit_on_xerror != 0;
     g.importTagsFromEwmh = (no_tag_import == 0);
+    g.trueTransparency = !noTransparency;
 }
 
 static void remove_zombies(int) {
@@ -541,6 +544,9 @@ int main(int argc, char* argv[]) {
         std::cerr << "herbstluftwm: another window manager is already running" << endl;
         delete X;
         exit(EXIT_FAILURE);
+    }
+    if (g.trueTransparency) {
+        X->tryInitTransparency();
     }
     // remove zombies on SIGCHLD
     sigaction_signal(SIGCHLD, remove_zombies);

--- a/src/root.h
+++ b/src/root.h
@@ -32,6 +32,7 @@ public:
     int initial_monitors_locked = 0;
     bool exitOnXlibError = false;
     bool importTagsFromEwmh = true;
+    bool trueTransparency = true; // try true transparency via xrender
 };
 
 class Root : public Object {

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -8,6 +8,8 @@
 
 #include "types.h"
 
+class XConnection;
+
 class Color {
 public:
     Color();
@@ -23,6 +25,10 @@ public:
     // return an XColor as obtained form XQueryColor
     XColor toXColor() const;
     unsigned long toX11Pixel() const { return x11pixelValue_; }
+
+    static unsigned long x11PixelPlusAlpha(unsigned long x11pixel, unsigned short alpha) {
+        return (x11pixel & 0xffffffu) | (alpha << 24);
+    }
 
     bool operator==(const Color& other) const {
         return red_ == other.red_
@@ -44,8 +50,7 @@ public:
     unsigned short alpha_ = 0xff; // 0 is fully transparent, 0xff is fully opaque
 
 private:
-
-    // the x11 internal pixel value.
+    // the x11 internal pixel value
     unsigned long x11pixelValue_ = 0;
 };
 

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -18,7 +18,7 @@ using std::string;
 using std::vector;
 
 bool XConnection::exitOnError_ = false;
-XConnection* XConnection::s_connection = nullptr;;
+XConnection* XConnection::s_connection = nullptr;
 
 void XConnection::setExitOnError(bool exitOnError)
 {

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -16,12 +16,19 @@ private:
 public:
     ~XConnection();
     static XConnection* connect(std::string display_name = {});
+    static XConnection& get() { return *s_connection; }
     Display* display() { return m_display; }
     int screen() { return m_screen; }
     Window root() { return m_root; }
     Window screenWidth() { return m_screen_width; }
     Window screenHeight() { return m_screen_height; }
+    Colormap colormap() { return colormap_; }
+    int depth() { return depth_; }
+    Visual* visual() { return visual_; }
+
     bool checkotherwm(); // return whether another WM is running
+    void tryInitTransparency();
+    bool usesTransparency() { return usesTransparency_; }
 
     // utility functions
     static const char* requestCodeToString(int requestCode);
@@ -57,7 +64,12 @@ private:
     int      m_screen_width;
     int      m_screen_height;
     Atom     utf8StringAtom_;
+    int depth_;
+    Visual* visual_;
+    Colormap colormap_;
+    bool usesTransparency_ = false;
     static bool     exitOnError_; //! exit on any xlib error
+    static XConnection* s_connection;
 };
 
 #endif

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -517,23 +517,42 @@ def xvfb(request):
     # also we add '-noreset' such that the server is not reset
     # when the last client connection is closed.
     #
-    # the optional parameter is the resolution. If you want another resolution,
-    # then annotate the test case with:
+    # the optional parameter is a dict for different settings. If you want
+    # another resolution, then annotate the test case with:
     #
-    #    @pytest.mark.parametrize("xvfb", [(1280, 1024)], indirect=True)
+    #    @pytest.mark.parametrize("xvfb", [{'resolution': (1280, 1024)}], indirect=True)
     #
-    screens = [(800, 600)]
+    parameters = {
+        'screens': [(800, 600)],
+        'xrender': True,
+    }
     if hasattr(request, 'param'):
-        screens = [request.param]
-    with MultiscreenDisplay(server='Xvfb', screens=screens, extra_args=['-noreset']) as xserver:
+        parameters.update(request.param)
+    if 'resolution' in parameters:
+        parameters['screens'] = [parameters['resolution']]
+    args = ['-noreset']
+    if parameters['xrender']:
+        args += ['+extension', 'RENDER']
+    with MultiscreenDisplay(server='Xvfb', screens=parameters['screens'], extra_args=args) as xserver:
         os.environ['DISPLAY'] = xserver.display
         yield xserver
 
 
 @pytest.fixture()
-def hlwm_process(hlwm_spawner, xvfb):
+def hlwm_process(hlwm_spawner, request, xvfb):
+    parameters = {
+        'transparency': True,
+    }
+    if hasattr(request, 'param'):
+        # the param must contain a dictionary possibly
+        # updating the default parameters
+        parameters.update(request.param)
+
     """Set up hlwm and also check that it shuts down gently afterwards"""
-    hlwm_proc = hlwm_spawner(['--no-tag-import'], display=xvfb.display)
+    additional_commandline = ['--no-tag-import']
+    if not parameters['transparency']:
+        additional_commandline += ['--no-transparency']
+    hlwm_proc = hlwm_spawner(additional_commandline, display=xvfb.display)
 
     yield hlwm_proc
 
@@ -737,22 +756,35 @@ def x11(x11_connection):
                                        X.ZPixmap, all_planes)
             # raw.data is a array of pixel-values, which need to
             # be interpreted using the colormap:
-            colorDict = {}
-            for pixel in raw.data:
-                colorDict[pixel] = None
-            colorPixelList = list(colorDict)
-            colorRGBList = attr.colormap.query_colors(colorPixelList)
-            for pixelval, rgbval in zip(colorPixelList, colorRGBList):
-                # Useful debug output if something blows up again (which is likely)
-                # print(f'{pixelval} -> {rgbval.red}  {rgbval.green} {rgbval.blue}')
-                colorDict[pixelval] = (rgbval.red % 256, rgbval.green % 256, rgbval.blue % 256)
-            # the image size is enlarged such that the width
-            # is a multiple of 4. Hence we remove these extra
-            # columns in the end when mapping colorDict[] over the data array
-            width_padded = geom.width
-            while width_padded % 4 != 0:
-                width_padded += 1
-            rgbvals = [colorDict[p] for idx, p in enumerate(raw.data) if idx % width_padded < geom.width]
+            if raw.depth == 8:
+                colorDict = {}
+                for pixel in raw.data:
+                    colorDict[pixel] = None
+                colorPixelList = list(colorDict)
+                colorRGBList = attr.colormap.query_colors(colorPixelList)
+                for pixelval, rgbval in zip(colorPixelList, colorRGBList):
+                    # Useful debug output if something blows up again (which is likely)
+                    # print(f'{pixelval} -> {rgbval.red}  {rgbval.green} {rgbval.blue}')
+                    colorDict[pixelval] = (rgbval.red % 256, rgbval.green % 256, rgbval.blue % 256)
+                # the image size is enlarged such that the width
+                # is a multiple of 4. Hence we remove these extra
+                # columns in the end when mapping colorDict[] over the data array
+                width_padded = geom.width
+                while width_padded % 4 != 0:
+                    width_padded += 1
+                rgbvals = [colorDict[p] for idx, p in enumerate(raw.data) if idx % width_padded < geom.width]
+            else:
+                assert raw.depth in [32, 24]
+                # both for depth 32 and 24, the order is BGRA
+                pixelsize = 4
+                (blue, green, red) = (0, 1, 2)
+                size = geom.width * geom.height
+                assert len(raw.data) == pixelsize * size
+                rgbvals = [(raw.data[pixelsize * (y * geom.width + x) + red],
+                            raw.data[pixelsize * (y * geom.width + x) + green],
+                            raw.data[pixelsize * (y * geom.width + x) + blue])
+                           for y in range(0, geom.height)
+                           for x in range(0, geom.width)]
             return RawImage(rgbvals, geom.width, geom.height)
 
         def decoration_screenshot(self, win_handle):
@@ -848,9 +880,10 @@ class MultiscreenDisplay:
         # ---------------------------
         self.screen_rects = []
         current_x_offset = 0
+        depth = 24
         for idx, (width, height) in enumerate(screens):
             self.screen_rects.append([current_x_offset, 0, width, height])
-            geo = '{}x{}x8'.format(width, height)
+            geo = '{}x{}x{}'.format(width, height, depth)
             if server == 'Xvfb':
                 self.full_cmd += ['-screen', str(idx), geo]
             else:

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -7,6 +7,8 @@ font_pool = [
 ]
 
 
+@pytest.mark.parametrize("xvfb", [{'xrender': v} for v in [True, False]], indirect=True)
+@pytest.mark.parametrize("hlwm_process", [{'transparency': v} for v in [True, False]], indirect=True)
 def test_window_border_plain(hlwm, x11):
     color = (0x9f, 0xbc, 0x12)
     bw = 5  # border width
@@ -21,6 +23,8 @@ def test_window_border_plain(hlwm, x11):
     assert img.color_count(color) == expected_count
 
 
+@pytest.mark.parametrize("xvfb", [{'xrender': v} for v in [True, False]], indirect=True)
+@pytest.mark.parametrize("hlwm_process", [{'transparency': v} for v in [True, False]], indirect=True)
 def test_window_border_inner(hlwm, x11):
     color = (239, 2, 190)
     bw = 5  # border width
@@ -40,6 +44,8 @@ def test_window_border_inner(hlwm, x11):
             assert img.pixel(x, y) == expected_color
 
 
+@pytest.mark.parametrize("xvfb", [{'xrender': v} for v in [True, False]], indirect=True)
+@pytest.mark.parametrize("hlwm_process", [{'transparency': v} for v in [True, False]], indirect=True)
 def test_window_border_outer(hlwm, x11):
     color = (239, 2, 190)
     bw = 6  # border width

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -128,7 +128,7 @@ def test_panel_wm_strut_partial_on_big_screen(hlwm, x11):
     assert hlwm.call('list_padding').stdout.strip() == '54 0 0 0'
 
 
-@pytest.mark.parametrize("xvfb", [(1280 + 1024, 1024)], indirect=True)
+@pytest.mark.parametrize("xvfb", [{'resolution': (1280 + 1024, 1024)}], indirect=True)
 def test_panel_wm_strut_partial_different_sized_screens(hlwm, x11):
     """This is the xinerama example from the EWMH doc on _NET_WM_STRUT_PARTIAL
     https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html#idm45075509080400
@@ -162,7 +162,7 @@ def test_panel_wm_strut_partial_different_sized_screens(hlwm, x11):
     assert hlwm.call('list_padding 1').stdout.strip() == '0 0 50 0'
 
 
-@pytest.mark.parametrize("xvfb", [(800 + 700, 600)], indirect=True)
+@pytest.mark.parametrize("xvfb", [{'resolution': (800 + 700, 600)}], indirect=True)
 def test_panel_wm_strut_between_monitors(hlwm, x11):
     hlwm.call('add anothertag')
     hlwm.call('set_monitors 800x600+0+0 700x600+800+0')
@@ -187,7 +187,7 @@ def test_panel_wm_strut_between_monitors(hlwm, x11):
 
 
 @pytest.mark.parametrize("edge", ["left", "right", "up", "down"])
-@pytest.mark.parametrize("xvfb", [(2 * 800, 2 * 600)], indirect=True)
+@pytest.mark.parametrize("xvfb", [{'resolution': (2 * 800, 2 * 600)}], indirect=True)
 def test_panel_wm_strut_between_monitors_2x2_grid(hlwm, x11, edge):
     hlwm.call('chain , add t1 , add t2 , add t3')
     hlwm.call(['set_monitors',


### PR DESCRIPTION
This adds true transparency support in all frame and client decorations
(using the xrender X11 extension), where the level of transparency is
controlled by the alpha value of the colors. The only instance where the
alpha value does not work yet is at Xft fonts.

Per default, hlwm tries to initialize true transparency on startup (this
can be prevented with --no-transparency).

The test cases for the decoration colors now run in all combinations of
xrender being available at the server and hlwm trying to use it.
For xrender to work, we need to start xvfb with color depth 24 (rather
than 8), and this also results in the screenshots being in a slightly
different format.

On the technical side, the XConnection class now provides a singleton
object getter, which can be used to obtain the pointers to Visual and
Colormap. These structures are either the 'default' or special structures
if true transparency is used.

The new library dependency xrender should be available on all systems,
but we can think of making it an optional dependency, since
XConnection::tryInitTransparency() is the only function using the
library.

I've also tested it on my intel graphics laptop, and it also works fine
(in particular it keeps the fix of #1178 intact).