### PR TITLE
Objects for panels

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,8 @@ Current git version
   * New command line option '--replace' for replacing an existing window manager.
   * The frame attributes ('selection', 'algorithm', 'fraction', 'split_type')
     are now writable.
+  * New objects for panels (under 'panels', exposing attributes 'instance',
+    'class', 'geometry', 'winid')
   * The setting 'monitors_locked' is now explicitly an unsigned integer.
   * The setting 'default_frame_layout' now holds an algorithm name.
   * The 'shift' command now moves the window to a neighboured monitor if

--- a/doc/format-doc.py
+++ b/doc/format-doc.py
@@ -181,7 +181,10 @@ class ObjectDocPrinter:
             if depth > 0:
                 # add multiple format indicators, as for the
                 # attribute name above
-                itemname = f"*+[entryname]#{child['name']}#+*"
+                if child['name'] is not None:
+                    itemname = f"*+[entryname]#{child['name']}#+*"
+                else:
+                    itemname = f"'[entryname]#{child['name_pattern']}#'"
                 bullet = '*'
             else:
                 itemname = f"{child['name']}"

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -385,6 +385,9 @@ class ObjectInformation:
         def set_default_value(self, cpp_token):
             if TokenGroup.IsTokenGroup(cpp_token):
                 # drop surrounding '{' ... '}' if its an initializer list
+                if len(cpp_token.enclosed_tokens) == 0:
+                    cpp_token = None
+                    return
                 cpp_token = cpp_token.enclosed_tokens[0]
             if cpp_token[0:1] == ['-']:
                 # this is most probably a signed number
@@ -407,6 +410,7 @@ class ObjectInformation:
         def __init__(self, cpp_name):
             self.cpp_name = cpp_name
             self.user_name = None  # what the user sees
+            self.user_name_pattern = None  # if no concrete user_name can be given
             self.child_class = None  # whether this is a Link_ or a Child_
             self.type = None  # the template argument to Link_ or Child_
             self.constructor_args = None
@@ -455,6 +459,10 @@ class ObjectInformation:
         for (clsname, attrs), attr in self.member2info.items():
             if clsname == 'Settings':
                 attr.writable = True
+
+        child_info = self.child_info('PanelManager', '0xWindowID')
+        child_info.user_name_pattern = '0xWindowID'
+        child_info.type = ClassName('Panel')
 
     def attribute_info(self, classname: str, attr_cpp_name: str):
         """return the AttributeInformation object for
@@ -583,6 +591,8 @@ class ObjectInformation:
                             'type': member.type.to_user_type_name(),
                             'class': member.child_class,
                         }
+                        if member.user_name_pattern is not None:
+                            obj['name_pattern'] = member.user_name_pattern
                         if member.doc is not None:
                             obj['doc'] = member.doc
                         children[member.user_name] = obj

--- a/src/attribute_.h
+++ b/src/attribute_.h
@@ -207,6 +207,8 @@ template<>
 inline Type Attribute_<Color>::staticType() { return Type::COLOR; }
 template<>
 inline Type Attribute_<Rectangle>::staticType() { return Type::RECTANGLE; }
+template<>
+inline Type Attribute_<WindowID>::staticType() { return Type::WINDOW; }
 
 template<typename T>
 class DynAttribute_ : public Attribute {

--- a/src/entity.h
+++ b/src/entity.h
@@ -15,6 +15,7 @@ enum class Type {
     NAMES, // a enum type containing names
     FONT,
     RECTANGLE,
+    WINDOW,
 };
 
 static const std::map<Type, std::pair<std::string, char>> type_strings = {
@@ -28,6 +29,7 @@ static const std::map<Type, std::pair<std::string, char>> type_strings = {
     {Type::NAMES,   {"Names",        'n'}},
     {Type::FONT,    {"Font",         'f'}},
     {Type::RECTANGLE, {"Rectangle",  'R'}},
+    {Type::WINDOW,  {"WindowID",     'w'}},
 };
 
 bool operator<(Type t1, Type t2);

--- a/src/panelmanager.h
+++ b/src/panelmanager.h
@@ -3,6 +3,8 @@
 #include <X11/X.h>
 #include <unordered_map>
 
+#include "attribute_.h"
+#include "object.h"
 #include "rectangle.h"
 #include "signal.h"
 
@@ -10,7 +12,7 @@ class Panel;
 class Settings;
 class XConnection;
 
-class PanelManager {
+class PanelManager : public Object {
 public:
     class ReservedSpace {
     public:
@@ -42,8 +44,12 @@ public:
     ReservedSpace computeReservedSpace(Rectangle monitorDimension);
     Signal panels_changed_;
     void rootWindowChanged(int width, int height);
+    DynAttribute_<unsigned long> count;
 private:
     friend Panel;
+    unsigned long getCount() {
+        return static_cast<unsigned long>(panels_.size());
+    };
     bool updateReservedSpace(Panel* p, Rectangle geometry);
 
     std::unordered_map<Window, Panel*> panels_;

--- a/src/root.h
+++ b/src/root.h
@@ -55,6 +55,7 @@ public:
     Child_<KeyManager> keys;
     Child_<MonitorManager> monitors;
     Child_<MouseManager> mouse;
+    Child_<PanelManager> panels;
     Child_<RuleManager> rules;
     Child_<Settings> settings;
     Child_<TagManager> tags;
@@ -69,7 +70,6 @@ public:
     IpcServer& ipcServer_;
     //! Temporary member. In the long run, ewmh should get its information
     // automatically from the signals emitted by ClientManager, etc
-    std::unique_ptr<PanelManager> panels; // Using "pimpl" to avoid include
     Ewmh& ewmh_;
 
     // global actions

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -41,6 +41,20 @@ def test_auto_detect_panels(hlwm, x11, value):
         hlwm.attr.settings.auto_detect_panels = 'toggle'
 
 
+def test_panel_object(hlwm, x11):
+    assert int(hlwm.attr.panels.count()) == 0
+
+    _, winid = x11.create_client(geometry=(1, 0, 800, 30),
+                                 wm_class=('panelinst', 'panelclass'),
+                                 window_type='_NET_WM_WINDOW_TYPE_DOCK')
+
+    assert int(hlwm.attr.panels.count()) == 1
+    assert hlwm.attr.panels[winid].instance() == 'panelinst'
+    assert hlwm.attr.panels[winid]['class']() == 'panelclass'
+    assert hlwm.attr.panels[winid].geometry() == '800x30+1+0'
+    assert hlwm.attr.panels[winid].winid() == winid
+
+
 @pytest.mark.parametrize("which_pad, pad_size, geometry", [
     ("pad_left", 10, (-1, 0, 11, 400)),
     ("pad_right", 20, (800 - 20, 23, 20, 400)),


### PR DESCRIPTION
This makes PanelManager an object containing children for all panels. A
panel's window attribute is the first attribute to use the type WindowID
(whose converter has been used before already).

The documentation of a class is only included in the man page if there
is a path that leads to such an object. For panels, we can't provide
such a path in general. As a fix, instead of the 'name' of an entry in
an object, the json doc now mentions a 'name_pattern'. This
'name_pattern' can be put into the documentation, but the test cases in
test_doc.py must not treat this name literally.