### PR TITLE
Always reply to a ConfigureRequest with ConfigureNotify

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -432,9 +432,11 @@ void Client::updatesizehints() {
 
 
 
-void Client::send_configure() {
+void Client::send_configure(bool force) {
     auto last_inner_rect = dec->last_inner();
-    if (geometry_reported_ == last_inner_rect) {
+    // force is just a quick fix: sometimes it is mandatory
+    // to send a configure request even if the geometry didn't change.
+    if (geometry_reported_ == last_inner_rect && !force) {
         // only send the configure notify if the window geometry really changed.
         // otherwise, sending this might trigger an endless loop between clients
         // and hlwm.

--- a/src/client.h
+++ b/src/client.h
@@ -115,7 +115,7 @@ public:
     void raise();
     void lower();
 
-    void send_configure();
+    void send_configure(bool force);
     bool applysizehints(int *w, int *h);
     void updatesizehints();
 

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -272,7 +272,7 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
             ewmh->windowUpdateWmState(client->window_, WmState::WSIconicState);
         }
     }
-    client->send_configure();
+    client->send_configure(true);
 
     // TODO: make this better
     Root::get()->mouse->grab_client_buttons(client, false);

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -279,7 +279,7 @@ void Decoration::resize_outline(Rectangle outline, const DecorationScheme& schem
                       outline.x, outline.y, outline.width, outline.height);
     updateFrameExtends();
     if (!client_->dragged_ || settings_.update_dragged_clients()) {
-        client_->send_configure();
+        client_->send_configure(false);
     }
     XSync(xcon.display(), False);
 }

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -317,7 +317,7 @@ void XMainLoop::configurerequest(XConfigureRequestEvent* cre) {
             }
         } else {
         // FIXME: why send event and not XConfigureWindow or XMoveResizeWindow??
-            client->send_configure();
+            client->send_configure(true);
         }
     } else {
         // if client not known.. then allow configure.


### PR DESCRIPTION
Depending on the context, it is mandatory to send back a configure
request, even if the window geometry did not change.

This fixes the issue that gnome-terminal and xfce4-terminal are blank on
start up, because they are waiting for the ConfigureNotify.

The bug was introduced by #1240 which is part of a sequence of changes
regarding issue #1235. The present change is just a quick fix, in the
long run this should be solved more elegantly.