### PR TITLE
Migrate the use_previous command to ArgParse

### DIFF
--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -106,6 +106,25 @@ void GlobalCommands::cycleValueCompletion(Completion& complete)
     }
 }
 
+void GlobalCommands::usePreviousCommand(CallOrComplete invoc)
+{
+    ArgParse().command(invoc,
+                       [&] (Output output) {
+        Monitor* monitor = root_.monitors->focus();
+        HSTag* tag = monitor->tag_previous;
+        HSAssert(tag);
+        int ret = monitor_set_tag(monitor, tag);
+        if (ret != 0) {
+            output << "use_previous: Could not change tag";
+            if (monitor->lock_tag()) {
+                output << " (monitor is locked)";
+            }
+            output << "\n";
+        }
+        return ret;
+    });
+}
+
 void GlobalCommands::jumptoCommand(CallOrComplete invoc)
 {
     Client* client = nullptr;

--- a/src/globalcommands.h
+++ b/src/globalcommands.h
@@ -24,6 +24,8 @@ public:
     int cycleValueCommand(Input input, Output output);
     void cycleValueCompletion(Completion& complete);
 
+    void usePreviousCommand(CallOrComplete invoc);
+
     void jumptoCommand(CallOrComplete invoc);
 
     void bringCommand(CallOrComplete invoc);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,7 +142,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
         {"add",            BIND_OBJECT(tags, tag_add_command) },
         {"use",            monitor_set_tag_command},
         {"use_index",      monitor_set_tag_by_index_command},
-        {"use_previous",   { monitor_set_previous_tag_command }},
+        {"use_previous",   {global_cmds, &GlobalCommands::usePreviousCommand }},
         {"jumpto",         {global_cmds, &GlobalCommands::jumptoCommand }},
         {"floating",       { tags, &TagManager::floatingCmd,
                                    &TagManager::floatingComplete }},

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -499,21 +499,6 @@ int monitor_set_tag_by_index_command(int argc, char** argv, Output output) {
     return ret;
 }
 
-int monitor_set_previous_tag_command(Output output) {
-    Monitor* monitor = get_current_monitor();
-    HSTag*  tag = monitor->tag_previous;
-    if (monitor && tag) {
-        int ret = monitor_set_tag(monitor, tag);
-        if (ret != 0) {
-            output << "use_previous: Could not change tag (maybe monitor is locked?)\n";
-        }
-        return ret;
-    } else {
-        output << "use_previous: Invalid monitor or tag\n";
-        return HERBST_INVALID_ARGUMENT;
-    }
-}
-
 void monitor_focus_by_index(unsigned new_selection) {
     // clamp to last
     new_selection = std::min(g_monitors->size() - 1, (size_t)new_selection);
@@ -611,14 +596,6 @@ void Monitor::restack() {
     };
     tag->stack->extractWindows(false, addToVector);
     XRestackWindows(g_display, buf.data(), buf.size());
-}
-
-void all_monitors_replace_previous_tag(HSTag *old, HSTag *newmon) {
-    for (auto m : *g_monitors) {
-        if (m->tag_previous == old) {
-            m->tag_previous = newmon;
-        }
-    }
 }
 
 Rectangle Monitor::getFloatingArea() const {

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -20,8 +20,8 @@ public:
     int relativeX(int x_root);
     int relativeY(int y_root);
 
-    HSTag*      tag;    // currently viewed tag
-    HSTag*      tag_previous;    // previously viewed tag
+    HSTag*      tag;    // currently viewed tag, this is always non-null
+    HSTag*      tag_previous;    // previously viewed tag, this is always non-null
     Attribute_<std::string>   name;
     Attribute_<unsigned long> index;
     DynAttribute_<std::string>   tag_string;
@@ -74,10 +74,8 @@ Monitor* get_current_monitor();
 int monitor_set_tag(Monitor* monitor, HSTag* tag);
 int monitor_set_tag_command(int argc, char** argv, Output output);
 int monitor_set_tag_by_index_command(int argc, char** argv, Output output);
-int monitor_set_previous_tag_command(Output output);
 void all_monitors_apply_layout();
 void ensure_monitors_are_available();
-void all_monitors_replace_previous_tag(HSTag* old, HSTag* newmon);
 
 void monitor_update_focus_objects();
 

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -876,6 +876,15 @@ Rectangle MonitorManager::interpretGlobalGeometry(Rectangle globalGeometry)
     return globalGeometry;
 }
 
+void MonitorManager::replacePreviousTag(HSTag* tagToRemove, HSTag* targetTag)
+{
+    for (Monitor* m : *this) {
+        if (m->tag_previous == tagToRemove) {
+            m->tag_previous = targetTag;
+        }
+    }
+}
+
 int MonitorManager::raiseMonitorCommand(Input input, Output output) {
     string monitorName = "";
     input >> monitorName;

--- a/src/monitormanager.h
+++ b/src/monitormanager.h
@@ -100,6 +100,8 @@ public:
 
     Rectangle interpretGlobalGeometry(Rectangle globalGeometry);
 
+    void replacePreviousTag(HSTag* tagToRemove, HSTag* targetTag);
+
     int cur_monitor;
 
     /**

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -135,7 +135,7 @@ int TagManager::removeTag(Input input, Output output) {
     }
 
     // Prevent dangling tag_previous pointers
-    all_monitors_replace_previous_tag(tagToRemove, targetTag);
+    monitors_->replacePreviousTag(tagToRemove, targetTag);
 
     // Collect all clients in tag
     vector<Client*> clients;

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -280,6 +280,43 @@ def test_use_previous_on_stolen_monitor(hlwm):
     assert hlwm.get_attr('tags.focus.name') == 'tag3'
 
 
+def test_use_previous_on_removed_tag(hlwm):
+    hlwm.call('add rmtag')
+    hlwm.call('add targettag')
+    hlwm.call('use rmtag')
+    hlwm.call('use_index 0')
+
+    # 'targettag' should inherit everything from 'rmtag'
+    hlwm.call('merge_tag rmtag targettag')
+    hlwm.call('use_previous')
+
+    assert hlwm.attr.tags.focus.name() == 'targettag'
+
+
+def test_use_previous_nothing_viewed_before(hlwm):
+    hlwm.call('add other_tag_that_may_not_be_used')
+
+    # is a no-op:
+    hlwm.call('use_previous')
+
+    assert hlwm.attr.monitors.focus.index() == '0'
+
+
+def test_use_previous_on_locked_monitor(hlwm):
+    hlwm.call('add othertag')
+    hlwm.call('use othertag')
+    hlwm.call('use_index 0')
+
+    hlwm.attr.monitors.focus.lock_tag = 'on'
+
+    hlwm.call_xfail('use_previous') \
+        .expect_stderr('Could not change tag.*monitor is locked')
+
+
+def test_use_previous_no_completion(hlwm):
+    hlwm.command_has_all_args(['use_previous'])
+
+
 @pytest.mark.parametrize("two_monitors", [True, False])
 def test_initial_client_position(hlwm, x11, two_monitors):
     # create two monitors side by side (with a little y-offset)


### PR DESCRIPTION
Just like use and use_index, the 'use_previous' command fits well into
GlobalCommands. There were already some tests in test_monitor.py and
I've extended them slightly (and left them in test_monitor.py).