### PR TITLE
Test herbstclient command line parsing

### DIFF
--- a/ipc-client/main.c
+++ b/ipc-client/main.c
@@ -230,6 +230,7 @@ int main(int argc, char* argv[]) {
     if ((argc - arg_index == 0) && !g_wait_for_hook) {
         // if there are no non-option arguments, and no --idle/--wait, display
         // the help and exit
+        fprintf(stderr, "Error: COMMAND or --wait or --idle missing.\n");
         print_help(argv[0], stderr);
         exit(EXIT_FAILURE);
     }

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -152,7 +152,7 @@ def test_version_without_hlwm_running():
 
 def test_quiet_without_hlwm_running():
     for flag in ['-q', '--quiet']:
-        cmd = [HC_PATH, flag, '-q', 'echo', 'test']
+        cmd = [HC_PATH, flag, 'echo', 'test']
         proc = subprocess.run(cmd,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -165,7 +165,7 @@ def test_quiet_without_hlwm_running():
 def test_quiet_with_hlwm_running(hlwm):
     # even with --quiet, herbstclient must produce output
     for flag in ['-q', '--quiet']:
-        cmd = [HC_PATH, flag, '-q', 'echo', 'test']
+        cmd = [HC_PATH, flag, 'echo', 'test']
         proc = subprocess.run(cmd,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,


### PR DESCRIPTION
This extends the tests for most command line flags of the herbstclient
command. Also, herbstclient now prints an error message if too few
parameters are passed.