### PR TITLE
Migrate 'add' command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                           &GlobalCommands::cycleValueCompletion}},
         {"cycle_monitor",  { monitors, &MonitorManager::cycleCommand }},
         {"focus_monitor",  { monitors, &MonitorManager::focusCommand }},
-        {"add",            BIND_OBJECT(tags, tag_add_command) },
+        {"add",            { tags, &TagManager::addCommand }},
         {"use",            { global_cmds, &GlobalCommands::useTagCommand }},
         {"use_index",      { global_cmds, &GlobalCommands::useTagByIndexCommand }},
         {"use_previous",   { global_cmds, &GlobalCommands::usePreviousCommand }},

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -120,7 +120,6 @@ void TagManager::addCommand(CallOrComplete invoc)
     string tagName;
     ArgParse().mandatory(tagName)
             .command(invoc, [&](Output output) {
-        string error;
         if (tagName.empty()) {
             string error = "An empty tag name is not permitted";
             output << invoc.command() << ": " << error << "\n";

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -115,17 +115,21 @@ HSTag* TagManager::add_tag(const string& name) {
     return tag;
 }
 
-int TagManager::tag_add_command(Input input, Output output) {
-    if (input.empty()) {
-        return HERBST_NEED_MORE_ARGS;
-    }
-    if (input.front().empty()) {
-        output << input.command() << ": An empty tag name is not permitted\n";
-        return HERBST_INVALID_ARGUMENT;
-    }
-    HSTag* tag = add_tag(input.front());
-    hook_emit({"tag_added", tag->name});
-    return 0;
+void TagManager::addCommand(CallOrComplete invoc)
+{
+    string tagName;
+    ArgParse().mandatory(tagName)
+            .command(invoc, [&](Output output) {
+        string error;
+        if (tagName.empty()) {
+            string error = "An empty tag name is not permitted";
+            output << invoc.command() << ": " << error << "\n";
+            return HERBST_INVALID_ARGUMENT;
+        }
+        HSTag* tag = add_tag(tagName);
+        hook_emit({"tag_added", tag->name});
+        return HERBST_EXIT_SUCCESS;
+    });
 }
 
 void TagManager::mergeTagCommand(CallOrComplete invoc) {

--- a/src/tagmanager.h
+++ b/src/tagmanager.h
@@ -34,7 +34,7 @@ public:
 
     void mergeTagCommand(CallOrComplete invoc);
     bool mergeTag(HSTag* tagToRemove, HSTag* targetTag);
-    int tag_add_command(Input input, Output output);
+    void addCommand(CallOrComplete invoc);
     void tag_rename_command(CallOrComplete invoc);
     void tag_move_window_command(CallOrComplete invoc);
     void tag_move_window_by_index_command(CallOrComplete invoc);

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -27,6 +27,20 @@ def test_add_tag_empty(hlwm):
         .expect_stderr('An empty tag name is not permitted')
 
 
+def test_add_tag_completion(hlwm):
+    hlwm.command_has_all_args(['add', 'foo'])
+
+
+def test_add_tag_duplicate(hlwm):
+    assert hlwm.attr.tags.count() == '1'
+    hlwm.call('add foo')
+    assert hlwm.attr.tags.count() == '2'
+    hlwm.call('add bar')
+    assert hlwm.attr.tags.count() == '3'
+    hlwm.call('add foo')
+    assert hlwm.attr.tags.count() == '3'
+
+
 def test_use_previous(hlwm):
     hlwm.call('add foobar')
     hlwm.call('use foobar')


### PR DESCRIPTION
This migrates 'add' to ArgParse and adds two more test cases. I didn't
remove the "add" from the command.cpp to avoid another merge commit.
The two main tables from command.cpp will be removed soon, anyway.