### PR TITLE
Option --replace to replace existing window manager

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ Current git version
   * Do not draw frame background behind clients (so for semi-transparent
     client decorations, one does not see the frame decoration behind but the
     wallpaper instead)
+  * New command line option '--replace' for replacing an existing window manager.
   * The frame attributes ('selection', 'algorithm', 'fraction', 'split_type')
     are now writable.
   * The setting 'monitors_locked' is now explicitly an unsigned integer.

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -28,6 +28,8 @@ of available <<COMMANDS,*COMMANDS*>> is listed below.
         print a short help and exit
     *-c*, *--autostart* 'PATH'::
         use 'PATH' as autostart file instead of the one in '$XDG_CONFIG_HOME'
+    *--replace*::
+        Replace existing window manager.
     *-l*, *--locked*::
         Initially set the monitors_locked setting to 1
     *--exit-on-xerror*::

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -2,9 +2,9 @@
 
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
+#include <unistd.h>
 #include <algorithm>
 #include <cstdio>
-#include <unistd.h>
 
 #include "client.h"
 #include "globals.h"

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -4,6 +4,7 @@
 #include <X11/Xlib.h>
 #include <algorithm>
 #include <cstdio>
+#include <unistd.h>
 
 #include "client.h"
 #include "globals.h"
@@ -94,8 +95,13 @@ Ewmh::Ewmh(XConnection& xconnection)
     readInitialEwmhState();
 
     /* init for the supporting wm check */
-    windowManagerWindow_ = XCreateSimpleWindow(X_.display(), X_.root(),
-                                      -100, -100, 1, 1, 0, 0, CWOverrideRedirect | CWEventMask);
+    XSetWindowAttributes attr = {};
+    attr.override_redirect = true;
+    attr.event_mask = 0;
+    windowManagerWindow_ = XCreateWindow(X_.display(), X_.root(),
+                                         -100, -100, 1, 1, 0, 0, 0, nullptr,
+                                         CWOverrideRedirect | CWEventMask,
+                                         &attr);
     X_.setPropertyWindow(windowManagerWindow_, netatom_[NetSupportingWmCheck], { windowManagerWindow_ });
     XMapWindow(X_.display(), windowManagerWindow_);
 }
@@ -145,6 +151,60 @@ long Ewmh::windowGetInitialDesktop(Window win)
         return maybe_idx.value()[0];
     }
     return -1;
+}
+
+bool Ewmh::acquireScreenSelection(bool replaceExistingWm)
+{
+    // strongly inspired by the xfwm4 implementation
+    // https://git.xfce.org/xfce/xfwm4/commit/?h=xfce-4.4&id=4ed599c097aad946513f46b670b966dce2c1c0e2
+    Atom wmSnAtom = windowManagerSelection();
+    Window current_wm = XGetSelectionOwner (X_.display(), wmSnAtom);
+    if (current_wm) {
+        if (!replaceExistingWm) {
+            return false;
+        }
+        // get events when current wm shuts down
+        XSetWindowAttributes attrs;
+        attrs.event_mask = StructureNotifyMask;
+        if (!XChangeWindowAttributes(X_.display(), current_wm, CWEventMask, &attrs))
+        {
+            // if there was an error in XChangeWindowAttributes, then
+            // the current_wm disappeared in the mean time.
+            current_wm = 0;
+        }
+    }
+    // make ourselves the owner of the selection.
+    if (!XSetSelectionOwner(X_.display(), wmSnAtom, windowManagerWindow_, CurrentTime))
+    {
+        HSDebug("Can not aquire ownership on screen %d\n", X_.screen());
+        return false;
+    }
+    // if the old window manager looses ownership, it should shut down
+    if (current_wm) {
+        // wait for the window 'current_wm' to be destroyed.
+        int timeout = 10;
+        while (timeout > 0) {
+            HSDebug("Granting the old WM (0x%lx) %d seconds to shut down\n", current_wm, timeout);
+            XEvent event;
+            if (XCheckWindowEvent(X_.display(), current_wm, StructureNotifyMask, &event)) {
+                if (event.type == DestroyNotify) {
+                    return true;
+                }
+            }
+            timeout -= 1;
+            sleep(1);
+        }
+        // if the timeout is reached, then it didn't shut down fast enough
+        HSDebug("Previous window manager (window 0x%lx) did not shut down\n", current_wm);
+        return false;
+    }
+    return true;
+}
+
+Atom Ewmh::windowManagerSelection()
+{
+    string atomName = "WM_S" + std::to_string(X_.screen());
+    return XInternAtom(X_.display(), atomName.c_str(), False);
 }
 
 void Ewmh::InitialState::print(FILE *file)

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -22,6 +22,7 @@
 
 using std::pair;
 using std::string;
+using std::to_string;
 using std::vector;
 
 /* list of names of all _NET-atoms */
