### PR TITLE
Add new command 'list_frame' that prints out list of x11 clients bound to current frame

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -215,6 +215,13 @@ list_keybinds::
 
 WARNING: Tabs within command parameters are not escaped!
 
+list_frame::
+    Lists all X11 window ids (as 'HEXID''s) of windows bound to currently
+    focused frame. This is convenience command most useful with max layout,
+    but it works with other layouts as well. Use this if you want to implement
+    custom focused frame (only) window picker using external tools like *rofi*
+    (or *dmenu*).
+
 lock::
     Increases the 'monitors_locked' setting. Use this if you want to do multiple
     window actions at once (i.e. without repainting between the single steps).

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -846,3 +846,14 @@ int frame_move_window_edge(Input input, Output output) {
     return 0;
 }
 
+int frame_list_clients(Output output) {
+    Monitor* current_monitor = get_current_monitor();
+    HSTag* current_tag = current_monitor->tag;
+    auto focusedFrame = current_tag->frame->focusedFrame();
+    focusedFrame->foreachClient([&output](Client* client) {
+        output << WindowID(client->x11Window()).str();
+        output << "\n";
+    });
+    return 0;
+}
+

--- a/src/layout.h
+++ b/src/layout.h
@@ -79,12 +79,12 @@ public:
     friend class HSTag; // for HSTag::foreachClient()
     DynAttribute_<std::string> frameIndexAttr_;
     std::string frameIndex() const;
+    void foreachClient(ClientAction action);
 public: // soon will be protected:
     virtual std::shared_ptr<FrameSplit> isSplit() { return std::shared_ptr<FrameSplit>(); };
     virtual std::shared_ptr<FrameLeaf> isLeaf() { return std::shared_ptr<FrameLeaf>(); };
 protected:
     void relayout();
-    void foreachClient(ClientAction action);
     HSTag* tag_;
     Settings* settings_;
     std::weak_ptr<FrameSplit> parent_;
@@ -200,6 +200,8 @@ bool focus_client(Client* client, bool switch_tag, bool switch_monitor, bool rai
 
 int frame_focus_edge(Input input, Output output);
 int frame_move_window_edge(Input input, Output output);
+
+int frame_list_clients(Output output);
 
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,6 +112,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
         {"wmexec",         wmexec},
         {"emit_hook",      { custom_hook_emit }},
         {"bring",          {global_cmds, &GlobalCommands::bringCommand }},
+        {"list_frame",     { frame_list_clients }},
         {"focus_nth",      { tags->frameCommand(&FrameTree::focusNthCommand) }},
         {"cycle",          { tags->frameCommand(&FrameTree::cycleSelectionCommand) }},
         {"cycle_all",      monitors->tagCommand(&HSTag::cycleAllCommand)},


### PR DESCRIPTION

With tiling window managers users may have very different usage patterns.

herbstlutfwm is unique in that it mixes manual window management (a la ancient musca)
with automatic one (like that in dwm, xmonad, etc.).

Unit of manual management is frame. Unit of automatic management is internal frame
layout mode. Some users like me, prefer explicit manual management style more than
the automatic one.

In my usecase, I often prefer 'max' layout as it allows biggest amount
of window information to be presented and also keeps window placement and ordering
strictly manual. But I also make heavy use of 'max's' "stacking" property. As I go,
I end up quickly opening and closing many windows in a frame (as with terminal like
urxvt, this operation is very cheap), mainly every time I discover I need to do
something related to the task at hand, but I don't want to pollute the current
"primary" window.

This works well for very shortlived windows, but some subtasks may turn out to take
longer then initailly anticipated. Those tend to stack up in the frame in increasing
number.

One can, of course, in those cases, cycle layouts in a frame or try, for example
just 'horizontal' layout, to get very quick overview, but in frames with many "running"
subtasks, this is rather inefficient and can cause heavy redraws of frame clients, just
to find out what they are and what they are doing.

It turns out, that window titles of such subtasks are most indicative information
one needs to manage and cull their numbers (or observe their overall progress),
and this presentation (just as a list of titles) also consumes much less mental
bandwith too.

To present this list, the `rofi`(or `dmenu`) tool is much better suited than anything
wm can provide, as it then allows very agile and configurable operations on this
in-frame windows list, like qucikly slicing, dicing and filtering such window set.

Unfortunately, it is extremely hard and inefficient to get a list of client WindowIDs
in the current frame by current methods. Especially when, with few lines of code,
xid list of current frame can be easily provided by herbstluftwm itself.

This commit adds a command, 'list_frame', which implements exactly that: very simple
iterator that dumps xids of all windows bound to current frame. List is dumped as-is
without any filtering and in it's entirety. This very useful information then can
be processed as user as they see fit, to match their needs.

I believe, that besides me, other users will find other creative uses for this command
as well.