### PR TITLE
Only resend ConfigureNotify on geometry change

### DIFF
--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -225,6 +225,7 @@ void Decoration::resize_outline(Rectangle outline, const DecorationScheme& schem
         // right when the window size changed.
         outline = scheme.inner_rect_to_outline(inner);
     }
+    bool windowGeometryChanged = inner != last_inner_rect;
     last_inner_rect = inner;
     inner.x -= outline.x;
     inner.y -= outline.y;
@@ -279,7 +280,12 @@ void Decoration::resize_outline(Rectangle outline, const DecorationScheme& schem
                       outline.x, outline.y, outline.width, outline.height);
     updateFrameExtends();
     if (!client_->dragged_ || settings_.update_dragged_clients()) {
-        client_->send_configure();
+        if (windowGeometryChanged) {
+            // only send the configure notify if the window geometry really changed.
+            // otherwise, sending this might trigger an endless loop between clients
+            // and hlwm.
+            client_->send_configure();
+        }
     }
     XSync(xcon.display(), False);
 }


### PR DESCRIPTION
This fixes an issue (#1235) which consisted of hlwm hanging because of a
loop between hlwm and the reaper application (reaper.fm).

Apparently, the issue is that `XA_WM_NORMAL_HINTS` is updated by the
reaper window, and this causes the tiling layout to be re-computed,
which results in a ConfigureNotify sent to the window. This event seems
to make reaper set `XA_WM_NORMAL_HINTS` again and so the whole process
starts again.

The solution is to only send the ConfigureNotify if the geometry really
changed. I don't know how to write a test case for it, but any test case
more or less should check that this still sends enough ConfigureNotify
events as requested by ICCCM (section 4.1.5.).