### PR TITLE
Man page generation: add dependency on source txt

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -84,7 +84,7 @@ function(gen_manpage sourcefile man_nr)
                     -a \"builddir=${CMAKE_CURRENT_BINARY_DIR}\"
                     --destination-dir="${CMAKE_CURRENT_BINARY_DIR}"
                     ${src}
-            DEPENDS ${ARGN}
+            DEPENDS ${src} ${ARGN}
             )
     endif()
     install(FILES ${dst} DESTINATION "${MANDIR}/man${man_nr}")


### PR DESCRIPTION
In the commit 59e175a68c81e53b0291c1e5d1ed1cee9ce978f6 (#1166)
I accidentally removed the dependency of the man page on the
asciidoc source file (doc/herbstluftwm.txt). This resulted in the man
page not being updated after changing doc/herbstluftwm.txt.