### PR TITLE
Start --locked from the .desktop file

### DIFF
--- a/share/herbstluftwm.desktop
+++ b/share/herbstluftwm.desktop
@@ -2,5 +2,5 @@
 Encoding=UTF-8
 Name=herbstluftwm
 Comment=Manual tiling window manager
-Exec=herbstluftwm
+Exec=herbstluftwm --locked
 Type=Application


### PR DESCRIPTION
As noticed by @Barbarossa93 in #599, this isn't the default although
the default autostart does `unlock`