### PR TITLE
Run-Time Converter for HSTag*

### DIFF
--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -1043,7 +1043,7 @@ int FrameTree::dumpLayoutCommand(Input input, Output output) {
 
 void FrameTree::dumpLayoutCompletion(Completion& complete) {
     if (complete == 0) {
-        global_tags->completeTag(complete);
+        global_tags->completeEntries(complete);
     } else if (complete == 1) {
         // no completion for frame index
     } else {

--- a/src/tagmanager.h
+++ b/src/tagmanager.h
@@ -5,6 +5,7 @@
 #include "commandio.h"
 #include "indexingobject.h"
 #include "link.h"
+#include "runtimeconverter.h"
 #include "signal.h"
 #include "tag.h"
 
@@ -17,10 +18,19 @@ class Settings;
 
 typedef std::function<int(FrameTree&,Input,Output)> FrameCommand;
 typedef void (FrameTree::*FrameCompleter)(Completion&);
-class TagManager : public IndexingObject<HSTag> {
+
+template<>
+RunTimeConverter<HSTag*>* Converter<HSTag*>::converter;
+
+class TagManager : public IndexingObject<HSTag>, public Manager<HSTag> {
 public:
     TagManager();
     void injectDependencies(MonitorManager* m, Settings *s);
+
+    // RunTimeConverter<HSTag*>:
+    virtual HSTag* parse(const std::string& str) override;
+    virtual std::string str(HSTag* tag) override;
+    virtual void completeEntries(Completion& completion) override;
 
     int removeTag(Input input, Output output);
     int tag_add_command(Input input, Output output);
@@ -31,7 +41,6 @@ public:
     void floatingComplete(Completion& complete);
     HSTag* add_tag(const std::string& name);
     HSTag* find(const std::string& name);
-    void completeTag(Completion& complete);
     HSTag* ensure_tags_are_available();
     HSTag* byIndexStr(const std::string& index_str, bool skip_visible_tags);
     HSTag* unusedTag();


### PR DESCRIPTION
This extracts the Converter for HSTag* out of the PR (#1224) since
multiple new PRs require this.