### PR TITLE
Make 'cycle' work for the floating layer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,7 @@ Current git version
     settings for compatibility).
   * New object 'types' containing documentation on (attribute-) types.
   * Relative values for integer attributes ('+=N' and '-=N')
+  * The 'cycle' command now also cycles through floating windows.
   * Bug fixes:
     - Fix mistakenly transparent borders of argb clients
   * New dependency: xrender

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -341,9 +341,10 @@ focus_nth 'INDEX'::
     window is focused.
 
 cycle ['DELTA']::
-    Cycles the selection within the current frame by 'DELTA'. If 'DELTA' is
-    omitted, 'DELTA' = 1 will be used. 'DELTA' can be negative; 'DELTA' = -1
-    means: cycle in the opposite direction by 1.
+    Cycles the selection within the current frame by 'DELTA' or cycles through
+    the clients in the floating layer if that is focused. If 'DELTA' is omitted,
+    'DELTA' = 1 will be used. 'DELTA' can be negative; 'DELTA' = -1 means: cycle
+    in the opposite direction by 1.
 
 cycle_all [*--skip-invisible*] ['DIRECTION']::
     Cycles through all non-minimized windows and frames on the current tag.

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -58,7 +58,6 @@ struct {
     bool    (*function)(int argc, char** argv, int pos);
 } g_parameter_expected[] = {
     { "close",          2,  no_completion },
-    { "cycle",          2,  no_completion },
     { "split",          4,  no_completion },
     { "cycle_monitor",  2,  no_completion },
     { "focus_monitor",  2,  no_completion },
@@ -97,7 +96,6 @@ struct {
 } g_completions[] = {
     /* name , relation, index,  completion method                   */
     { "close",          EQ, 1,  complete_against_winids, 0 },
-    { "cycle",          EQ, 1,  nullptr, completion_pm_one },
     { "cycle_monitor",  EQ, 1,  nullptr, completion_pm_one },
     { "dump",           EQ, 1,  complete_against_tags, 0 },
     { "layout",         EQ, 1,  complete_against_tags, 0 },

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -30,7 +30,6 @@ static int complete_against_commands(int argc, char** argv, int position, Output
 // behaviour
 static bool g_shell_quoting = false;
 
-static const char* completion_pm_one[]= { "+1", "-1", nullptr };
 static const char* completion_split_modes[]= { "horizontal", "vertical", "left", "right", "top", "bottom", "explode", "auto", nullptr };
 static const char* completion_split_ratios[]= {
     "0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", nullptr };

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -140,22 +140,6 @@ shared_ptr<FrameLeaf> FrameTree::focusedFrame(shared_ptr<Frame> node) {
 }
 
 
-int FrameTree::cycleSelectionCommand(Input input, Output output) {
-    int delta = 1;
-    string deltaStr;
-    if (input >> deltaStr) {
-        delta = atoi(deltaStr.c_str());
-    }
-    // find current selection
-    auto frame = focusedFrame();
-    auto count = frame->clientCount();
-    if (count != 0) {
-        frame->setSelection(MOD(frame->getSelection() + delta, count));
-    }
-    get_current_monitor()->applyLayout();
-    return 0;
-}
-
 //! command that removes the focused frame
 int FrameTree::removeFrameCommand() {
     auto frame = focusedFrame();

--- a/src/frametree.h
+++ b/src/frametree.h
@@ -58,7 +58,6 @@ public:
     bool resizeFrame(FixPrecDec delta, Direction dir);
 
     // Commands
-    int cycleSelectionCommand(Input input, Output output);
     int removeFrameCommand();
     int rotateCommand();
     enum class MirrorDirection {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,7 +113,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
         {"emit_hook",      { custom_hook_emit }},
         {"bring",          {global_cmds, &GlobalCommands::bringCommand }},
         {"focus_nth",      {global_cmds, &GlobalCommands::focusNthCommand }},
-        {"cycle",          { tags->frameCommand(&FrameTree::cycleSelectionCommand) }},
+        {"cycle",          { monitors->tagCommand(&HSTag::cycleCommand) }},
         {"cycle_all",      monitors->tagCommand(&HSTag::cycleAllCommand)},
         {"cycle_layout",   tags->frameCommand(&FrameTree::cycleLayoutCommand, &FrameTree::cycleLayoutCompletion) },
         {"cycle_frame",    { tags->frameCommand(&FrameTree::cycleFrameCommand) }},

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -18,6 +18,7 @@
 #include "settings.h"
 #include "stack.h"
 #include "tagmanager.h"
+#include "utils.h"
 
 using std::endl;
 using std::function;
@@ -448,6 +449,33 @@ void HSTag::cycleAll(bool forward, bool skip_invisible)
     }
     // finally, redraw the layout
     needsRelayout_.emit();
+}
+
+void HSTag::cycleCommand(CallOrComplete invoc)
+{
+    int delta = 1;
+    ArgParse().optional(delta, {"+1", "-1"})
+              .command(invoc, [&] (Output) {
+        if (floating_focused()) {
+            if (floating_clients_.empty()) {
+                return 0;
+            }
+            int idx = static_cast<int>(floating_clients_focus_);
+            int count = static_cast<int>(floating_clients_.size());
+            idx = MOD(idx + delta, count);
+            floating_clients_focus_ = static_cast<size_t>(idx);
+            needsRelayout_.emit();
+        } else {
+            auto curFrame = frame->focusedFrame();
+            int idx = curFrame->getSelection();
+            auto count = static_cast<int>(curFrame->clientCount());
+            if (count != 0) {
+                curFrame->setSelection(MOD(idx + delta, count));
+            }
+            needsRelayout_.emit();
+        }
+        return 0;
+    });
 }
 
 int HSTag::resizeCommand(Input input, Output output)

--- a/src/tag.h
+++ b/src/tag.h
@@ -74,6 +74,8 @@ public:
     void cycleAllCommand(CallOrComplete invoc);
     void cycleAll(bool forward, bool skip_invisible);
 
+    void cycleCommand(CallOrComplete invoc);
+
     int resizeCommand(Input input, Output output);
     void resizeCompletion(Completion& complete);
 


### PR DESCRIPTION
If the floating layer is focused, 'cycle' should traverse through the
clients in there. While at it, I've migrated the command to ArgParse and
moved it to HSTag. As usual, there are some new test cases.

Still, this only cycles through the windows explicitly marked as
floating, which is maybe odd when switching the entire tag to floating
(which should be fixed in the long run, see issue #948).