### PR TITLE
Parse --skip-visible in move_index command

### DIFF
--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -311,7 +311,8 @@ void TagManager::tag_move_window_command(CallOrComplete invoc) {
 void TagManager::tag_move_window_by_index_command(CallOrComplete invoc) {
     string tagIndex;
     bool skip_visible = false;
-    ArgParse().mandatory(tagIndex)
+    ArgParse().mandatory(tagIndex, {"-1", "+1"})
+            .flags({{"--skip-visible", &skip_visible}})
             .command(invoc,
                      [&] (Output output) {
         HSTag* tag = byIndexStr(tagIndex, skip_visible);

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -159,6 +159,7 @@ def test_completable_commands(hlwm, request, run_destructives):
         'jumpto': {3},
         'remove_monitor': {6},
         'use_index': {3},
+        'move_index': {3},
         'bring': {3},
         '!': {1},
         'shift': {6},


### PR DESCRIPTION
When migrating the 'move_index' command in a5bdb0d45 (#1227) I forgot to
parse the --skip-visible flag. This brings the flag back and extends the
test cases of 'use_index' to also test 'move_index'.

While at it, I've also added the suggestions "-1" and "+1" for the index
argument (as it already exists for 'use_index'). This now needs an exception in
the automated completion tests (similarly to 'use_index')

This fixes #1256, thanks to @gravndal for reporting this issue!
