### PR TITLE
Use posix escaping in Completion objects

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -303,19 +303,18 @@ static void try_complete_suffix(const char* needle, const char* to_check, const 
         }
     }
     if (matches) {
-        char* escaped = nullptr;
-        if (g_shell_quoting) {
-            escaped = posix_sh_escape(to_check);
-        }
-        char* prefix_escaped = nullptr;
         if (prefix) {
             if (g_shell_quoting) {
-                prefix_escaped = posix_sh_escape(prefix);
+                output << posix_sh_escape(prefix);
+            } else {
+                output << prefix;
             }
-            output << (prefix_escaped ? prefix_escaped : prefix);
         }
-        output << (escaped ? escaped : to_check);
-        free(escaped);
+        if (g_shell_quoting) {
+            output << posix_sh_escape(to_check);
+        } else {
+            output << to_check;
+        }
         output << suffix;
     }
 }

--- a/src/completion.cpp
+++ b/src/completion.cpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "utils.h"
+
 using std::string;
 
 /** Construct a completion context
@@ -55,7 +57,7 @@ void Completion::none() {
 
 //! Return the given string posix sh escaped if in shell output mode
 string Completion::escape(const string& str) {
-    return str;
+    return shellOutput_ ? posix_sh_escape(str) : str;
 }
 
 //! the requested position is beyond the number of expected parameters

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -241,65 +241,21 @@ void tree_print_to(shared_ptr<TreeInterface> intface, Output output) {
     subtree_print_to(intface, " ", rootIndicator, output);
 }
 
-char* posix_sh_escape(const char* source) {
-    size_t count = 0;
-    int i;
-    for (i = 0; source[i]; i++) {
-        int j = LENGTH(ESCAPE_CHARACTERS) - 1; // = strlen(ESCAPE_CHARACTERS)
-        slow_assert(j == strlen(ESCAPE_CHARACTERS));
-        while (j--) {
-            slow_assert(0 <= j && j < strlen(ESCAPE_CHARACTERS));
-            if (source[i] == ESCAPE_CHARACTERS[j]) {
-                count++;
-                break;
-            }
+string posix_sh_escape(const string& source) {
+    if (source.empty()) {
+        return "\'\'";
+    }
+    string target = "";
+    for (char ch : source) {
+        // escape everything in ESCAPE_CHARACTERS
+        bool needsEscape = strchr(ESCAPE_CHARACTERS, ch);
+        // and escape a tilde at the beginning of a string
+        needsEscape = needsEscape || (target.empty() && ch == '~');
+        if (needsEscape) {
+            target += '\\';
         }
+        target += ch;
     }
-    auto source_len = (size_t)i;
-    // special chars:
-    if (source[0] == '~') {
-        count++;
-    }
-    // if there is nothing to escape
-    if (count == 0) {
-        return nullptr;
-    }
-    // TODO migrate to new
-    char* target = (char*)malloc(sizeof(char) * (count + source_len + 1));
-
-    // do the actual escaping
-    // special chars:
-    int s = 0; // position in the source
-    int t = 0; // position in the target
-    slow_assert(s < strlen(source));
-    slow_assert(t < (count + source_len));
-    if (source[0] == '~') {
-        target[t++] = '\\';
-        target[t++] = source[s++];
-    }
-    slow_assert(s < strlen(source));
-    slow_assert(t < (count + source_len));
-    while (source[s]) {
-        // check if we need to escape the next char
-        int j = LENGTH(ESCAPE_CHARACTERS) - 1; // = strlen(ESCAPE_CHARACTERS)
-        slow_assert(s < strlen(source));
-        slow_assert(t < (count + source_len));
-        while (j--) {
-            if (source[s] == ESCAPE_CHARACTERS[j]) {
-                // if source[s] needs to be escape, then put an backslash first
-                target[t++] = '\\';
-                break;
-            }
-        }
-        slow_assert(s < strlen(source));
-        slow_assert(t < (count + source_len));
-        // put the actual character
-        target[t++] = source[s++];
-    }
-    slow_assert(s == strlen(source));
-    slow_assert(t == (count + source_len));
-    // terminate the string
-    target[t] = '\0';
     return target;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -80,7 +80,7 @@ std::string utf8_string_at(const std::string& str, size_t offset);
 
 // returns an posix sh escaped string or NULL if there is nothing to escape
 // if a new string is returned, then the caller has to free it
-char* posix_sh_escape(const char* source);
+std::string posix_sh_escape(const std::string& source);
 // does the reverse action to posix_sh_escape by modifing the string
 void posix_sh_compress_inplace(char* str);
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -110,7 +110,7 @@ def generate_commands(hlwm, length, steps_per_argument=4, prefix=[]):
             # TODO: where does the empty string come from?
             continue
         if arg.endswith(' '):
-            arg = arg[0:-1]  # strip trailing ' '
+            arg = shlex.split(arg)[0] # strip trailing ' ' and evaluate escapes
             if arg in prefix:
                 # ignore commands where the same flag is passed twice
                 continue

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -110,7 +110,7 @@ def generate_commands(hlwm, length, steps_per_argument=4, prefix=[]):
             # TODO: where does the empty string come from?
             continue
         if arg.endswith(' '):
-            arg = shlex.split(arg)[0] # strip trailing ' ' and evaluate escapes
+            arg = shlex.split(arg)[0]  # strip trailing ' ' and evaluate escapes
             if arg in prefix:
                 # ignore commands where the same flag is passed twice
                 continue

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -234,13 +234,19 @@ def test_metacommand(hlwm, command_prefix):
         == sorted(['ARG'] + cmdlist)
 
 
-def test_posix_escape(hlwm):
-    tags = [r'tag"with\special', 'a&b', '$dollar', '(paren)']
+def test_posix_escape_via_use(hlwm):
+    tags = [r'tag"with\special', 'a&b', '$dollar', '(paren)', 'foo~bar', '~foo']
     for t in tags:
         hlwm.call(['add', t])
-    results = hlwm.complete(['use'], evaluate_escapes=True)
-    print(results)
-    assert sorted(['default'] + tags) == sorted(results)
+    for command in ['move', 'use']:
+        results = hlwm.complete(['use'], evaluate_escapes=True)
+        assert sorted(['default'] + tags) == sorted(results)
+
+
+def test_posix_escape_via_pad(hlwm):
+    res = hlwm.complete(['pad', '0'])
+    assert '\'\'' in res
+    assert '0' in res
 
 
 @pytest.mark.exclude_from_coverage(

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -277,7 +277,7 @@ def test_keymask_complete(hlwm):
     cmd = ['set_attr', 'clients.focus.keymask']
     reg = 'Foo(a [th]*)*'
     hlwm.call(cmd + [reg])
-    assert hlwm.complete(cmd) == [reg]
+    assert hlwm.complete(cmd, evaluate_escapes=True) == [reg]
 
 
 def test_keys_inactive_not_if_no_focus(hlwm, keyboard):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -248,7 +248,7 @@ def test_raise_monitor_completion(hlwm):
     expected = ['']
     expected += '-1 +0 +1 0 1 monitor2'.split(' ')
     expected.sort()
-    assert hlwm.complete('raise_monitor') == expected
+    assert hlwm.complete('raise_monitor', evaluate_escapes=True) == expected
 
 
 def test_use_previous_on_tag_stealing_monitor(hlwm):
@@ -640,7 +640,7 @@ def test_pad_invalid_arg(hlwm):
 def test_pad_completion(hlwm):
     assert '0' in hlwm.complete('pad')
     for cmd in ['pad 0', 'pad 0 12', 'pad 0 12 12', 'pad 0 12 12 12']:
-        res = hlwm.complete(cmd)
+        res = hlwm.complete(cmd, evaluate_escapes=True)
         assert '' in res
         assert '0' in res
     hlwm.command_has_all_args('pad 0 10 20 30 40'.split(' '))


### PR DESCRIPTION
In the objects of the Completion class, the shellOutput_ member was not
used at all, and so the completion results were not escaped correctly.

Now, the results are escaped and while at it, the posix_escape()
function is converted to C++. This makes the implementation much simpler
and it even fixes a memory leak in command.cpp (prefix_escaped is never
free'd).

A new special case in the posix_escape() function is the empty string,
which is now escaped correctly (before, zsh just added a space to the
command line, which of course did not have any effect).

In the tests, there is a new case for the empty string, and the escaping
of the other characters is now tested for the commands 'use' and 'move'
which still use the old command completion but will soon be migrated
(for 'use', see #1224).