### PR TITLE
Remember last reported geometry in client directly

### DIFF
--- a/python/herbstluftwm/types.py
+++ b/python/herbstluftwm/types.py
@@ -1,0 +1,50 @@
+import re
+"""
+Module containing types used in the communication with herbstluftwm;
+primarily, types used in attributes.
+"""
+
+
+class Rectangle:
+    """
+    A rectangle on the screen, defined by its size and its distance to
+    the top left screen corner.
+    """
+    def __init__(self, x=0, y=0, width=0, height=0):
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+
+    def __str__(self):
+        return f'Rectangle({self.x}, {self.y}, {self.width}, {self.height})'
+
+    def __repr__(self):
+        return f'Rectangle({self.x}, {self.y}, {self.width}, {self.height})'
+
+    def __eq__(self, other):
+        return self.x == other.x \
+            and self.y == other.y \
+            and self.width == other.width \
+            and self.height == other.height
+
+    def to_user_str(self):
+        return "%dx%d%+d%+d" % (self.width, self.height, self.x, self.y)
+
+    @staticmethod
+    def from_user_str(string):
+        reg = '([0-9]+)x([0-9]+)([+-][0-9]+)([+-][0-9]+)'
+        m = re.match(reg, string)
+        if m is None:
+            raise Exception(f'"{string}" is not in format {reg}')
+        w = int(m.group(1))
+        h = int(m.group(2))
+        x = int(m.group(3))
+        y = int(m.group(4))
+        return Rectangle(x, y, w, h)
+
+    def adjusted(self, dx=0, dy=0, dw=0, dh=0):
+        """return a new rectangle whose components
+        are adjusted by the provided deltas.
+        """
+        return Rectangle(self.x + dx, self.y + dy, self.width + dw, self.height + dh)

--- a/src/client.h
+++ b/src/client.h
@@ -78,6 +78,7 @@ public:
     Attribute_<bool> sizehints_tiling_;  // respect size hints regarding this client in tiling mode
     DynAttribute_<std::string> window_class_;
     DynAttribute_<std::string> window_instance_;
+    Attribute_<Rectangle> geometry_reported_;
 
 public:
     void init_from_X();

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -225,7 +225,6 @@ void Decoration::resize_outline(Rectangle outline, const DecorationScheme& schem
         // right when the window size changed.
         outline = scheme.inner_rect_to_outline(inner);
     }
-    bool windowGeometryChanged = inner != last_inner_rect;
     last_inner_rect = inner;
     inner.x -= outline.x;
     inner.y -= outline.y;
@@ -280,12 +279,7 @@ void Decoration::resize_outline(Rectangle outline, const DecorationScheme& schem
                       outline.x, outline.y, outline.width, outline.height);
     updateFrameExtends();
     if (!client_->dragged_ || settings_.update_dragged_clients()) {
-        if (windowGeometryChanged) {
-            // only send the configure notify if the window geometry really changed.
-            // otherwise, sending this might trigger an endless loop between clients
-            // and hlwm.
-            client_->send_configure();
-        }
+        client_->send_configure();
     }
     XSync(xcon.display(), False);
 }


### PR DESCRIPTION
Instead of deciding in Decoration when to send a configure, just
remember the last configure event in every client so we know directly
whether it is worth sending a new configure event or not.

This fixes the bug #1239 where moving a client with the mouse did not
send the configure event when the mouse dragging was over. (This caused
the menus in Qt applications to be positioned wrong.). The bug was
originally introduced by #1236, thanks to @tiosgz for reporting it!

For easier testing, this remembered window geometry is exposed via the
attribute system. To simplify writing tests for it, there is a new type
'Rectangle' in the python bindings.