### PR TITLE
Fix completion in EmptyOrInt

### DIFF
--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -814,7 +814,7 @@ string Converter<EmptyOrInt>::str(EmptyOrInt payload) {
 template<>
 void Converter<EmptyOrInt>::complete(Completion& complete, EmptyOrInt const* relTo) {
     complete.full("");
-    Converter<int>::complete(complete, relTo ? &relTo->value_ : nullptr);
+    Converter<int>::complete(complete, (relTo && relTo->defined_) ? &relTo->value_ : nullptr);
 }
 
 void MonitorManager::padCommand(CallOrComplete invoc)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -262,3 +262,16 @@ def test_junk_args_dont_crash(hlwm, args_before, junk_arg):
             full_cmd.append(completions[0])
         full_cmd.append(junk_arg)
         hlwm.unchecked_call(full_cmd)
+
+
+def test_optional_args_in_argparse_dont_pile_up(hlwm):
+    hlwm.call(['move_monitor', '0', '400x300+0+0', '1', '1', '1', '1'])
+    commands = [
+        ['move_monitor', '0', '400x300+0+0'],
+        ['move_monitor', '0', '400x300+0+0', '0'],
+        ['move_monitor', '0', '400x300+0+0', '0', '0'],
+        ['move_monitor', '0', '400x300+0+0', '0', '0', '0'],
+    ]
+    for cmd in commands:
+        res = hlwm.complete(cmd, evaluate_escapes=True)
+        assert len([v for v in res if v == '0']) == 1


### PR DESCRIPTION
The '0' was listed multiple times in the completion of the
'move_monitor' command. The issue was a wrong completion in the
EmptyOrInt class.

The new test case checks that there is only one '0' in the completion
list. In particular, this test ensures that the completions of multiple
optional arguments (such as in 'move_monitor') do not overlap.