### PR TITLE
Add converter for objects such as Monitor

### DIFF
--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -235,7 +235,11 @@ class TokenStream:
                 if t == self.pos:
                     nextline += '^ here'
                 else:
-                    nextline += ' ' * len(self.tokens[t])
+                    if isinstance(self.tokens[t], list):
+                        length = len(self.tokens[t])
+                    else:
+                        length = len(str(self.tokens[t]))
+                    nextline += ' ' * length
             text += '\n' + nextline
             if msg != '':
                 text += "\n'{}'".format(msg)
@@ -622,9 +626,14 @@ class TokTreeInfoExtrator:
             name = arg.value
         if stream.try_match('<'):
             tok = stream.pop('expected template argument')
+            if stream.try_match('*'):
+                tok += '*'
             tmpl_args.append(tok)
             while stream.try_match(','):
-                tmpl_args.append(stream.pop('expected template argument'))
+                tok = stream.pop('expected template argument')
+                if stream.try_match('*'):
+                    tok += '*'
+                tmpl_args.append(tok)
             stream.assert_match('>',
                                 msg='expecting > after last template argument')
         return ClassName(name, type_modifier=type_modifier,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(herbstluftwm PRIVATE
     root.cpp root.h
     rulemanager.cpp rulemanager.h
     rules.cpp rules.h
+    runtimeconverter.h
     settings.cpp settings.h
     signal.h
     stack.cpp stack.h

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -16,15 +16,10 @@ GlobalCommands::GlobalCommands(Root& root)
 
 int GlobalCommands::tagStatusCommand(Input input, Output output)
 {
-    string monitorStr = "";
-    ArgParse argparse = ArgParse().optional(monitorStr);
+    Monitor* monitor = root_.monitors->focus();
+    ArgParse argparse = ArgParse().optional(monitor);
     if (argparse.parsingAllFails(input, output)) {
         return argparse.exitCode();
-    }
-    Monitor* monitor = root_.monitors->byString(monitorStr);
-    if (!monitor) {
-        output << input.command() << ": Monitor \"" << monitorStr << "\" not found!\n";
-        return HERBST_INVALID_ARGUMENT;
     }
     tag_update_flags();
     output << '\t';
@@ -60,7 +55,7 @@ int GlobalCommands::tagStatusCommand(Input input, Output output)
 void GlobalCommands::tagStatusCompletion(Completion& complete)
 {
     if (complete == 0) {
-        root_.monitors->completeMonitorName(complete);
+        Converter<Monitor*>::complete(complete);
     } else {
         complete.none();
     }

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -196,7 +196,7 @@ Monitor* MonitorManager::parse(const string& str)
     }
 }
 
-std::string MonitorManager::str(Monitor* monitor)
+string MonitorManager::str(Monitor* monitor)
 {
     if (monitor) {
         return monitor->index.str();

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <memory>
 
+#include "argparse.h"
 #include "command.h"
 #include "completion.h"
 #include "ewmh.h"
@@ -32,6 +33,9 @@ using std::shared_ptr;
 using std::string;
 using std::to_string;
 using std::vector;
+
+template<>
+RunTimeConverter<Monitor*>* Converter<Monitor*>::converter = nullptr;
 
 MonitorManager* g_monitors;
 
@@ -182,6 +186,30 @@ Monitor* MonitorManager::byString(string str) {
     return ((idx >= 0) && idx < static_cast<int>(size())) ? byIdx(idx) : nullptr;
 }
 
+Monitor* MonitorManager::parse(const string& str)
+{
+    int idx = string_to_monitor_index(str);
+    if ((idx >= 0) && idx < static_cast<int>(size())) {
+        return byIdx(static_cast<size_t>(idx));
+    } else {
+        throw std::invalid_argument(string("No such monitor: ") + str);
+    }
+}
+
+std::string MonitorManager::str(Monitor* monitor)
+{
+    if (monitor) {
+        return monitor->index.str();
+    } else {
+        return {};
+    }
+}
+
+void MonitorManager::complete(Completion& completion)
+{
+    completeMonitorName(completion);
+}
+
 function<int(Input, Output)> MonitorManager::byFirstArg(MonitorCommand cmd)
 {
     return [this,cmd](Input input, Output output) -> int {
@@ -291,15 +319,10 @@ void MonitorManager::relayoutAll()
 
 int MonitorManager::removeMonitor(Input input, Output output)
 {
-    string monitorIdxString;
-    if (!(input >> monitorIdxString)) {
-        return HERBST_NEED_MORE_ARGS;
-    }
-    auto monitor = byString(monitorIdxString);
-
-    if (monitor == nullptr) {
-        output << input.command() << ": Monitor \"" << monitorIdxString << "\" not found!\n";
-        return HERBST_INVALID_ARGUMENT;
+    Monitor* monitor = nullptr;
+    ArgParse argparse = ArgParse().mandatory(monitor);
+    if (argparse.parsingAllFails(input, output)) {
+        return argparse.exitCode();
     }
 
     if (size() <= 1) {

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -10,6 +10,7 @@
 #include "link.h"
 #include "monitor.h"
 #include "plainstack.h"
+#include "runtimeconverter.h"
 #include "signal.h"
 
 extern MonitorManager* g_monitors;
@@ -26,7 +27,7 @@ typedef std::function<void(Monitor&,Completion&)> MonitorCompletion;
 typedef std::function<int(HSTag&,Input,Output)> TagCommand;
 typedef std::function<void(HSTag&,Completion&)> TagCompletion;
 
-class MonitorManager : public IndexingObject<Monitor> {
+class MonitorManager : public IndexingObject<Monitor>, public Manager<Monitor> {
 public:
     MonitorManager();
     ~MonitorManager();
@@ -40,6 +41,12 @@ public:
     Monitor* byTag(HSTag* tag);
     Monitor* byCoordinate(Point2D p);
     Monitor* byFrame(std::shared_ptr<Frame> frame);
+
+    // RunTimeConverter<Monitor*>:
+    virtual Monitor* parse(const std::string& str) override;
+    virtual std::string str(Monitor* monitor) override;
+    virtual void complete(Completion& completion) override;
+
     int list_monitors(Output output);
     int list_padding(Input input, Output output);
     int string_to_monitor_index(std::string string);

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -27,6 +27,9 @@ typedef std::function<void(Monitor&,Completion&)> MonitorCompletion;
 typedef std::function<int(HSTag&,Input,Output)> TagCommand;
 typedef std::function<void(HSTag&,Completion&)> TagCompletion;
 
+template<>
+RunTimeConverter<Monitor*>* Converter<Monitor*>::converter;
+
 class MonitorManager : public IndexingObject<Monitor>, public Manager<Monitor> {
 public:
     MonitorManager();

--- a/src/runtimeconverter.h
+++ b/src/runtimeconverter.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <type_traits>
+
+#include "types.h"
+
+/**
+ * the same definition as 'Converter', but without the 'static'
+ */
+template <typename T>
+class RunTimeConverter {
+public:
+    virtual T parse(const std::string& source) = 0;
+    virtual std::string str(T payload) = 0;
+    virtual void complete(Completion& completion) = 0;
+};
+
+/**
+ * A converter for pointer types T, e.g. Client*, Tag*, Monitor*.
+ * A converter for such types has callbacks to the respective manager
+ * which does the actual conversion and completion.
+ */
+template <typename T>
+class Converter<T, typename std::enable_if< std::is_pointer<T>::value >::type> {
+public:
+    static RunTimeConverter<T>* converter;
+    static T parse(const std::string& source) {
+        if (converter) {
+            return converter->parse(source);
+        } else {
+            throw std::invalid_argument("Converter not initialized!");
+        }
+    }
+    static std::string str(T payload) {
+        if (converter) {
+            return converter->str(payload);
+        } else {
+            return "Error: Converter not initialized!";
+        }
+    }
+    static void complete(Completion& completion) {
+        if (converter) {
+            converter->complete(completion);
+        }
+    }
+    static void complete(Completion& completion, T const*) {
+        complete(completion);
+    }
+};
+
+/**
+ * Inheriting from this in the manager will automatic register/unregister
+ * the RunTimeConverter<T*> at the Converter<T*>.
+ */
+template <typename T>
+class Manager : public RunTimeConverter<T*> {
+public:
+    Manager() {
+        Converter<T*>::converter = this;
+    }
+    ~Manager() {
+        Converter<T*>::converter = nullptr;
+    }
+};

--- a/tests/test_global_commands.py
+++ b/tests/test_global_commands.py
@@ -1,6 +1,6 @@
 def test_tag_status_invalid_monitor(hlwm):
     hlwm.call_xfail('tag_status foobar') \
-        .expect_stderr('Monitor "foobar" not found!')
+        .expect_stderr('No such monitor: foobar')
 
 
 def test_tag_status_one_monitor(hlwm, x11):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -100,8 +100,8 @@ def test_remove_monitor_invalid_args(hlwm):
 
 
 def test_cannot_remove_nonexistent_monitor(hlwm):
-    call = hlwm.call_xfail('remove_monitor 1')
-    assert call.stderr == 'remove_monitor: Monitor "1" not found!\n'
+    hlwm.call_xfail('remove_monitor 1') \
+        .expect_stderr('No such monitor: 1')
     assert hlwm.get_attr('monitors.count') == '1'
 
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -89,6 +89,8 @@ def test_remove_monitor_invalid_args(hlwm):
     hlwm.call_xfail('remove_monitor') \
         .expect_stderr('Expected one argument, but got only 0')
 
+    assert hlwm.get_attr('monitors.count') == '1'
+
     hlwm.call('add tag2')
     hlwm.call('add_monitor 800x600+40+40 tag2 monitor2')
 
@@ -98,11 +100,7 @@ def test_remove_monitor_invalid_args(hlwm):
     hlwm.call_xfail('remove_monitor 2') \
         .expect_stderr('No such monitor: 2')
 
-
-def test_cannot_remove_nonexistent_monitor(hlwm):
-    hlwm.call_xfail('remove_monitor 1') \
-        .expect_stderr('No such monitor: 1')
-    assert hlwm.get_attr('monitors.count') == '1'
+    assert hlwm.get_attr('monitors.count') == '2'
 
 
 def test_cannot_remove_last_monitor(hlwm):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -85,6 +85,20 @@ def test_remove_monitor(hlwm):
     assert hlwm.get_attr('monitors.focus.name') == 'monitor2'
 
 
+def test_remove_monitor_invalid_args(hlwm):
+    hlwm.call_xfail('remove_monitor') \
+        .expect_stderr('Expected one argument, but got only 0')
+
+    hlwm.call('add tag2')
+    hlwm.call('add_monitor 800x600+40+40 tag2 monitor2')
+
+    hlwm.call_xfail('remove_monitor foobar') \
+        .expect_stderr('No such monitor: foobar')
+
+    hlwm.call_xfail('remove_monitor 2') \
+        .expect_stderr('No such monitor: 2')
+
+
 def test_cannot_remove_nonexistent_monitor(hlwm):
     call = hlwm.call_xfail('remove_monitor 1')
     assert call.stderr == 'remove_monitor: Monitor "1" not found!\n'


### PR DESCRIPTION
This introduces a new converter class for the parsing of descriptions of
objects, e.g. Monitors, Tags, Clients. So far, only the converter for
Monitor* is implemented. If a command gets a monitor as a parameter, we
can now use ArgParse which internally uses the Converter class.

This new converter is used in the commands remove_monitor and tag_status
and their test cases have slightly been adjusted and extended.