### PR TITLE
Add screenshot-based tests for frame decoration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -743,7 +743,8 @@ def x11(x11_connection):
                 self.sync_with_hlwm()
             return w, self.winid_str(w)
 
-        def screenshot(self, win_handle):
+        def screenshot(self, win_handle) -> RawImage:
+            """screenshot of a windows content, not including its border"""
             geom = win_handle.get_geometry()
             attr = win_handle.get_attributes()
             # Xlib defines AllPlanes as: ((unsigned long)~0L)


### PR DESCRIPTION
This adds tests for the XShape functionality in the frame decorations.
This covers both the setting frame_bg_transparent /
frame_transparent_width and the new functionality of hiding the frame
content behind clients (PR #1187 / f7ba8f9940).