### PR TITLE
New objects for types documentation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,7 @@ Current git version
   * New command 'lower' to lower a window in the stack.
   * The 'cycle_value' command now expects an attribute (and only works for
     settings for compatibility).
+  * New object 'types' containing documentation on (attribute-) types.
   * Bug fixes:
     - Fix mistakenly transparent borders of argb clients
   * New dependency: xrender

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -192,7 +192,11 @@ false::
     Ignores all arguments and always returns failure, i.e. 1.
 
 help ['OBJECT'|'ATTRIBUTE']::
-    Print help on a given object or attribute.
+    Print help on a given object or attribute. For example:
+
+    * help clients.focus
+    * help monitors
+    * help types.color
 
 list_commands::
     Lists all available commands.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(herbstluftwm PRIVATE
     tilingresult.cpp tilingresult.h
     tmp.cpp tmp.h
     types.cpp types.h
+    typesdoc.cpp typesdoc.h
     utils.cpp utils.h
     watchers.h watchers.cpp
     x11-types.cpp x11-types.h

--- a/src/entity.h
+++ b/src/entity.h
@@ -19,17 +19,17 @@ enum class Type {
 };
 
 static const std::map<Type, std::pair<std::string, char>> type_strings = {
-    {Type::INT,     {"Integer",      'i'}},
-    {Type::ULONG,   {"Unsigned",     'u'}},
-    {Type::BOOL,    {"Boolean",      'b'}},
-    {Type::DECIMAL, {"Decimal",      'd'}},
-    {Type::COLOR,   {"Color",        'c'}},
-    {Type::STRING,  {"String",       's'}},
-    {Type::REGEX,   {"Regex",        'r'}},
-    {Type::NAMES,   {"Names",        'n'}},
-    {Type::FONT,    {"Font",         'f'}},
-    {Type::RECTANGLE, {"Rectangle",  'R'}},
-    {Type::WINDOW,  {"WindowID",     'w'}},
+    {Type::BOOL,    {"bool",         'b'}},
+    {Type::COLOR,   {"color",        'c'}},
+    {Type::DECIMAL, {"decimal",      'd'}},
+    {Type::FONT,    {"font",         'f'}},
+    {Type::INT,     {"int",          'i'}},
+    {Type::NAMES,   {"names",        'n'}},
+    {Type::RECTANGLE, {"rectangle",  'R'}},
+    {Type::REGEX,   {"regex",        'r'}},
+    {Type::STRING,  {"string",       's'}},
+    {Type::ULONG,   {"uint",         'u'}},
+    {Type::WINDOW,  {"windowid",     'w'}},
 };
 
 bool operator<(Type t1, Type t2);

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -19,6 +19,7 @@
 #include "tagmanager.h"
 #include "theme.h"
 #include "tmp.h"
+#include "typesdoc.h"
 #include "utils.h"
 #include "watchers.h"
 
@@ -37,6 +38,7 @@ Root::Root(Globals g, XConnection& xconnection, Ewmh& ewmh, IpcServer& ipcServer
     , tags(*this, "tags")
     , theme(*this, "theme")
     , tmp(*this, TMP_OBJECT_PATH)
+    , types(*this, "types")
     , watchers(*this, "watchers")
     , globals(g)
     , meta_commands(make_unique<MetaCommands>(*this))
@@ -56,6 +58,7 @@ Root::Root(Globals g, XConnection& xconnection, Ewmh& ewmh, IpcServer& ipcServer
     tags.init();
     theme.init();
     tmp.init();
+    types.init();
     watchers.init();
 
     // inject dependencies where needed

--- a/src/root.h
+++ b/src/root.h
@@ -24,6 +24,7 @@ class Settings; // IWYU pragma: keep
 class TagManager; // IWYU pragma: keep
 class Theme; // IWYU pragma: keep
 class Tmp; // IWYU pragma: keep
+class TypesDoc; // IWYU pragma: keep
 class Watchers;
 class XConnection;
 
@@ -61,6 +62,7 @@ public:
     Child_<TagManager> tags;
     Child_<Theme> theme;
     Child_<Tmp> tmp;
+    Child_<TypesDoc> types;
     Child_<Watchers> watchers;
 
     Globals globals;

--- a/src/typesdoc.cpp
+++ b/src/typesdoc.cpp
@@ -1,0 +1,82 @@
+#include "typesdoc.h"
+
+#include <vector>
+
+#include "attribute_.h"
+
+using std::string;
+using std::vector;
+
+class TypeDesc : public Object {
+public:
+    Attribute_<string> fullname_;
+    Attribute_<string> shortname_;
+
+    TypeDesc(Type type)
+        : fullname_(this, "fullname", {})
+        , shortname_(this, "shortname", {})
+    {
+        fullname_ = Entity::typestr(type);
+        shortname_ = string() + Entity::typechar(type);
+
+        fullname_.setDoc("the full and unique name of this type");
+        shortname_.setDoc(
+            "A short (one-character long) name of this type "
+            "which is used in the output of the 'attr' command"
+        );
+    }
+};
+
+TypesDoc::TypesDoc()
+    : bool_(*this, "bool")
+    , color_(*this, "color")
+    , decimal_(*this, "decimal")
+    // , font_(*this, "font") // TODO
+    , int_(*this, "int")
+    // , names_(*this, "names") // TODO
+    // , rectangle_(*this, "rectangle") // TODO
+    // , regex_(*this, "regex") // TODO
+    , string_(*this, "string")
+    , uint_(*this, "uint")
+    // , windowid_(*this, "windowid") // TODO
+{
+    setDoc(
+        "This lists the types that are used for attributes and command arguments.");
+    bool_.init(Type::BOOL);
+    bool_.setDoc(
+        "Type representing boolean values, i.e. an 'on' or 'off' state,"
+        "with aliases 'true' and 'false'. When writing to a boolean value,"
+        "one can also specify 'toggle' in order to alter its value."
+    );
+
+    color_.init(Type::COLOR);
+    color_.setDoc(
+        "Type representing colors.\n"
+        "A color can be defined in one of the following formats:\n"
+        "1. #RRGGBB where R, G, B are hexidecimal digits (0-9, A-F),\n"
+        "   and RR, GG, BB represent the values for red, green, blue.\n"
+        "2. #RRGGBBAA represents a color with alpha-value AA.\n"
+        "   The alpha value 00 is fully transparent and FF is fully\n"
+        "   opaque/intransparent.\n"
+        "3. a common color name like 'red', 'blue,' 'orange', etc.\n"
+    );
+
+    decimal_.init(Type::DECIMAL);
+    decimal_.setDoc("Fixed precision decimal numbers, e.g. 0.34");
+
+    int_.init(Type::INT);
+    int_.setDoc("Type representing signed integers");
+
+    string_.init(Type::STRING);
+    string_.setDoc("Type representing normal text.");
+
+    uint_.init(Type::ULONG);
+    uint_.setDoc("Type representing unsigned (i.e. non-negative) integers");
+}
+
+TypesDoc::~TypesDoc()
+{
+    // we need to define the destructor explicitly,
+    // because the implicit constructor in the ".h file"
+    // fails since TypeDesc is an incomplete type there.
+}

--- a/src/typesdoc.h
+++ b/src/typesdoc.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "child.h"
+#include "object.h"
+
+class TypeDesc;
+
+/**
+ * @brief expose meta-information on the types via the object tree.
+ *
+ * Its main purpose is that the auto-generated documentation describes
+ * the types and their syntax. Hence, the documentation on the types
+ * is in the man page and in the interactive help, thus one can run
+ * for example `herbstclient help types.color` in order to obtain
+ * information on the syntax of colors.
+ */
+class TypesDoc : public Object
+{
+public:
+    TypesDoc();
+    ~TypesDoc();
+private:
+    Child_<TypeDesc> bool_;
+    Child_<TypeDesc> color_;
+    Child_<TypeDesc> decimal_;
+    // Child_<TypeDesc> font_; // TODO
+    Child_<TypeDesc> int_;
+    // Child_<TypeDesc> names_; // TODO
+    // Child_<TypeDesc> rectangle_; // TODO
+    // Child_<TypeDesc> regex_; // TODO
+    Child_<TypeDesc> string_;
+    Child_<TypeDesc> uint_;
+    // Child_<TypeDesc> windowid_; // TODO
+};

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -183,7 +183,7 @@ def test_attribute_completion(hlwm):
     assert complete('monitors.fooob') == []
     assert complete('monitors.fooo.bar') == []
     assert len(complete('monitors.focus.')) >= 8
-    assert complete('t') == ['tags.', 'theme.', 'tmp.']
+    assert complete('t') == ['tags.', 'theme.', 'tmp.', 'types.']
     assert complete('') == [child + '.' for child in hlwm.list_children_via_attr('')]
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -69,3 +69,9 @@ def test_int_uint_unparsable_suffix(hlwm):
 
         hlwm.call_xfail(['set_attr', attr, '+3x']) \
             .expect_stderr('unparsable suffix')
+
+
+def test_type_children_names(hlwm):
+    types = hlwm.list_children('types')
+    for t in types:
+        assert hlwm.attr.types[t].fullname() == t


### PR DESCRIPTION
This extends the object tree to also contain meta-information on the
available types. In order to keep the diff small, only the most basic
types are included.

The table defining the names of the types has not been used really (only
in the 'help' command so far). To make the names more uniform, I have
adjusted the names such that they match to the type argument of the
`new_attr` command (in the long run, `new_attr` should of course work
for all entries of the Types enum).

Since the objects essentially consist of documentation, there is not
much to test.