### PR TITLE
Migrate 'close' command to ArgParse

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -485,18 +485,6 @@ Rectangle Client::outer_floating_rect() {
     return dec->inner_to_outer(float_size_);
 }
 
-int close_command(Input input, Output) {
-    string winid = "";
-    input >> winid; // try to read, use "" otherwise
-    auto window = get_window(winid);
-    if (window != 0) {
-        Ewmh::get().windowClose(window);
-    } else {
-        return HERBST_INVALID_ARGUMENT;
-    }
-    return 0;
-}
-
 bool Client::is_client_floated() {
     if (floating_()) {
         return true;

--- a/src/client.h
+++ b/src/client.h
@@ -154,8 +154,6 @@ Client* get_current_client();
 Client* get_client(const char* str);
 Window get_window(const std::string& str);
 
-int close_command(Input input, Output output);
-
 // sets a client property, depending on argv[0]
 int client_set_property_command(int argc, char** argv);
 bool is_window_class_ignored(char* window_class);

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -27,7 +27,6 @@ static void try_complete(const char* needle, const char* to_check, Output output
 
 static void complete_against_tags(int argc, char** argv, int pos, Output output);
 static void complete_against_monitors(int argc, char** argv, int pos, Output output);
-static void complete_against_winids(int argc, char** argv, int pos, Output output);
 static void complete_merge_tag(int argc, char** argv, int pos, Output output);
 static int complete_against_commands(int argc, char** argv, int position, Output output);
 
@@ -57,7 +56,6 @@ struct {
                         /* if current pos >= min_index */
     bool    (*function)(int argc, char** argv, int pos);
 } g_parameter_expected[] = {
-    { "close",          2,  no_completion },
     { "cycle",          2,  no_completion },
     { "split",          4,  no_completion },
     { "cycle_monitor",  2,  no_completion },
@@ -98,7 +96,6 @@ struct {
 } g_completions[] = {
     /* name , relation, index,  completion method                   */
     { "add_monitor",    EQ, 2,  complete_against_tags, 0 },
-    { "close",          EQ, 1,  complete_against_winids, 0 },
     { "cycle",          EQ, 1,  nullptr, completion_pm_one },
     { "cycle_monitor",  EQ, 1,  nullptr, completion_pm_one },
     { "dump",           EQ, 1,  complete_against_tags, 0 },
@@ -352,20 +349,6 @@ void complete_against_monitors(int argc, char** argv, int pos, Output output) {
         if (m->name != "") {
             try_complete(needle, m->name->c_str(), output);
         }
-    }
-}
-
-void complete_against_winids(int argc, char** argv, int pos, Output output) {
-    const char* needle;
-    if (pos >= argc) {
-        needle = "";
-    } else {
-        needle = argv[pos];
-    }
-    for (auto c : Root::common().clients()) {
-        char buf[100];
-        snprintf(buf, LENGTH(buf), "0x%lx", c.second->window_);
-        try_complete(needle, buf, output);
     }
 }
 

--- a/src/globalcommands.h
+++ b/src/globalcommands.h
@@ -39,6 +39,8 @@ public:
     void bringCommand(CallOrComplete invoc);
     void bring(Client* client);
 
+    void closeCommand(CallOrComplete invoc);
+
     void raiseCommand(CallOrComplete invoc);
     void lowerCommand(CallOrComplete invoc);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,7 +117,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
         {"cycle_all",      monitors->tagCommand(&HSTag::cycleAllCommand)},
         {"cycle_layout",   tags->frameCommand(&FrameTree::cycleLayoutCommand, &FrameTree::cycleLayoutCompletion) },
         {"cycle_frame",    { tags->frameCommand(&FrameTree::cycleFrameCommand) }},
-        {"close",          { close_command }},
+        {"close",          { global_cmds, &GlobalCommands::closeCommand }},
         {"close_or_remove",{ monitors->tagCommand(&HSTag::closeOrRemoveCommand) }},
         {"close_and_remove",{ monitors->tagCommand(&HSTag::closeAndRemoveCommand) }},
         {"split",          { tags->frameCommand(&FrameTree::splitCommand) }},

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -48,18 +48,21 @@ def test_close_without_clients(hlwm):
     assert hlwm.unchecked_call('close').returncode == 3
 
 
-@pytest.mark.parametrize("running_clients_num", [1, 2, 3, 4])
-def test_close_for_multiple_clients(hlwm, running_clients_num):
-    hlwm.create_clients(running_clients_num)
-    hlwm.call('close')
-
-
-def test_close_focused_client(hlwm):
+@pytest.mark.parametrize("running_clients_num", [0, 1, 4])  # number of unfocused clients
+def test_close_focused_client(hlwm, running_clients, running_clients_num):
+    hlwm.call('rule focus=on')
     winid, proc = hlwm.create_client()
+    assert hlwm.attr.clients.focus.winid() == winid
 
     hlwm.call('close')
 
-    proc.wait(10)  # wait for the client to shut down
+    proc.wait(20)  # wait for the client to shut down
+    hlwm.call('true')  # sync with hlwm
+    clients = hlwm.list_children('clients')
+    # all other clients still run:
+    assert winid not in clients
+    for other in running_clients:
+        assert other in clients
 
 
 def test_close_unfocused_client(hlwm):


### PR DESCRIPTION
The usual migration commit: use ArgParse for argument parsing and
command line completions, add tests for it, remove the old
implementation and completion code.