### PR TITLE
Migrate focus_nth to ArgParse

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -60,7 +60,6 @@ struct {
                         /* if current pos >= min_index */
     bool    (*function)(int argc, char** argv, int pos);
 } g_parameter_expected[] = {
-    { "focus_nth",      2,  no_completion },
     { "close",          2,  no_completion },
     { "cycle",          2,  no_completion },
     { "split",          4,  no_completion },

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -156,17 +156,6 @@ int FrameTree::cycleSelectionCommand(Input input, Output output) {
     return 0;
 }
 
-//! focus the nth window within the focused frame
-int FrameTree::focusNthCommand(Input input, Output output) {
-    string index;
-    if (!(input >> index)) {
-        return HERBST_NEED_MORE_ARGS;
-    }
-    focusedFrame()->setSelection(atoi(index.c_str()));
-    get_current_monitor()->applyLayout();
-    return 0;
-}
-
 //! command that removes the focused frame
 int FrameTree::removeFrameCommand() {
     auto frame = focusedFrame();

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -59,7 +59,6 @@ public:
 
     // Commands
     int cycleSelectionCommand(Input input, Output output);
-    int focusNthCommand(Input input, Output output);
     int removeFrameCommand();
     int rotateCommand();
     enum class MirrorDirection {

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -249,3 +249,20 @@ void GlobalCommands::lowerCommand(CallOrComplete invoc)
     });
 }
 
+void GlobalCommands::focusNthCommand(CallOrComplete invoc)
+{
+    // essentially an alias to:
+    // set_attr tags.focus.tiling.focused_frame.selection
+    // with the additional feature that setSelection() allows
+    // to directly focus the last window in a frame.
+    int index = 0;
+    ArgParse().mandatory(index, {"0", "-1"})
+            .command(invoc, [&](Output) {
+        HSTag* tag = root_.tags->focus_();
+        auto frame = tag->frame->focusedFrame();
+        frame->setSelection(index);
+        tag->needsRelayout_.emit();
+        return 0;
+    });
+}
+

--- a/src/globalcommands.h
+++ b/src/globalcommands.h
@@ -36,6 +36,8 @@ public:
 
     void raiseCommand(CallOrComplete invoc);
     void lowerCommand(CallOrComplete invoc);
+
+    void focusNthCommand(CallOrComplete invoc);
 private:
     Root& root_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,7 +112,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
         {"wmexec",         wmexec},
         {"emit_hook",      { custom_hook_emit }},
         {"bring",          {global_cmds, &GlobalCommands::bringCommand }},
-        {"focus_nth",      { tags->frameCommand(&FrameTree::focusNthCommand) }},
+        {"focus_nth",      {global_cmds, &GlobalCommands::focusNthCommand }},
         {"cycle",          { tags->frameCommand(&FrameTree::cycleSelectionCommand) }},
         {"cycle_all",      monitors->tagCommand(&HSTag::cycleAllCommand)},
         {"cycle_layout",   tags->frameCommand(&FrameTree::cycleLayoutCommand, &FrameTree::cycleLayoutCompletion) },

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -25,9 +25,9 @@ RunTimeConverter<HSTag*>* Converter<HSTag*>::converter = nullptr;
 
 TagManager::TagManager()
     : IndexingObject()
+    , focus_(*this, "focus")
     , by_name_(*this)
     , settings_(nullptr)
-    , focus_(*this, "focus")
 {
     indicesChanged.connect([](){
         Ewmh::get().updateDesktopNames();

--- a/src/tagmanager.h
+++ b/src/tagmanager.h
@@ -53,13 +53,13 @@ public:
     void updateFocusObject(Monitor* focusedMonitor);
     std::string isValidTagName(std::string name);
     Signal_<HSTag*> needsRelayout_;
+    Link_<HSTag> focus_;
 private:
     std::function<void(Completion&)> frameCompletion(FrameCompleter completer);
     void onTagRename(HSTag* tag);
     ByName by_name_;
     MonitorManager* monitors_ = {}; // circular dependency
     Settings* settings_;
-    Link_<HSTag> focus_;
 };
 
 extern TagManager* global_tags; // temporary, set in Root constr.

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -335,24 +335,6 @@ def test_cycle(hlwm, running_clients, running_clients_num, num_splits, cycle_del
         assert winids[new_windex] == hlwm.get_attr('clients.focus.winid')
 
 
-@pytest.mark.parametrize("running_clients_num", [0, 1, 5])
-@pytest.mark.parametrize("index", [0, 1, 3, 5])
-def test_focus_nth(hlwm, running_clients, running_clients_num, index):
-    # bring the clients in the right order
-    layout = '(clients vertical:0 '
-    layout += ' '.join(running_clients)
-    layout += ')'
-    hlwm.call(['load', layout])
-
-    # focus the n_th
-    hlwm.call('focus_nth {}'.format(index))
-
-    windex = int(hlwm.get_attr('tags.0.curframe_windex'))
-    assert windex == max(0, min(index, running_clients_num - 1))
-    if running_clients_num > 0:
-        assert hlwm.get_attr('clients.focus.winid') == running_clients[windex]
-
-
 @pytest.mark.parametrize("running_clients_num", [5])
 def test_rotate(hlwm, running_clients, running_clients_num):
     # generate some layout with clients in it


### PR DESCRIPTION
Since focus_nth is just a convenience setting for
tags.focus.tiling.focused_frame.selection it better fits in
GlobalCommands. I've moved the existing test case to the other python
file and added a few more test cases. Also, the completion now
explicitly mentions '0' and '-1' for selecting the first and last window
in a frame.

This requires access to tags.focus which I thus had to make public in
TagManager.