### PR TITLE
Add 'lower' command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,7 @@ Current git version
   * The setting 'default_frame_layout' now holds an algorithm name.
   * The 'shift' command now moves the window to a neighboured monitor if
     the window cannot be moved within a tag in the desired direction.
+  * New command 'lower' to lower a window in the stack.
   * Bug fixes:
     - Fix mistakenly transparent borders of argb clients
   * New dependency: xrender

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -474,13 +474,17 @@ focus_edge ['-i'|'-e'] 'DIRECTION'::
 +
 
 raise 'WINID'::
-    Raises the specified window. See the <<WINDOW_IDS, section on WINDOW IDS>>
-    on how to reference a certain window. Its result is only visible in floating
-    mode.
+    Raises the specified managed or unmanaged window. Managed windows are only
+    moved within the tag's stack (as reported by the 'stack' command), and unmanaged
+    windows are raised globally, i.e. are raised above all managed windows.
+    See the <<WINDOW_IDS, section on WINDOW IDS>> on how to reference a certain
+    window. Its result is only visible for floating windows and unmanaged windows.
 
-TIP: The 'WINID' also can specify an unmanaged window, although the completion
-for the raise command does not list the IDs of unmanaged windows.
-
+lower 'WINID'::
+    Lowers the specified managed or unmanaged window, analogously to the 'raise'
+    command: managed windows are lowered within the stack of floating windows
+    (with no effect for tiled windows) and unmanaged windows are moved below all
+    managed windows (for example, it can be used to lower desktop windows).
 
 jumpto 'WINID'::
     Puts the focus to the specified window. See the <<WINDOW_IDS, section on

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -285,6 +285,11 @@ void Client::raise() {
     this->tag()->stack->raiseSlice(this->slice);
 }
 
+void Client::lower()
+{
+    this->tag()->stack->lowerSlice(this->slice);
+}
+
 /**
  * @brief Client::resize_tiling
  * @param the outer geometry of the client

--- a/src/client.h
+++ b/src/client.h
@@ -111,6 +111,7 @@ public:
     void update_wm_hints();
     void update_title();
     void raise();
+    void lower();
 
     void send_configure();
     bool applysizehints(int *w, int *h);

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -107,13 +107,31 @@ void GlobalCommands::raiseCommand(CallOrComplete invoc)
 {
     Either<Client*,WindowID> clientOrWin = {nullptr};
     ArgParse().mandatory(clientOrWin).command(invoc,
-                                              [&] (Output output) {
+                                              [&] (Output) {
         auto forClients = [] (Client* client) {
             client->raise();
             client->needsRelayout.emit(client->tag());
         };
         auto forWindowIDs = [&] (WindowID window) {
             XRaiseWindow(root_.X.display(), window);
+        };
+        clientOrWin.cases(forClients, forWindowIDs);
+        return 0;
+    });
+}
+
+
+void GlobalCommands::lowerCommand(CallOrComplete invoc)
+{
+    Either<Client*,WindowID> clientOrWin = {nullptr};
+    ArgParse().mandatory(clientOrWin).command(invoc,
+                                              [&] (Output) {
+        auto forClients = [] (Client* client) {
+            client->lower();
+            client->needsRelayout.emit(client->tag());
+        };
+        auto forWindowIDs = [&] (WindowID window) {
+            XLowerWindow(root_.X.display(), window);
         };
         clientOrWin.cases(forClients, forWindowIDs);
         return 0;

--- a/src/globalcommands.h
+++ b/src/globalcommands.h
@@ -27,6 +27,7 @@ public:
     void bring(Client* client);
 
     void raiseCommand(CallOrComplete invoc);
+    void lowerCommand(CallOrComplete invoc);
 private:
     Root& root_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,6 +167,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
         {"monitor_rect",   { monitors, &MonitorManager::rectCommand }},
         {"pad",            { monitors, &MonitorManager::padCommand }},
         {"raise",          { global_cmds, &GlobalCommands::raiseCommand }},
+        {"lower",          { global_cmds, &GlobalCommands::lowerCommand }},
         {"rule",           {rules, &RuleManager::addRuleCommand,
                                    &RuleManager::addRuleCompletion}},
         {"unrule",         {rules, &RuleManager::unruleCommand,

--- a/src/plainstack.h
+++ b/src/plainstack.h
@@ -25,6 +25,14 @@ public:
         // that it becomes the new first element
         std::rotate(data_.begin(), it, it + 1);
     }
+    void lower(const T& element) {
+        auto it = std::find(data_.begin(), data_.end(), element);
+        assert(it != data_.end());
+        // rotate the range (it, end] in such a way
+        // that it+1 becomes the first element. Hence,
+        // it must have become the last element.
+        std::rotate(it, it + 1, data_.end());
+    }
     typename std::vector<T>::const_iterator begin() const {
         return data_.cbegin();
     }

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -142,6 +142,14 @@ void Stack::raiseSlice(Slice* slice) {
     dirty = true;
 }
 
+void Stack::lowerSlice(Slice* slice) {
+    for (auto layer : slice->layers) {
+        layers_[layer].lower(slice);
+    }
+    dirty = true;
+}
+
+
 //! insert the slice to the given layer. if 'insertOnTop' is set, insert at the top
 //! otherwise insert at the bottom of the layer
 void Stack::sliceAddLayer(Slice* slice, HSLayer layer, bool insertOnTop) {

--- a/src/stack.h
+++ b/src/stack.h
@@ -60,6 +60,7 @@ public:
     void insertSlice(Slice* elem);
     void removeSlice(Slice* elem);
     void raiseSlice(Slice* slice);
+    void lowerSlice(Slice* slice);
     void sliceAddLayer(Slice* slice, HSLayer layer, bool insertOnTop = true);
     void sliceRemoveLayer(Slice* slice, HSLayer layer);
     bool isLayerEmpty(HSLayer layer);

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -155,6 +155,7 @@ def test_completable_commands(hlwm, request, run_destructives):
         'false': {1},
         'close': {3},
         'raise': {3},
+        'lower': {3},
         'jumpto': {3},
         'remove_monitor': {6},
         'use_index': {3},

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -556,7 +556,10 @@ def test_raise_lower_winid_missing(hlwm):
         .expect_stderr('lower: not enough arguments\n')
 
 
-def test_raise_invalid_winid(hlwm):
+def test_raise_lower_invalid_winid(hlwm):
+    hlwm.call_xfail('raise foobar') \
+        .expect_stderr('Invalid format, expecting')
+
     hlwm.call_xfail('lower foobar') \
         .expect_stderr('Invalid format, expecting')
 

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -548,13 +548,16 @@ def test_integer_out_of_range(hlwm):
                 .expect_stderr('out of range')
 
 
-def test_raise_winid_missing(hlwm):
+def test_raise_lower_winid_missing(hlwm):
     hlwm.call_xfail('raise') \
         .expect_stderr('raise: not enough arguments\n')
 
+    hlwm.call_xfail('lower') \
+        .expect_stderr('lower: not enough arguments\n')
+
 
 def test_raise_invalid_winid(hlwm):
-    hlwm.call_xfail('raise foobar') \
+    hlwm.call_xfail('lower foobar') \
         .expect_stderr('Invalid format, expecting')
 
 


### PR DESCRIPTION
Analogously to the 'raise' command, there should be a 'lower' command
that lowers a managed or unmanaged window in the stack. For example,
this can be used to manually lower a desktop window.

Fortunately, the test cases for 'raise' could either extended or easily
adapted to the 'lower' command.