### PR TITLE
Run-Time Converter for Client*

### DIFF
--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -67,7 +67,7 @@ void ClientManager::injectDependencies(Settings* s, Theme* t, Ewmh* e) {
     ewmh = e;
 }
 
-std::string ClientManager::str(Client* client)
+string ClientManager::str(Client* client)
 {
     return client->window_id_str;
 }
@@ -91,7 +91,7 @@ Client* ClientManager::client(Window window)
  *                  a decimal number its decimal window id.
  * \return          Pointer to the resolved client.
  */
-Client* ClientManager::parse(const std::string& identifier)
+Client* ClientManager::parse(const string& identifier)
 {
     if (identifier.empty()) {
         Client* c = focus();

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -7,6 +7,7 @@
 #include "commandio.h"
 #include "link.h"
 #include "object.h"
+#include "runtimeconverter.h"
 #include "signal.h"
 
 class Client;
@@ -17,18 +18,25 @@ class HSTag;
 class Settings;
 class Theme;
 
+template<>
+RunTimeConverter<Client*>* Converter<Client*>::converter;
+
 // Note: this is basically a singleton
 
-class ClientManager : public Object
+class ClientManager : public Object, public Manager<Client>
 {
 public:
     ClientManager();
     ~ClientManager() override;
     void injectDependencies(Settings* s, Theme* t, Ewmh* e);
 
+    // RunTimeConverter<Monitor*>:
+    virtual Client* parse(const std::string& identifier) override;
+    virtual std::string str(Client* client) override;
+    virtual void completeEntries(Completion& completion) override;
+
     Client* client(Window window);
     Client* client(const std::string &identifier);
-    void completeClients(Completion& complete);
     const std::unordered_map<Window, Client*>&
     clients() { return clients_; }
 

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -66,8 +66,6 @@ struct {
     { "cycle",          2,  no_completion },
     { "split",          4,  no_completion },
     { "raise",          2,  no_completion },
-    { "jumpto",         2,  no_completion },
-    { "bring",          2,  no_completion },
     { "focus_edge",     2,  no_completion },
     { "shift_edge",     2,  no_completion },
     { "cycle_monitor",  2,  no_completion },
@@ -114,8 +112,6 @@ struct {
 } g_completions[] = {
     /* name , relation, index,  completion method                   */
     { "add_monitor",    EQ, 2,  complete_against_tags, 0 },
-    { "bring",          EQ, 1,  nullptr, completion_special_winids },
-    { "bring",          EQ, 1,  complete_against_winids, 0 },
     { "close",          EQ, 1,  complete_against_winids, 0 },
     { "cycle",          EQ, 1,  nullptr, completion_pm_one },
     { "cycle_monitor",  EQ, 1,  nullptr, completion_pm_one },
@@ -129,8 +125,6 @@ struct {
     { "rename",         EQ, 1,  complete_against_tags, 0 },
     { "raise",          EQ, 1,  nullptr, completion_special_winids },
     { "raise",          EQ, 1,  complete_against_winids, 0 },
-    { "jumpto",         EQ, 1,  nullptr, completion_special_winids },
-    { "jumpto",         EQ, 1,  complete_against_winids, 0 },
     { "shift_edge",     EQ, 1,  nullptr, completion_directions },
     { "split",          EQ, 1,  nullptr, completion_split_modes },
     { "split",          EQ, 2,  nullptr, completion_split_ratios },

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -2,6 +2,7 @@
 
 #include "argparse.h"
 #include "client.h"
+#include "clientmanager.h"
 #include "frametree.h"
 #include "layout.h"
 #include "monitor.h"

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -1,6 +1,9 @@
 #include "globalcommands.h"
 
 #include "argparse.h"
+#include "client.h"
+#include "frametree.h"
+#include "layout.h"
 #include "monitor.h"
 #include "monitormanager.h"
 #include "root.h"
@@ -59,4 +62,58 @@ void GlobalCommands::tagStatusCompletion(Completion& complete)
     } else {
         complete.none();
     }
+}
+
+int GlobalCommands::jumptoCommand(Input input, Output output)
+{
+    Client* client = nullptr;
+    ArgParse argparse = ArgParse().mandatory(client);
+    if (argparse.parsingAllFails(input, output)) {
+        return argparse.exitCode();
+    }
+    focus_client(client, true, true, true);
+    return 0;
+}
+
+void GlobalCommands::jumptoCompletion(Completion& complete)
+{
+    if (complete == 0) {
+        Converter<Client*>::complete(complete);
+    } else {
+        complete.none();
+    }
+}
+
+int GlobalCommands::bringCommand(Input input, Output output)
+{
+    Client* client = nullptr;
+    ArgParse argparse = ArgParse().mandatory(client);
+    if (argparse.parsingAllFails(input, output)) {
+        return argparse.exitCode();
+    }
+    HSTag* tag = get_current_monitor()->tag;
+    root_.tags->moveClient(client, tag, {}, true);
+    // mark as un-minimized first, such that a minimized tiling client
+    // is added to the frame tree now.
+    client->minimized_ = false;
+    auto frame = tag->frame->root_->frameWithClient(client);
+    if (frame && !frame->isFocused()) {
+        // regardless of the client's floating or minimization state:
+        // if the client was in the frame tree, it is moved
+        // to the focused frame
+        frame->removeClient(client);
+        tag->frame->focusedFrame()->insertClient(client, true);
+    }
+    focus_client(client, false, false, true);
+    return 0;
+}
+
+void GlobalCommands::bringCompletion(Completion& complete)
+{
+    if (complete == 0) {
+        Converter<Client*>::complete(complete);
+    } else {
+        complete.none();
+    }
+
 }

--- a/src/globalcommands.h
+++ b/src/globalcommands.h
@@ -18,6 +18,12 @@ public:
     GlobalCommands(Root& root);
     int tagStatusCommand(Input input, Output output);
     void tagStatusCompletion(Completion& complete);
+
+    int jumptoCommand(Input input, Output output);
+    void jumptoCompletion(Completion& complete);
+
+    int bringCommand(Input input, Output output);
+    void bringCompletion(Completion& complete);
 private:
     Root& root_;
 };

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -429,37 +429,6 @@ void Frame::foreachClient(ClientAction action) {
          0);
 }
 
-int frame_current_bring(int argc, char** argv, Output output) {
-    if (argc < 2) {
-        return HERBST_NEED_MORE_ARGS;
-    }
-    auto client = get_client(argv[1]);
-    if (!client) {
-        output << argv[0] << ": Could not find client";
-        if (argc > 1) {
-            output << " \"" << argv[1] << "\".\n";
-        } else {
-            output << ".\n";
-        }
-        return HERBST_INVALID_ARGUMENT;
-    }
-    HSTag* tag = get_current_monitor()->tag;
-    global_tags->moveClient(client, tag, {}, true);
-    // mark as un-minimized first, such that a minimized tiling client
-    // is added to the frame tree now.
-    client->minimized_ = false;
-    auto frame = tag->frame->root_->frameWithClient(client);
-    if (frame && !frame->isFocused()) {
-        // regardless of the client's floating or minimization state:
-        // if the client was in the frame tree, it is moved
-        // to the focused frame
-        frame->removeClient(client);
-        tag->frame->focusedFrame()->insertClient(client, true);
-    }
-    focus_client(client, false, false, true);
-    return 0;
-}
-
 void FrameLeaf::setSelection(int index) {
     if (clients.empty()) {
         return;

--- a/src/layout.h
+++ b/src/layout.h
@@ -193,9 +193,6 @@ private:
     friend class FrameTree;
 };
 
-// functions
-int frame_current_bring(int argc, char** argv, Output output);
-
 bool focus_client(Client* client, bool switch_tag, bool switch_monitor, bool raise);
 
 int frame_focus_edge(Input input, Output output);

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -205,7 +205,7 @@ string MonitorManager::str(Monitor* monitor)
     }
 }
 
-void MonitorManager::complete(Completion& completion)
+void MonitorManager::completeEntries(Completion& completion)
 {
     completeMonitorName(completion);
 }

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -48,7 +48,7 @@ public:
     // RunTimeConverter<Monitor*>:
     virtual Monitor* parse(const std::string& str) override;
     virtual std::string str(Monitor* monitor) override;
-    virtual void complete(Completion& completion) override;
+    virtual void completeEntries(Completion& completion) override;
 
     int list_monitors(Output output);
     int string_to_monitor_index(std::string string);

--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -152,7 +152,7 @@ int MouseManager::dragCommand(Input input, Output output)
 void MouseManager::dragCompletion(Completion& complete)
 {
     if (complete == 0) {
-        Root::get()->clients->completeClients(complete);
+        Root::get()->clients->completeEntries(complete);
     } else if (complete == 1) {
         for (auto& it : mouseFunctions_) {
             complete.full(it.first);

--- a/src/runtimeconverter.h
+++ b/src/runtimeconverter.h
@@ -12,7 +12,7 @@ class RunTimeConverter {
 public:
     virtual T parse(const std::string& source) = 0;
     virtual std::string str(T payload) = 0;
-    virtual void complete(Completion& completion) = 0;
+    virtual void completeEntries(Completion& completion) = 0;
 };
 
 /**
@@ -40,7 +40,7 @@ public:
     }
     static void complete(Completion& completion) {
         if (converter) {
-            converter->complete(completion);
+            converter->completeEntries(completion);
         }
     }
     static void complete(Completion& completion, T const*) {

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -159,11 +159,6 @@ def test_bring_from_different_tag(hlwm, x11):
     assert hlwm.get_attr('clients.focus.winid') == bonnie
 
 
-def test_bring_invalid_client(hlwm):
-    hlwm.call_xfail('bring foobar') \
-        .expect_stderr('Could not find client')
-
-
 def test_bring_from_same_tag_different_frame(hlwm, x11):
     hlwm.call('split horizontal')
     hlwm.call('focus right')

--- a/tests/test_global_commands.py
+++ b/tests/test_global_commands.py
@@ -44,3 +44,34 @@ def test_tag_status_completion(hlwm):
     hlwm.attr.monitors[1].name = monname
 
     assert monname in hlwm.complete('tag_status')
+
+
+def test_jumpto_bring_invalid_client(hlwm):
+    for cmd in ['jumpto', 'bring']:
+        hlwm.call_xfail([cmd, 'foobar']) \
+            .expect_stderr('Cannot parse argument "foobar": stoul')
+
+        hlwm.call_xfail([cmd, 'urgent']) \
+            .expect_stderr('No client is urgent')
+
+        hlwm.call_xfail([cmd, '']) \
+            .expect_stderr('No client is focused')
+
+        hlwm.call_xfail([cmd, '0xdead']) \
+            .expect_stderr('No managed client with window id 0xdead')
+
+
+def test_jumpto_bring_completion(hlwm):
+    for cmd in ['jumpto', 'bring']:
+        winid, proc = hlwm.create_client()
+
+        res = hlwm.complete([cmd])
+        assert winid in res
+        assert 'urgent' in res
+
+        proc.kill()
+        proc.wait(10)
+
+        res = hlwm.complete([cmd])
+        assert winid not in res
+        assert 'urgent' in res

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -548,11 +548,6 @@ def test_integer_out_of_range(hlwm):
                 .expect_stderr('out of range')
 
 
-def test_jumpto_invalid_client(hlwm):
-    hlwm.call_xfail('jumpto foobar') \
-        .expect_stderr('Could not find client "foobar".')
-
-
 def test_raise_winid_missing(hlwm):
     hlwm.call_xfail('raise') \
         .expect_stderr('raise: not enough arguments\n')


### PR DESCRIPTION
This implements RunTimeConverter for Client* and uses it in the commands
jumpto and bring which are moved to GlobalCommands.

Since there are multiple variables and functions called 'complete',
RunTimeConverter::complete is renamed to RunTimeConverter::completeEntries
to make the variable names a bit more unique.

The test cases with error handling are slightly extended and moved to
test_global_commands.py, but the existing 'positive' test cases for
bring and jumpto are still in test_clients and test_layout in order to
keep the diff small.