### PR TITLE
Cut holes into frames behind tiled clients

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,9 @@ Current git version
   * True transparency support for frame and client decorations (requires a
     compositor like picom, compton, or xcompmgr)
   * Colors contain alpha-values (format #RRGGBBAA)
+  * Do not draw frame background behind clients (so for semi-transparent
+    client decorations, one does not see the frame decoration behind but the
+    wallpaper instead)
   * Bug fixes:
     - Fix mistakenly transparent borders of argb clients
   * New dependency: xrender

--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -120,8 +120,7 @@ void FrameDecoration::render(const FrameDecorationData& data, bool isFocused) {
             geom.y -= data.geometry.y;
             holes.push_back(geom);
         }
-        window_cut_rect_hole(window, rect.width, rect.height,
-                             holes);
+        window_cut_rect_holes(window, rect.width, rect.height, holes);
         window_transparent = true;
     } else if (window_transparent) {
         window_make_intransparent(window, rect.width, rect.height);

--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -1,8 +1,8 @@
 #include "framedecoration.h"
 
-#include <vector>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <vector>
 
 #include "client.h"
 #include "decoration.h"

--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -111,8 +111,8 @@ void FrameDecoration::render(const FrameDecorationData& data, bool isFocused) {
     if (settings->frame_bg_transparent() || data.hasClients) {
         vector<Rectangle> holes;
         if (settings->frame_bg_transparent()) {
-            int bw = settings->frame_transparent_width();
-            holes.push_back(Rectangle(bw, bw, rect.width - 2 * bw, rect.height - 2 * bw));
+            int ftw = settings->frame_transparent_width();
+            holes.push_back(Rectangle(ftw, ftw, rect.width - 2 * ftw, rect.height - 2 * ftw));
         }
         for (Client* client : frame_.clients) {
             Rectangle geom = client->dec->last_outer();

--- a/src/layout.h
+++ b/src/layout.h
@@ -20,6 +20,7 @@ class Client;
 typedef std::function<void(Client*)> ClientAction;
 
 class HSTag;
+class FrameDecoration;
 class FrameLeaf;
 class FrameSplit;
 class Settings;
@@ -137,6 +138,7 @@ public:
     DynAttribute_<int> selectionAttr_;
     DynAttribute_<LayoutAlgorithm> algorithmAttr_;
 private:
+    friend class FrameDecoration;
     friend class FrameTree;
     // layout algorithms
     TilingResult layoutLinear(Rectangle rect, bool vertical);

--- a/src/x11-utils.cpp
+++ b/src/x11-utils.cpp
@@ -9,11 +9,10 @@
 using std::vector;
 
 /**
- * \brief   cut a rect out of the window, s.t. the window has geometry rect and
- * a frame of width framewidth remains
+ * \brief cut the given rectangles out of the window using XShape
  */
-void window_cut_rect_hole(Window win, int width, int height,
-                          const vector<Rectangle>& holes) {
+void window_cut_rect_holes(Window win, int width, int height,
+                           const vector<Rectangle>& holes) {
     // inspired by the xhole.c example
     // http://www.answers.com/topic/xhole-c
     Display* d = g_display;

--- a/src/x11-utils.cpp
+++ b/src/x11-utils.cpp
@@ -6,18 +6,19 @@
 
 #include "globals.h"
 
+using std::vector;
+
 /**
  * \brief   cut a rect out of the window, s.t. the window has geometry rect and
  * a frame of width framewidth remains
  */
-void window_cut_rect_hole(Window win, int width, int height, int framewidth) {
+void window_cut_rect_hole(Window win, int width, int height,
+                          const vector<Rectangle>& holes) {
     // inspired by the xhole.c example
     // http://www.answers.com/topic/xhole-c
     Display* d = g_display;
     GC gp;
     int bw = 100; // add a large border, just to be sure the border is visible
-    int holewidth = width - 2*framewidth;
-    int holeheight = height - 2*framewidth;
     width += 2*bw;
     height += 2*bw;
 
@@ -31,8 +32,10 @@ void window_cut_rect_hole(Window win, int width, int height, int framewidth) {
     //XFillArc(d, p, gp,
     //         width/2 - radius, height/2 - radius, radius, radius,
     //         0, 360*64);
-    XFillRectangle(d, p, gp, bw + framewidth, bw + framewidth,
-                             holewidth, holeheight);
+    for (const auto& rect : holes) {
+        XFillRectangle(d, p, gp, bw + rect.x, bw + rect.y,
+                                 rect.width, rect.height);
+    }
 
     /* set the pixmap as the new window mask;
     the pixmap is slightly larger than the window to allow for the window

--- a/src/x11-utils.h
+++ b/src/x11-utils.h
@@ -8,8 +8,8 @@
 #include "x11-types.h"
 
 // cut the specified rectangles out of the window
-void window_cut_rect_hole(Window win, int width, int height,
-                          const std::vector<Rectangle>& holes);
+void window_cut_rect_holes(Window win, int width, int height,
+                           const std::vector<Rectangle>& holes);
 // fill the hole again, i.e. remove all masks
 void window_make_intransparent(Window win, int width, int height);
 

--- a/src/x11-utils.h
+++ b/src/x11-utils.h
@@ -2,12 +2,14 @@
 #define __HERBST_X11_UTILS_H_
 
 #include <X11/X.h>
+#include <vector>
 
+#include "rectangle.h"
 #include "x11-types.h"
 
-// cut a rect out of the window, s.t. the window has geometry rect and a frame
-// of width framewidth remains
-void window_cut_rect_hole(Window win, int width, int height, int framewidth);
+// cut the specified rectangles out of the window
+void window_cut_rect_hole(Window win, int width, int height,
+                          const std::vector<Rectangle>& holes);
 // fill the hole again, i.e. remove all masks
 void window_make_intransparent(Window win, int width, int height);
 


### PR DESCRIPTION
For semi-transparent clients, it is unpleasant to see the frame
decoration shining through. Hence, we now cut holes into the frame's
decoration at the area where clients are. If no true transparency is
activated, no difference should be noticeable, and for true transparency,
one sees the wallpaper or desktop window shining through.

Internally, the last 'outer' geometry of every client is used, and so
this also interacts nicely with pseudotiled windows and the grid layout.

This should improve the cosmetics and implicitly also solve #1183.