### PR TITLE
Rename types.h (and .cpp) -> converter.h (and .cpp)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ target_sources(herbstluftwm PRIVATE
     theme.cpp theme.h
     tilingresult.cpp tilingresult.h
     tmp.cpp tmp.h
-    types.cpp types.h
+    converter.cpp converter.h
     utils.cpp utils.h
     watchers.h watchers.cpp
     x11-types.cpp x11-types.h

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -7,7 +7,7 @@
 
 #include "commandio.h"
 #include "ipc-protocol.h"
-#include "types.h"
+#include "converter.h"
 
 /**
  * @brief The InputConvert class is a convenience wrapper around Input::operator>> and

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -6,8 +6,8 @@
 #include <vector>
 
 #include "commandio.h"
-#include "ipc-protocol.h"
 #include "converter.h"
+#include "ipc-protocol.h"
 
 /**
  * @brief The InputConvert class is a convenience wrapper around Input::operator>> and

--- a/src/client.h
+++ b/src/client.h
@@ -11,7 +11,7 @@
 #include "rectangle.h"
 #include "regexstr.h"
 #include "theme.h"
-#include "types.h"
+#include "converter.h"
 #include "x11-types.h"
 
 class Decoration;

--- a/src/client.h
+++ b/src/client.h
@@ -5,9 +5,9 @@
 #include <X11/Xlib.h>
 
 #include "attribute_.h"
-#include "converter.h"
 #include "child.h"
 #include "commandio.h"
+#include "converter.h"
 #include "object.h"
 #include "rectangle.h"
 #include "regexstr.h"

--- a/src/client.h
+++ b/src/client.h
@@ -5,13 +5,13 @@
 #include <X11/Xlib.h>
 
 #include "attribute_.h"
+#include "converter.h"
 #include "child.h"
 #include "commandio.h"
 #include "object.h"
 #include "rectangle.h"
 #include "regexstr.h"
 #include "theme.h"
-#include "converter.h"
 #include "x11-types.h"
 
 class Decoration;

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -1,4 +1,4 @@
-#include "types.h"
+#include "converter.h"
 
 #include "completion.h"
 

--- a/src/converter.h
+++ b/src/converter.h
@@ -1,9 +1,4 @@
-#ifndef HERBSTLUFT_TYPES_H
-#define HERBSTLUFT_TYPES_H
-
-/** Definition of core types
- *
- */
+#pragma once
 
 #include <map>
 #include <set>
@@ -14,6 +9,12 @@ class Completion;
 
 // only a trick such that we don't need to include completion.h here
 void completeFull(Completion& complete, std::string string);
+
+/**
+ * The Converter<T> class provides static functions for all the I/O-operations
+ * of the type T, used in parsing and printing of attributes and in the
+ * parsing and completion of command line arguments.
+ */
 
 /* Primitive types that can be converted from/to user input/output */
 template<typename T, typename = void>
@@ -123,5 +124,3 @@ inline Direction Converter<Direction>::parse(const std::string &payload) {
 template<> void Converter<Direction>::complete(Completion& complete, Direction const* relativeTo);
 
 // Note: include x11-types.h for colors
-
-#endif

--- a/src/either.h
+++ b/src/either.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <type_traits>
 
-#include "types.h"
+#include "converter.h"
 
 /**
  * The Either<A,B> class holds either something of type

--- a/src/finite.h
+++ b/src/finite.h
@@ -3,7 +3,7 @@
 #include <type_traits>
 
 #include "completion.h"
-#include "types.h"
+#include "converter.h"
 
 /** The Finite<T> class defines the Converter methods
  * for enum class types, that is, for types with only finitely many values.

--- a/src/fixprecdec.h
+++ b/src/fixprecdec.h
@@ -2,7 +2,7 @@
 #define FIXPRECDEC_H
 
 #include "attribute_.h"
-#include "types.h"
+#include "converter.h"
 
 /**
  * @brief A class for fixed precision decimals encoded in the type int.

--- a/src/font.h
+++ b/src/font.h
@@ -6,7 +6,7 @@
 
 #include "attribute_.h"
 #include "entity.h"
-#include "types.h"
+#include "converter.h"
 
 class FontData;
 class XConnection;

--- a/src/font.h
+++ b/src/font.h
@@ -5,8 +5,8 @@
 #include <string>
 
 #include "attribute_.h"
-#include "entity.h"
 #include "converter.h"
+#include "entity.h"
 
 class FontData;
 class XConnection;

--- a/src/framedata.h
+++ b/src/framedata.h
@@ -17,9 +17,9 @@
 #include <vector>
 
 #include "attribute_.h"
+#include "converter.h"
 #include "finite.h"
 #include "fixprecdec.h"
-#include "converter.h"
 
 class Client;
 

--- a/src/framedata.h
+++ b/src/framedata.h
@@ -19,7 +19,7 @@
 #include "attribute_.h"
 #include "finite.h"
 #include "fixprecdec.h"
-#include "types.h"
+#include "converter.h"
 
 class Client;
 

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -6,11 +6,11 @@
 #include <string>
 
 #include "child.h"
+#include "converter.h"
 #include "finite.h"
 #include "fixprecdec.h"
 #include "link.h"
 #include "object.h"
-#include "converter.h"
 
 class Client;
 class Completion;

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -10,7 +10,7 @@
 #include "fixprecdec.h"
 #include "link.h"
 #include "object.h"
-#include "types.h"
+#include "converter.h"
 
 class Client;
 class Completion;

--- a/src/keycombo.h
+++ b/src/keycombo.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "types.h"
+#include "converter.h"
 
 /*!
  * Represents the press of a combination of modifiers keys.

--- a/src/layout.h
+++ b/src/layout.h
@@ -7,11 +7,11 @@
 #include <memory>
 
 #include "attribute_.h"
+#include "converter.h"
 #include "framedata.h"
 #include "link.h"
 #include "object.h"
 #include "tilingresult.h"
-#include "converter.h"
 #include "x11-types.h"
 
 // execute an action on an client

--- a/src/layout.h
+++ b/src/layout.h
@@ -11,7 +11,7 @@
 #include "link.h"
 #include "object.h"
 #include "tilingresult.h"
-#include "types.h"
+#include "converter.h"
 #include "x11-types.h"
 
 // execute an action on an client

--- a/src/metacommands.h
+++ b/src/metacommands.h
@@ -7,7 +7,7 @@
 
 #include "attribute.h"
 #include "commandio.h"
-#include "types.h"
+#include "converter.h"
 
 class Object;
 class Completion;

--- a/src/object.h
+++ b/src/object.h
@@ -10,7 +10,7 @@
 #include "arglist.h"
 #include "commandio.h"
 #include "entity.h"
-#include "types.h"
+#include "converter.h"
 
 #define OBJECT_PATH_SEPARATOR '.'
 #define USER_ATTRIBUTE_PREFIX "my_"

--- a/src/object.h
+++ b/src/object.h
@@ -9,8 +9,8 @@
 
 #include "arglist.h"
 #include "commandio.h"
-#include "entity.h"
 #include "converter.h"
+#include "entity.h"
 
 #define OBJECT_PATH_SEPARATOR '.'
 #define USER_ATTRIBUTE_PREFIX "my_"

--- a/src/rectangle.h
+++ b/src/rectangle.h
@@ -4,7 +4,7 @@
 #include <string>
 
 #include "commandio.h"
-#include "types.h"
+#include "converter.h"
 #include "x11-types.h"
 
 struct Rectangle {

--- a/src/regexstr.h
+++ b/src/regexstr.h
@@ -4,7 +4,7 @@
 #include <regex>
 
 #include "attribute_.h"
-#include "types.h"
+#include "converter.h"
 
 /** wrapper class for extended regexes that remembers
  * its source string

--- a/src/rules.h
+++ b/src/rules.h
@@ -7,7 +7,7 @@
 #include "finite.h"
 #include "optional.h"
 #include "regexstr.h"
-#include "types.h"
+#include "converter.h"
 
 class Client;
 

--- a/src/rules.h
+++ b/src/rules.h
@@ -4,10 +4,10 @@
 #include <functional>
 #include <regex>
 
+#include "converter.h"
 #include "finite.h"
 #include "optional.h"
 #include "regexstr.h"
-#include "converter.h"
 
 class Client;
 

--- a/src/runtimeconverter.h
+++ b/src/runtimeconverter.h
@@ -2,7 +2,7 @@
 
 #include <type_traits>
 
-#include "types.h"
+#include "converter.h"
 
 /**
  * the same definition as 'Converter', but without the 'static'

--- a/src/watchers.h
+++ b/src/watchers.h
@@ -4,8 +4,8 @@
 #include <string>
 
 #include "attribute_.h"
-#include "object.h"
 #include "converter.h"
+#include "object.h"
 
 class Completion;
 

--- a/src/watchers.h
+++ b/src/watchers.h
@@ -5,7 +5,7 @@
 
 #include "attribute_.h"
 #include "object.h"
-#include "types.h"
+#include "converter.h"
 
 class Completion;
 

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "types.h"
+#include "converter.h"
 
 class XConnection;
 


### PR DESCRIPTION
The types.h file mainly contains the Converter definition, and has
nothing to do with the Type enum (which is defined in entity.h). Thus, I
think it is more appropriate to call the file converter.h.