### PR TITLE
Rename 'geometry_reported' to 'content_geometry'

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -11,6 +11,10 @@ The command 'cycle_value' now expects an attribute path instead of a settings
 name. For compatibility reasons, passing settings name directly (without the
 prefix +settings.+) is still supported.
 
+Only for people using the git-version: During the development of 0.9.3, the
+'content_geometry' attribute of clients initially had the name
+'geometry_reported'.
+
 0.8.3 to 0.9.0
 --------------
 

--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ Current git version
     'class', 'geometry', 'winid')
   * The setting 'monitors_locked' is now explicitly an unsigned integer.
   * The setting 'default_frame_layout' now holds an algorithm name.
+  * New client attribute 'content_geometry' holding the geometry of the
+    application's content.
   * The 'shift' command now moves the window to a neighboured monitor if
     the window cannot be moved within a tag in the desired direction.
   * New command 'lower' to lower a window in the stack.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -56,7 +56,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , sizehints_tiling_(this, "sizehints_tiling", false)
     , window_class_(this, "class", &Client::getWindowClass)
     , window_instance_(this, "instance", &Client::getWindowInstance)
-    , geometry_reported_(this, "geometry_reported", {})
+    , content_geometry_(this, "content_geometry", {})
     , manager(cm)
     , theme(*cm.theme)
     , settings(*cm.settings)
@@ -136,9 +136,10 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
                              "should be respected in tiling mode");
     sizehints_floating_.setDoc("if sizehints for this client should "
                                "be respected in floating mode");
-    geometry_reported_.setDoc(
-                "the geometry the client thinks it has. "
-                "This is the last window geometry that "
+    content_geometry_.setDoc(
+                "the geometry of the application content, that is, not taking "
+                "the decoration into account. "
+                "Also, this is the last window geometry that "
                 "was reported to the client application."
      );
 }
@@ -436,13 +437,13 @@ void Client::send_configure(bool force) {
     auto last_inner_rect = dec->last_inner();
     // force is just a quick fix: sometimes it is mandatory
     // to send a configure request even if the geometry didn't change.
-    if (geometry_reported_ == last_inner_rect && !force) {
+    if (content_geometry_ == last_inner_rect && !force) {
         // only send the configure notify if the window geometry really changed.
         // otherwise, sending this might trigger an endless loop between clients
         // and hlwm.
         return;
     }
-    geometry_reported_ = last_inner_rect;
+    content_geometry_ = last_inner_rect;
     XConfigureEvent ce;
     ce.type = ConfigureNotify;
     ce.display = X_.display();

--- a/src/client.h
+++ b/src/client.h
@@ -78,7 +78,7 @@ public:
     Attribute_<bool> sizehints_tiling_;  // respect size hints regarding this client in tiling mode
     DynAttribute_<std::string> window_class_;
     DynAttribute_<std::string> window_instance_;
-    Attribute_<Rectangle> geometry_reported_;
+    Attribute_<Rectangle> content_geometry_;
 
 public:
     void init_from_X();

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -126,7 +126,7 @@ def test_drag_move_sends_configure(hlwm, x11, mouse, update_dragged):
     hlwm.attr.settings.update_dragged_clients = hlwm.bool(update_dragged)
     client, winid = x11.create_client()
     x, y = x11.get_absolute_top_left(client)
-    before = Rectangle.from_user_str(hlwm.attr.clients[winid].geometry_reported())
+    before = Rectangle.from_user_str(hlwm.attr.clients[winid].content_geometry())
     assert (x, y) == (before.x, before.y)
     mouse.move_into(winid, wait=True)
 
@@ -135,7 +135,7 @@ def test_drag_move_sends_configure(hlwm, x11, mouse, update_dragged):
     mouse.click('1')  # stop dragging
     hlwm.call('true')  # sync
 
-    after = Rectangle.from_user_str(hlwm.attr.clients[winid].geometry_reported())
+    after = Rectangle.from_user_str(hlwm.attr.clients[winid].content_geometry())
     assert before.adjusted(dx=12, dy=15) == after
 
 
@@ -207,7 +207,7 @@ def test_drag_resize_floating_client(hlwm, x11, mouse, live_update):
 
     client, winid = x11.create_client(geometry=(50, 50, 300, 200))
     hlwm.call(f'set_attr clients.{winid}.floating true')
-    geom_before = Rectangle.from_user_str(hlwm.attr.clients[winid].geometry_reported())
+    geom_before = Rectangle.from_user_str(hlwm.attr.clients[winid].content_geometry())
     assert geom_before == x11.get_absolute_geometry(client)  # duck-typing
     assert (geom_before.width, geom_before.height) == (300, 200)
     # move cursor to the top left corner, so we change the
@@ -234,7 +234,7 @@ def test_drag_resize_floating_client(hlwm, x11, mouse, live_update):
     mouse.click('1', wait=True)
     geom_after = client.get_geometry()
     assert (geom_after.width, geom_after.height) == final_size
-    assert Rectangle.from_user_str(hlwm.attr.clients[winid].geometry_reported()) \
+    assert Rectangle.from_user_str(hlwm.attr.clients[winid].content_geometry()) \
         == geom_before.adjusted(dx=100, dy=120, dw=-100, dh=-120)
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -968,7 +968,7 @@ def test_smart_placement_within_monitor(hlwm):
     winid, _ = hlwm.create_client()
 
     inner_geometry = Rectangle.from_user_str(
-        hlwm.attr.clients[winid].geometry_reported())
+        hlwm.attr.clients[winid].content_geometry())
 
     # assert that the top left corner of the decoration
     # is still within the monitor


### PR DESCRIPTION
I think the latter name is more self-explanatory and is not specific to
the internals of the X11 protocol.