### PR TITLE
Remove old completion code from command.cpp

### DIFF
--- a/src/command.h
+++ b/src/command.h
@@ -7,18 +7,6 @@
 
 #include "commandio.h"
 
-// returns a command binding that internalizes object to given a command that
-// calls the member function of the given object
-#define BIND_OBJECT(OBJECT, MEMBER) \
-    (CommandBinding([OBJECT](Input in, Output out) { \
-        return (OBJECT)->MEMBER(in, out); \
-    }))
-
-#define BIND_PARAMETER(PARAM, FUNCTION) \
-    (CommandBinding([PARAM](Input in, Output out) { \
-        return FUNCTION(PARAM, in, out); \
-    }))
-
 class Completion;
 
 /** User facing commands.
@@ -126,9 +114,7 @@ public:
     // C functions to C++
     CommandBinding(int func(int argc, char** argv, Output output))
         : command(commandFromCFunc(func)) {}
-    CommandBinding(int func(int argc, const char** argv, Output output));
     CommandBinding(int func(int argc, char** argv));
-    CommandBinding(int func(int argc, const char** argv));
 
     bool hasCompletion() const { return (bool)completion_; }
     void complete(Completion& completion) const;

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -207,7 +207,7 @@ def test_inputless_commands(hlwm, name):
 
 
 def test_completionless_commands(hlwm):
-    # commands that accept arguments but don't have compltion.
+    # commands that accept arguments but don't have completion.
     # Their completion must return '0' (instead of NO_PARAMETER_EXPECTED)
     for cmd in ['spawn', 'wmexec']:
         for idx in ['1', '2', '3']:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -208,7 +208,7 @@ def test_inputless_commands(hlwm, name):
 
 def test_completionless_commands(hlwm):
     # commands that accept arguments but don't have compltion.
-    # Their completion must return '0' (ineast of NO_PARAMETER_EXPECTED)
+    # Their completion must return '0' (instead of NO_PARAMETER_EXPECTED)
     for cmd in ['spawn', 'wmexec']:
         for idx in ['1', '2', '3']:
             assert hlwm.call(['complete', idx, cmd])

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -206,6 +206,14 @@ def test_inputless_commands(hlwm, name):
         .returncode == 7
 
 
+def test_completionless_commands(hlwm):
+    # commands that accept arguments but don't have compltion.
+    # Their completion must return '0' (ineast of NO_PARAMETER_EXPECTED)
+    for cmd in ['spawn', 'wmexec']:
+        for idx in ['1', '2', '3']:
+            assert hlwm.call(['complete', idx, cmd])
+
+
 def test_remove_attr(hlwm):
     attr_path = "monitors.my_test"
     # assume you have a user-defined attribute


### PR DESCRIPTION
With the completion code from all commands migrated, most of the code in
command.cpp is now obsolete. There is still a bit of the char**-based code
which needs to be reorganized until we get rid of the old command
interface entirely.

The new tests verify that the exit code of the completion of `spawn` and
`wmexec` still are correct.