### PR TITLE
Make setting monitors_locked an unsigned long

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ Current git version
   * Do not draw frame background behind clients (so for semi-transparent
     client decorations, one does not see the frame decoration behind but the
     wallpaper instead)
+  * The setting +monitors_locked+ is now explicitly an unsigned integer.
   * Bug fixes:
     - Fix mistakenly transparent borders of argb clients
   * New dependency: xrender

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1141,7 +1141,7 @@ focus_stealing_prevention (Boolean)::
     If set, only pagers and taskbars are allowed to change the focus. If unset,
     all applications can request a focus change.
 
-monitors_locked (Integer)::
+monitors_locked (Unsigned Integer)::
     If greater than 0, then the clients on all monitors aren't moved or resized
     anymore. If it is set to 0, then the arranging of monitors is enabled again,
     and all monitors are rearranged if their content has changed in the

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -480,18 +480,15 @@ Monitor* MonitorManager::addMonitor(Rectangle rect, HSTag* tag) {
 
 void MonitorManager::lock() {
     settings_->monitors_locked = settings_->monitors_locked() + 1;
-    lock_number_changed();
 }
 
 void MonitorManager::unlock() {
-    settings_->monitors_locked = std::max(0, settings_->monitors_locked() - 1);
-    lock_number_changed();
+    if (settings_->monitors_locked > 0) {
+        settings_->monitors_locked = settings_->monitors_locked() - 1;
+    }
 }
 
 void MonitorManager::lock_number_changed() {
-    if (settings_->monitors_locked() < 0) {
-        return;
-    }
     if (!settings_->monitors_locked()) {
         // if not locked anymore, then repaint all the dirty monitors
         for (auto m : *this) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -60,7 +60,7 @@ public:
     Attribute_<bool>          hide_covered_windows = {"hide_covered_windows", false};
     Attribute_<bool>          smart_frame_surroundings = {"smart_frame_surroundings", false};
     Attribute_<bool>          smart_window_surroundings = {"smart_window_surroundings", false};
-    Attribute_<int>           monitors_locked = {"monitors_locked", 0};
+    Attribute_<unsigned long> monitors_locked = {"monitors_locked", 0};
     Attribute_<bool>          auto_detect_monitors = {"auto_detect_monitors", false};
     Attribute_<bool>          auto_detect_panels = {"auto_detect_panels", true};
     Attribute_<int>           pseudotile_center_threshold = {"pseudotile_center_threshold", 10};

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -98,3 +98,8 @@ def test_toggle_invalid_setting(hlwm):
 def test_cycle_value_invalid_setting(hlwm):
     hlwm.call_xfail('cycle_value foobar baz') \
         .expect_stderr('Setting "foobar" not found\n')
+
+
+def test_monitors_locked_negative_value(hlwm):
+    hlwm.call_xfail('set monitors_locked -1') \
+        .expect_stderr('out of range')


### PR DESCRIPTION
The lock counter was always used as a non-negative integer and should
also be such on the type level. In the original settings code, all
integers where signed, but now it is finally updated.

Also it is not necessary anymore to call lock_number_changed() manually,
because this happens automatically through signals.

Both changes are tested by the new test cases for lock/unlock.