### PR TITLE
tox: Switch default Python env to 38

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -42,9 +42,10 @@ With everything installed, you can run the following from the build directory:
 
     tox -c ..  -- -v --maxfail=1
 
-If you run Arch Linux, it may be necessary to add -e py38 to the tox parameters
-(that is, before the --). If you have an old version of tox installed, it may be
-necessary to pass ../tox.ini instead of .. to the -c parameter.
+Depending on the Python 3 version you have installed, e.g. 3.9.x, it may be
+necessary to add -e py39 to the tox parameters (that is, before the --). If you
+have an old version of tox installed, it may be necessary to pass ../tox.ini
+instead of .. to the -c parameter.
 
 The argument after the -- are pytest parameters (add -h to see a help). If you
 do not want to use tox and instead run pytest directly, then call the following

--- a/ci/build.py
+++ b/ci/build.py
@@ -143,7 +143,7 @@ if args.run_tests:
 
     # First, run only the tests that are NOT marked to be excluded from code
     # coverage collection.
-    tox('-e py38 -- -n auto --cache-clear -v -x -m "not exclude_from_coverage"', build_dir)
+    tox('-- -n auto --cache-clear -v -x -m "not exclude_from_coverage"', build_dir)
 
     # Create the code coverage report:
     sp.check_call('lcov --capture --directory . --output-file coverage.info', shell=True, cwd=build_dir)
@@ -152,4 +152,4 @@ if args.run_tests:
     (build_dir / 'coverage.info').rename(repo / 'coverage.info')
 
     # Run the tests that have been skipped before (without clearing the pytest cache this time):
-    tox('-e py38 -- -n auto -v -x -m exclude_from_coverage', build_dir)
+    tox('-- -n auto -v -x -m exclude_from_coverage', build_dir)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py38
 skipsdist = true
 
 ###


### PR DESCRIPTION
Not sure if 3.6 is really used in "current" distributions anymore? At
least the CI is using 3.8. Also adjust the description in HACKING to be
more generic, this is not an Arch specific problem.