### PR TITLE
Remove unused lock_number_change return value

### DIFF
--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -488,9 +488,9 @@ void MonitorManager::unlock() {
     lock_number_changed();
 }
 
-string MonitorManager::lock_number_changed() {
+void MonitorManager::lock_number_changed() {
     if (settings_->monitors_locked() < 0) {
-        return "must be non-negative";
+        return;
     }
     if (!settings_->monitors_locked()) {
         // if not locked anymore, then repaint all the dirty monitors
@@ -500,7 +500,6 @@ string MonitorManager::lock_number_changed() {
             }
         }
     }
-    return {};
 }
 
 //! return the stack of windows by successive calls to the given yield

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -75,7 +75,7 @@ public:
 
     void lock();
     void unlock();
-    std::string lock_number_changed();
+    void lock_number_changed();
 
     int stackCommand(Output output);
     void extractWindowStack(bool real_clients, std::function<void(Window)> yield);


### PR DESCRIPTION
Change it to void, nobody uses the returned string.