### PR TITLE
Remove -Wuseless-cast

### DIFF
--- a/cmake/debugflags.cmake
+++ b/cmake/debugflags.cmake
@@ -43,7 +43,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # Add GCC- *and* C++-specific flags
     set(CXX_FLAGS ${CXX_FLAGS}
         # Additional warnings that don't come with Wall/Wextra:
-        -Wuseless-cast
         )
 endif()
 


### PR DESCRIPTION
The issue is that we have to make casts from platform dependently sized
types such as size_t to platform independent types such as unsigned
long. Such a cast is sometimes useless and sometimes important,
depending on the platform, so we can't omit it.

This should make #1214 build again which contained such a "useless" cast.