### PR TITLE
Fix doc/gendoc.py extractor to strip comments

### DIFF
--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -23,6 +23,10 @@ class TokenRe:
 
 
 def extract_file_tokens(filepath):
+    """
+    Tokenize a C++ file and 'yield' its tokens. For correct
+    line number computation, this also includes comments.
+    """
     # in the following, it's important to use
     # non-capturing groups (?: .... )
     token_types = [
@@ -49,6 +53,14 @@ def extract_file_tokens(filepath):
         for t in entire_regex.split(fh.read().replace('\r', '') + '\n'):
             if t is not None and t.strip(' \t') != '':
                 yield t
+
+
+def strip_comment_tokens(tokens):
+    for t in tokens:
+        if t.startswith('//') or t.startswith('/*'):
+            continue
+        else:
+            yield t
 
 
 def pretty_print_token_list(tokens, indent='  '):
@@ -827,7 +839,7 @@ def main():
         objInfo = ObjectInformation()
         for f in files():
             # print("parsing file {}".format(f), file=sys.stderr)
-            toks = [t for t in extract_file_tokens(f) if t.strip() != '']
+            toks = [t for t in strip_comment_tokens(extract_file_tokens(f)) if t.strip() != '']
             toktree = list(build_token_tree_list(TokenStream(toks)))
             extractor = TokTreeInfoExtrator(objInfo)
             extractor.main(list(toktree))

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -72,6 +72,7 @@ classname2examplepath = [
     ('Settings', lambda _: 'settings'),
     ('TagManager', lambda _: 'tags'),
     ('Theme', lambda _: 'theme'),
+    ('TypesDoc', lambda _: 'types'),
 ]
 
 
@@ -202,3 +203,8 @@ def test_help_on_children_vs_json(hlwm, clsname, object_path, json_doc):
         if 'doc' in child:
             assert f"Entry '{name}'" in help_txt
             assert child['doc'] in help_txt
+        else:
+            # if there is no child doc in the json
+            # then there should be one in the cpp source
+            # and thus also not in the help output:
+            assert f"Entry '{name}'" not in help_txt


### PR DESCRIPTION
Formerly, the doc/gendoc.py keept the comment tokens in the token tree.
This resulted in a comment being treated as the function body of a
function definition and hence some of the documentation was missed.

Also, this was not noticed because the classname2examplepath array was
not extended in test_doc.py. The present change fixes the main issue and
the test case, and even makes it a bit stricter.