### PR TITLE
Manage desktop windows in global stack

### DIFF
--- a/src/desktopwindow.cpp
+++ b/src/desktopwindow.cpp
@@ -4,6 +4,7 @@
 
 #include "globals.h"
 
+using std::function;
 using std::make_shared;
 using std::shared_ptr;
 using std::vector;
@@ -38,7 +39,7 @@ void DesktopWindow::unregisterDesktop(Window win) {
                   windows.end());
 }
 
-void DesktopWindow::foreachDesktopWindow(std::function<void (DesktopWindow&)> loopbody)
+void DesktopWindow::foreachDesktopWindow(function<void (DesktopWindow&)> loopbody)
 {
     for (auto& dw : windows) {
         loopbody(*dw.get());

--- a/src/desktopwindow.cpp
+++ b/src/desktopwindow.cpp
@@ -29,12 +29,6 @@ void DesktopWindow::registerDesktop(Window win) {
     windows.push_back(dw);
 }
 
-void DesktopWindow::lowerDesktopWindows() {
-    for (auto dw : windows) {
-        XLowerWindow(g_display, dw->win_);
-    }
-}
-
 void DesktopWindow::unregisterDesktop(Window win) {
     windows.erase(std::remove_if(
                    windows.begin(), windows.end(),
@@ -42,4 +36,11 @@ void DesktopWindow::unregisterDesktop(Window win) {
                         return win == dw->window();
                    }),
                   windows.end());
+}
+
+void DesktopWindow::foreachDesktopWindow(std::function<void (DesktopWindow&)> loopbody)
+{
+    for (auto& dw : windows) {
+        loopbody(*dw.get());
+    }
 }

--- a/src/desktopwindow.h
+++ b/src/desktopwindow.h
@@ -2,6 +2,7 @@
 #define __HERBSTLUFT_DESKTOPWINDOW_H_
 
 #include <X11/X.h>
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -18,6 +19,7 @@ public:
     static void registerDesktop(Window win);
     static void lowerDesktopWindows();
     static void unregisterDesktop(Window win);
+    static void foreachDesktopWindow(std::function<void(DesktopWindow&)> loopbody);
 private:
 
     // members:

--- a/src/desktopwindow.h
+++ b/src/desktopwindow.h
@@ -17,7 +17,6 @@ public:
     bool below() const;
     Window window() const;
     static void registerDesktop(Window win);
-    static void lowerDesktopWindows();
     static void unregisterDesktop(Window win);
     static void foreachDesktopWindow(std::function<void(DesktopWindow&)> loopbody);
 private:

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -7,6 +7,7 @@
 #include "argparse.h"
 #include "command.h"
 #include "completion.h"
+#include "desktopwindow.h"
 #include "ewmh.h"
 #include "floating.h"
 #include "frametree.h"
@@ -520,6 +521,9 @@ void MonitorManager::extractWindowStack(bool real_clients, function<void(Window)
 void MonitorManager::restack() {
     vector<Window> buf;
     extractWindowStack(false, [&buf](Window w) { buf.push_back(w); });
+    DesktopWindow::foreachDesktopWindow([&buf](DesktopWindow& dw) {
+        buf.push_back(dw.window());
+    });
     XRestackWindows(g_display, buf.data(), buf.size());
     Ewmh::get().updateClientListStacking();
 }
@@ -568,6 +572,15 @@ int MonitorManager::stackCommand(Output output) {
 
         monitors.push_back(make_shared<StringTree>(monitor->getDescription(), layers));
     }
+    vector<shared_ptr<StringTree>> desktopWins;
+    XConnection& X_ = XConnection::get();
+    DesktopWindow::foreachDesktopWindow([&desktopWins,&X_](DesktopWindow& dw) {
+        string txt = Converter<WindowID>::str(dw.window());
+        auto info = X_.getClassHint(dw.window());
+        txt += " " + info.first + " " + info.second;
+        desktopWins.push_back(make_shared<StringTree>(txt));
+    });
+    monitors.push_back(make_shared<StringTree>("Desktop Windows", desktopWins));
 
     auto stackRoot = make_shared<StringTree>("", monitors);
     tree_print_to(stackRoot, output);

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -117,7 +117,7 @@ void XMainLoop::scanExistingClients() {
         if (root_->ewmh_.getWindowType(win) == NetWmWindowTypeDesktop)
         {
             DesktopWindow::registerDesktop(win);
-            DesktopWindow::lowerDesktopWindows();
+            root_->monitors->restack();
             XMapWindow(X_.display(), win);
         }
         else if (root_->ewmh_.getWindowType(win) == NetWmWindowTypeDock)
@@ -147,6 +147,7 @@ void XMainLoop::scanExistingClients() {
         XReparentWindow(X_.display(), win, X_.root(), 0,0);
         clientmanager->manage_client(win, true, false, findTagForWindow(win));
     }
+    root_->monitors->restack();
 }
 
 
@@ -479,7 +480,7 @@ void XMainLoop::maprequest(XMapRequestEvent* mapreq) {
         if (root_->ewmh_.getWindowType(window) == NetWmWindowTypeDesktop)
         {
             DesktopWindow::registerDesktop(window);
-            DesktopWindow::lowerDesktopWindows();
+            root_->monitors->restack();
             XMapWindow(X_.display(), window);
         }
         else if (root_->ewmh_.getWindowType(window) == NetWmWindowTypeDock)

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -217,8 +217,6 @@ def test_stack_tree_desktop_windows(hlwm, x11):
       - {winid} TestDesktop TestDeskClass
 '''
     stack = hlwm.call('stack')
-    print("expected:")
-    print(expected_stack)
     assert stack.stdout == expected_stack
 
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -191,8 +191,35 @@ def test_stack_tree(hlwm):
         - Client <windowid> "bash"
       - Frame Layer
         - Window <windowid>
+    - Desktop Windows
 '''
     assert strip_winids(stack.stdout) == expected_stack
+
+
+def test_stack_tree_desktop_windows(hlwm, x11):
+
+    _, winid = x11.create_client(wm_class=('TestDesktop', 'TestDeskClass'),
+                                 window_type='_NET_WM_WINDOW_TYPE_DESKTOP')
+
+    # Simplified tree style:
+    hlwm.call('set tree_style "     - -"')
+    framewindows = [x11.winid_str(w) for w in x11.get_hlwm_frames()]
+    expected_stack = f'''\
+  -
+    - Monitor 0 with tag "default"
+      - Focus-Layer
+      - Fullscreen-Layer
+      - Floating-Layer
+      - Tiling-Layer
+      - Frame Layer
+        - Window {framewindows[0]}
+    - Desktop Windows
+      - {winid} TestDesktop TestDeskClass
+'''
+    stack = hlwm.call('stack')
+    print("expected:")
+    print(expected_stack)
+    assert stack.stdout == expected_stack
 
 
 @pytest.mark.parametrize("focus_idx", range(0, 4))


### PR DESCRIPTION
Instead of lowering desktop windows when they appear, manage desktop
windows in the global stack explicitly. Unfortunately, I did not find a
way to query the window stack. So for debugging and testing the output
of the `stack` command is extended by the desktop windows' winid and
window instance/class.

This solves an issue here where the Xfce's desktop window covered all
normal windows if I run `herbstluftwm --replace` in a running Xfce
session.