### PR TITLE
Converter for integers checks entire input string

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -26,7 +26,12 @@ void Converter<Direction>::complete(Completion& complete, const Direction* relat
 template<>
 unsigned long Converter<unsigned long>::parse(const string& source)
 {
-    long value = std::stol(source);
+    size_t pos = 0;
+    long value = std::stol(source, &pos);
+    if (pos < source.size()) {
+        throw std::invalid_argument("unparsable suffix: "
+                                    + source.substr(pos));
+    }
     if (value < 0) {
         throw std::invalid_argument("negative number is out of range");
     } else {

--- a/src/types.h
+++ b/src/types.h
@@ -55,7 +55,13 @@ struct Converter {
 // Integers
 template<>
 inline int Converter<int>::parse(const std::string &payload) {
-    return std::stoi(payload);
+    size_t pos = 0;
+    int val = std::stoi(payload, &pos);
+    if (pos < payload.size()) {
+        throw std::invalid_argument("unparsable suffix: "
+                                    + payload.substr(pos));
+    }
+    return val;
 }
 template<>
 unsigned long Converter<unsigned long>::parse(const std::string &source);

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -51,3 +51,21 @@ def test_color_names(hlwm):
     for name, rgb in colors:
         hlwm.attr.theme.color = name
         assert hlwm.attr.theme.color() == rgb
+
+
+def test_int_uint_unparsable_suffix(hlwm):
+    for attrtype in ['int', 'uint']:
+        attr = 'my_' + attrtype
+        hlwm.call(['new_attr', attrtype, attr])
+
+        hlwm.call_xfail(['set_attr', attr, '3f']) \
+            .expect_stderr('unparsable suffix: f')
+
+        hlwm.call_xfail(['set_attr', attr, '3+']) \
+            .expect_stderr('unparsable suffix')
+
+        hlwm.call_xfail(['set_attr', attr, '3.0']) \
+            .expect_stderr('unparsable suffix')
+
+        hlwm.call_xfail(['set_attr', attr, '+3x']) \
+            .expect_stderr('unparsable suffix')


### PR DESCRIPTION
In the Converter for int and unsigned long, the parser now checks that
the entire input string is processed and no unparsable suffix is left at
the end.

This fixes #944.