@@ -203,7 +204,7 @@ bool Ewmh::acquireScreenSelection(bool replaceExistingWm)
 
 Atom Ewmh::windowManagerSelection()
 {
-    string atomName = "WM_S" + std::to_string(X_.screen());
+    string atomName = "WM_S" + to_string(X_.screen());
     return XInternAtom(X_.display(), atomName.c_str(), False);
 }
 

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -177,7 +177,7 @@ bool Ewmh::acquireScreenSelection(bool replaceExistingWm)
     // make ourselves the owner of the selection.
     if (!XSetSelectionOwner(X_.display(), wmSnAtom, windowManagerWindow_, CurrentTime))
     {
-        HSDebug("Can not aquire ownership on screen %d\n", X_.screen());
+        HSDebug("Can not acquire ownership on screen %d\n", X_.screen());
         return false;
     }
     // if the old window manager looses ownership, it should shut down

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -116,6 +116,16 @@ public:
     const InitialState &initialState();
     long windowGetInitialDesktop(Window win);
 
+    /**
+     * @brief Check that no other window manager owns the screen
+     * selection according to ICCCM 2.8
+     * https://tronche.com/gui/x/icccm/sec-2.html#s-2.8
+     * @param whether to ask the other WM to stop
+     * @return if no other WM is running
+     */
+    bool acquireScreenSelection(bool replaceExistingWm);
+    Atom windowManagerSelection();
+    Window windowManagerWindow() { return windowManagerWindow_; }
     enum class WM { Name, Protocols, Delete, State, ChangeState, TakeFocus, Last };
 
     void injectDependencies(Root* root);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -375,11 +375,13 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
     int exit_on_xerror = g.exitOnXlibError;
     int noTransparency = !g.trueTransparency;
     int no_tag_import = 0;
+    int replace = 0;
     struct option long_options[] = {
         {"version",         0, nullptr, 'v'},
         {"help",            0, nullptr, 'h'},
         {"autostart",       1, nullptr, 'c'},
         {"locked",          0, nullptr, 'l'},
+        {"replace",         0, &replace, 1},
         {"no-transparency", 0, &noTransparency, 1},
         {"exit-on-xerror",  0, &exit_on_xerror, 1},
         {"no-tag-import",   0, &no_tag_import, 1},
@@ -435,6 +437,7 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
                 exit(EXIT_FAILURE);
         }
     }
+    g.replaceExistingWm = replace != 0;
     g.exitOnXlibError = exit_on_xerror != 0;
     g.importTagsFromEwmh = (no_tag_import == 0);
     g.trueTransparency = !noTransparency;
@@ -482,8 +485,8 @@ int main(int argc, char* argv[]) {
         exit(EXIT_FAILURE);
     }
     Ewmh* ewmh = new Ewmh(*X);
-    if (X->otherWmListensRoot()) {
-        std::cerr << "herbstluftwm: another window manager is already running" << endl;
+    if (!ewmh->acquireScreenSelection(g.replaceExistingWm) || X->otherWmListensRoot()) {
+        std::cerr << "herbstluftwm: another window manager is already running (try --replace)" << endl;
         delete X;
         exit(EXIT_FAILURE);
     }

--- a/src/root.h
+++ b/src/root.h
@@ -31,6 +31,7 @@ class Globals {
 public:
     Globals() = default;
     int initial_monitors_locked = 0;
+    bool replaceExistingWm = false;
     bool exitOnXlibError = false;
     bool importTagsFromEwmh = true;
     bool trueTransparency = true; // try true transparency via xrender

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -69,7 +69,7 @@ XMainLoop::XMainLoop(XConnection& X, Root* root)
     handlerTable_[ MotionNotify      ] = EH(&XMainLoop::motionnotify);
     handlerTable_[ PropertyNotify    ] = EH(&XMainLoop::propertynotify);
     handlerTable_[ UnmapNotify       ] = EH(&XMainLoop::unmapnotify);
-
+    handlerTable_[ SelectionClear    ] = EH(&XMainLoop::selectionclear);
     root_->monitors->dropEnterNotifyEvents
             .connect(this, &XMainLoop::dropEnterNotifyEvents);
 }
@@ -496,6 +496,16 @@ void XMainLoop::maprequest(XMapRequestEvent* mapreq) {
                 XMapWindow(X_.display(), window);
             }
         }
+    }
+}
+
+void XMainLoop::selectionclear(XSelectionClearEvent* event)
+{
+    if (event->selection == root_->ewmh_.windowManagerSelection()
+        && event->window == root_->ewmh_.windowManagerWindow())
+    {
+        HSDebug("Getting replaced by another window manager. exiting.");
+        quit();
     }
 }
 

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -40,6 +40,7 @@ private:
     void motionnotify(XMotionEvent* event);
     void mapnotify(XMapEvent* event);
     void maprequest(XMapRequestEvent* mapreq);
+    void selectionclear(XSelectionClearEvent* event);
     void propertynotify(XPropertyEvent* event);
     void unmapnotify(XUnmapEvent* event);
 


### PR DESCRIPTION
Herbstluftwm now uses the ICCCM-specified way of checking whether there
is an existing window manager, namely by checking the ownership
particular 'selection'. The owner of this selection is the active window
manager. This change introduces the new features:

    1. herbstluftwm does not start if the selection is already owned
    2. if herbstluftwm is started with --replace, try to become the
       owner of the selection
    3. if herbstluftwm looses the ownership, then quit, because there is
       some other window manager booting up.

In the test case, we only check that herbstluftwm can replace itself,
but I've tested it locally and the replacement works (forth and back)
with xfwm4, openbox, fvwm2, pekwm.

This change also adds a test case for the 'quit' command because it is
essentially half the test of '--replace'.

This implements #838.