### PR TITLE
Add client attribute 'floating_geometry'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,7 +20,7 @@ Current git version
     'class', 'geometry', 'winid')
   * The setting 'monitors_locked' is now explicitly an unsigned integer.
   * The setting 'default_frame_layout' now holds an algorithm name.
-  * New client attribute:
+  * New client attributes:
     - 'float_geometry' holding the client's floating size (writable).
     - 'content_geometry' holding the geometry of the application's content.
   * The 'shift' command now moves the window to a neighboured monitor if

--- a/NEWS
+++ b/NEWS
@@ -21,7 +21,7 @@ Current git version
   * The setting 'monitors_locked' is now explicitly an unsigned integer.
   * The setting 'default_frame_layout' now holds an algorithm name.
   * New client attributes:
-    - 'float_geometry' holding the client's floating size (writable).
+    - 'floating_geometry' holding the client's floating size (writable).
     - 'content_geometry' holding the geometry of the application's content.
   * The 'shift' command now moves the window to a neighboured monitor if
     the window cannot be moved within a tag in the desired direction.

--- a/NEWS
+++ b/NEWS
@@ -20,8 +20,9 @@ Current git version
     'class', 'geometry', 'winid')
   * The setting 'monitors_locked' is now explicitly an unsigned integer.
   * The setting 'default_frame_layout' now holds an algorithm name.
-  * New client attribute 'content_geometry' holding the geometry of the
-    application's content.
+  * New client attribute:
+    - 'float_geometry' holding the client's floating size (writable).
+    - 'content_geometry' holding the geometry of the application's content.
   * The 'shift' command now moves the window to a neighboured monitor if
     the window cannot be moved within a tag in the desired direction.
   * New command 'lower' to lower a window in the stack.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -36,7 +36,7 @@ static Client* lastfocus = nullptr;
 Client::Client(Window window, bool visible_already, ClientManager& cm)
     : window_(window)
     , dec(make_unique<Decoration>(this, *cm.settings))
-    , float_size_(this, "float_geometry",  {0, 0, 100, 100})
+    , float_size_(this, "floating_geometry",  {0, 0, 100, 100})
     , visible_(this, "visible", visible_already)
     , urgent_(this, "urgent", false)
     , floating_(this,  "floating", false)

--- a/src/client.h
+++ b/src/client.h
@@ -33,7 +33,7 @@ public:
     Window      window_;
     std::unique_ptr<Decoration> dec; // pimpl
     Rectangle   last_size_;      // last size excluding the window border
-    Rectangle   float_size_ = {0, 0, 100, 100};     // floating size without the window border
+    Attribute_<Rectangle> float_size_;     // floating size without the window border
     HSTag*      tag_ = {};
     Slice* slice = {};
     bool        ewmhfullscreen_ = false; // ewmh fullscreen state
@@ -129,6 +129,7 @@ public:
 
     void updateEwmhState();
 private:
+    void floatingGeometryChanged();
     std::string getWindowClass();
     std::string getWindowInstance();
     std::string triggerRelayoutMonitor();

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -51,7 +51,7 @@ ClientManager::~ClientManager()
 {
     // make all clients visible at their original floating position
     for (auto c : clients_) {
-        auto r = c.second->float_size_;
+        Rectangle r = c.second->float_size_;
         auto window = c.second->x11Window();
         XMoveResizeWindow(X_->display(), window, r.x, r.y, r.width, r.height);
         XReparentWindow(X_->display(), window, X_->root(), r.x, r.y);

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -586,7 +586,7 @@ void Monitor::evaluateClientPlacement(Client* client, ClientPlacement placement)
                     - client->float_size_->dimensions() / 2;
                 client->float_size_ = Rectangle(new_tl.x, new_tl.y,
                                                 client->float_size_->width,
-                                                client->float_size_->width);
+                                                client->float_size_->height);
             }
             break;
 
@@ -597,7 +597,7 @@ void Monitor::evaluateClientPlacement(Client* client, ClientPlacement placement)
                                              area, settings->snap_gap);
                 client->float_size_ = Rectangle(new_tl.x, new_tl.y,
                                                 client->float_size_->width,
-                                                client->float_size_->width);
+                                                client->float_size_->height);
             }
             break;
 

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -583,9 +583,10 @@ void Monitor::evaluateClientPlacement(Client* client, ClientPlacement placement)
                     // the center of the monitor
                     getFloatingArea().dimensions() / 2
                     // minus half the dimensions of the client
-                    - client->float_size_.dimensions() / 2;
-                client->float_size_.x = new_tl.x;
-                client->float_size_.y = new_tl.y;
+                    - client->float_size_->dimensions() / 2;
+                client->float_size_ = Rectangle(new_tl.x, new_tl.y,
+                                                client->float_size_->width,
+                                                client->float_size_->width);
             }
             break;
 
@@ -594,8 +595,9 @@ void Monitor::evaluateClientPlacement(Client* client, ClientPlacement placement)
                 Point2D area = getFloatingArea().dimensions();
                 Point2D new_tl = Floating::smartPlacement(tag, client,
                                              area, settings->snap_gap);
