### PR TITLE
tests: Relax timeouts for shut down a bit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ COPY_ENV_WHITELIST = ['LSAN_OPTIONS']
 # time in seconds to wait for a process to shut down
 PROCESS_SHUTDOWN_TIME = 5
 
+
 def extend_env_with_whitelist(environment):
     """Copy some whitelisted environment variables (if set) into an existing environment"""
     environment.update({e: os.environ[e] for e in os.environ if e in COPY_ENV_WHITELIST})


### PR DESCRIPTION
Sometimes the CI fails because the shutdown takes too long.
Thus, a slightly longer timeout might be reasonable. Moreover, the
shutdown of the HlwmBridge is now in parallel, so all processes are
sent the term signal simultaneously, so in sum, this might even speed up
the shut down phase of test cases with clients.