-                client->float_size_.x = new_tl.x;
-                client->float_size_.y = new_tl.y;
+                client->float_size_ = Rectangle(new_tl.x, new_tl.y,
+                                                client->float_size_->width,
+                                                client->float_size_->width);
             }
             break;
 

--- a/src/rectangle.h
+++ b/src/rectangle.h
@@ -24,6 +24,11 @@ struct Rectangle {
     Point2D tr() const { return {x + width, y}; }
     Point2D dimensions() const { return { width, height}; }
 
+    //! return the rectangle with an adjusted position
+    Rectangle shifted(Point2D delta) const {
+        return Rectangle(x + delta.x, y + delta.y, width, height);
+    }
+
     //! Grow/shrink by dx left and right, by dy top and bottom, respectively
     Rectangle adjusted(int dx, int dy) const;
     //! Grow/shrink in each of the four given directions

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -255,7 +255,7 @@ void XMainLoop::configurerequest(XConfigureRequestEvent* cre) {
     Client* client = root_->clients->client(cre->window);
     if (client) {
         bool changes = false;
-        auto newRect = client->float_size_;
+        Rectangle newRect = client->float_size_;
         if (client->sizehints_floating_ &&
             (client->is_client_floated() || client->pseudotile_))
         {

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,4 +1,5 @@
 import pytest
+from herbstluftwm.types import Rectangle
 
 
 def test_client_lives_longer_than_hlwm(hlwm):
@@ -354,3 +355,27 @@ def test_parent_frame_attribute_tag_floating(hlwm):
 
         assert ('parent_frame' in hlwm.list_children(f'clients.{winid}')) \
             == (value == 'off')
+
+
+@pytest.mark.parametrize("minimized", [True, False])
+@pytest.mark.parametrize("floating", [True, False])
+@pytest.mark.parametrize("othertag", [True, False])
+def test_float_geometry_change(hlwm, minimized, floating, x11, othertag):
+    if othertag:
+        hlwm.call('add othertag')
+        hlwm.call('rule tag=othertag')
+    handle, winid = x11.create_client()
+    clientobj = hlwm.attr.clients[winid]
+    clientobj.floating = hlwm.bool(floating)
+    clientobj.minimized = hlwm.bool(minimized)
+    hlwm.call('pad "" 0 0 0 0')
+    hlwm.call('move_monitor "" 800x600+0+0')
+
+    for geom in [Rectangle(x=50, y=100, width=100, height=300),
+                 Rectangle(x=-20, y=2, width=430, height=200)]:
+
+        clientobj.float_geometry = geom.to_user_str()
+
+        if not minimized and not othertag:
+            assert (Rectangle.from_user_str(clientobj.content_geometry()) == geom) == floating
+            assert (x11.get_absolute_top_left(handle) == (geom.x, geom.y)) == floating

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -360,7 +360,7 @@ def test_parent_frame_attribute_tag_floating(hlwm):
 @pytest.mark.parametrize("minimized", [True, False])
 @pytest.mark.parametrize("floating", [True, False])
 @pytest.mark.parametrize("othertag", [True, False])
-def test_float_geometry_change(hlwm, minimized, floating, x11, othertag):
+def test_floating_geometry_change(hlwm, minimized, floating, x11, othertag):
     if othertag:
         hlwm.call('add othertag')
         hlwm.call('rule tag=othertag')
@@ -374,7 +374,7 @@ def test_float_geometry_change(hlwm, minimized, floating, x11, othertag):
     for geom in [Rectangle(x=50, y=100, width=100, height=300),
                  Rectangle(x=-20, y=2, width=430, height=200)]:
 
-        clientobj.float_geometry = geom.to_user_str()
+        clientobj.floating_geometry = geom.to_user_str()
 
         if not minimized and not othertag:
             assert (Rectangle.from_user_str(clientobj.content_geometry()) == geom) == floating

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -715,7 +715,7 @@ def test_pad_applied_to_floating_pos(hlwm):
             hlwm.attr.monitors.focus.pad_left = left
             hlwm.attr.monitors.focus.pad_up = up
             content_geom = Rectangle.from_user_str(clientobj.content_geometry())
-            float_geom = Rectangle.from_user_str(clientobj.float_geometry())
+            float_geom = Rectangle.from_user_str(clientobj.floating_geometry())
 
             assert content_geom.width == float_geom.width
             assert content_geom.height == float_geom.height

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,4 +1,5 @@
 import pytest
+from herbstluftwm.types import Rectangle
 
 
 def test_default_monitor(hlwm):
@@ -701,6 +702,25 @@ def test_pad_command(hlwm):
         args_passed_so_far.add(args)
 
     assert len(args_passed_so_far) == 2**0 + 2**1 + 2**2 + 2**3 + 2**4
+
+
+def test_pad_applied_to_floating_pos(hlwm):
+    winid, _ = hlwm.create_client()
+    clientobj = hlwm.attr.clients[winid]
+    clientobj.floating = 'on'
+    for monitor_rect in [Rectangle(width=300, height=400),
+                         Rectangle(x=2, y=30, width=800, height=600)]:
+        hlwm.attr.monitors.focus.geometry = monitor_rect.to_user_str()
+        for left, up in [(10, 20), (5, 30)]:
+            hlwm.attr.monitors.focus.pad_left = left
+            hlwm.attr.monitors.focus.pad_up = up
+            content_geom = Rectangle.from_user_str(clientobj.content_geometry())
+            float_geom = Rectangle.from_user_str(clientobj.float_geometry())
+
+            assert content_geom.width == float_geom.width
+            assert content_geom.height == float_geom.height
+            assert content_geom.x == float_geom.x + left + monitor_rect.x
+            assert content_geom.y == float_geom.y + up + monitor_rect.y
 
 
 def test_pad_invalid_arg(hlwm):

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -118,7 +118,7 @@ def test_drag_move(hlwm, x11, mouse, repeat):
     hlwm.call('true')  # sync
 
     assert x11.get_absolute_top_left(client) == (x + 12, y + 15)
-    r = Rectangle.from_user_str(hlwm.attr.clients[winid].float_geometry())
+    r = Rectangle.from_user_str(hlwm.attr.clients[winid].floating_geometry())
     assert (r.x, r.y) == (x + 12, y + 15)
 
 
@@ -238,7 +238,7 @@ def test_drag_resize_floating_client(hlwm, x11, mouse, live_update):
     assert (geom_after.width, geom_after.height) == final_size
     assert Rectangle.from_user_str(hlwm.attr.clients[winid].content_geometry()) \
         == geom_before.adjusted(dx=100, dy=120, dw=-100, dh=-120)
-    assert Rectangle.from_user_str(hlwm.attr.clients[winid].float_geometry()) \
+    assert Rectangle.from_user_str(hlwm.attr.clients[winid].floating_geometry()) \
         == geom_before.adjusted(dx=100, dy=120, dw=-100, dh=-120)
 
 

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -118,6 +118,8 @@ def test_drag_move(hlwm, x11, mouse, repeat):
     hlwm.call('true')  # sync
 
     assert x11.get_absolute_top_left(client) == (x + 12, y + 15)
+    r = Rectangle.from_user_str(hlwm.attr.clients[winid].float_geometry())
+    assert (r.x, r.y) == (x + 12, y + 15)
 
 
 @pytest.mark.parametrize('update_dragged', [True, False])
@@ -235,6 +237,8 @@ def test_drag_resize_floating_client(hlwm, x11, mouse, live_update):
     geom_after = client.get_geometry()
     assert (geom_after.width, geom_after.height) == final_size
     assert Rectangle.from_user_str(hlwm.attr.clients[winid].content_geometry()) \
+        == geom_before.adjusted(dx=100, dy=120, dw=-100, dh=-120)
+    assert Rectangle.from_user_str(hlwm.attr.clients[winid].float_geometry()) \
         == geom_before.adjusted(dx=100, dy=120, dw=-100, dh=-120)
 
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -371,7 +371,7 @@ def test_floating_correct_position(hlwm, single, tag):
 
     # the floating geometry is used iff tag or client is set to floating:
     floating_geom_applied = single or tag
-    assert (clientobj.float_geometry() == clientobj.content_geometry()) \
+    assert (clientobj.floating_geometry() == clientobj.content_geometry()) \
         == floating_geom_applied
 
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -355,6 +355,26 @@ def test_floating_focused_vacouus(hlwm):
         .expect_stderr(r'There are no \(non-minimized\) floating windows')
 
 
+@pytest.mark.parametrize("tag", [True, False])
+@pytest.mark.parametrize("single", [True, False])
+def test_floating_correct_position(hlwm, single, tag):
+    if single:
+        hlwm.call('rule floating=on')
+    if tag:
+        hlwm.attr.tags.focus.floating = 'on'
+
+    winid, _ = hlwm.create_client()
+    hlwm.call('move_monitor "" 800x600+0+0')
+    hlwm.call('pad "" 0 0 0 0')
+
+    clientobj = hlwm.attr.clients[winid]
+
+    # the floating geometry is used iff tag or client is set to floating:
+    floating_geom_applied = single or tag
+    assert (clientobj.float_geometry() == clientobj.content_geometry()) \
+        == floating_geom_applied
+
+
 def test_urgent_count(hlwm, x11):
     # create 5 urgent clients
     for i in range(0, 5):


### PR DESCRIPTION
Add a new attribute to access and write the floating geometry of a
client. In order to keep the diff small, I kept the name of the C++
variable in the source code, even though '...geometry' is more
appropriate.

In the diff, I replaced member write-access with a preparation of the
new Rectangle and a single write. This is inevitable anyway because the
operators * and -> of Attribute_<> only return const references (as they
should). Read-only member access is no problem; here, I only had to
replace '.' with '->'.

There is not much necessity to test the attribute itself, but instead,
it serves as a tool to test other features of hlwm (e.g. the pad and the
monitor geometry).