### PR TITLE
New command 'list_clients'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@ Current git version
     client decorations, one does not see the frame decoration behind but the
     wallpaper instead)
   * New command line option '--replace' for replacing an existing window manager.
+  * New command 'list_clients'.
   * The frame attributes ('selection', 'algorithm', 'fraction', 'split_type')
     are now writable.
   * New objects for panels (under 'panels', exposing attributes 'instance',

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -215,10 +215,10 @@ list_keybinds::
 
 WARNING: Tabs within command parameters are not escaped!
 
-list_clients [*--on-tag=*'TAG'|*--on-monitor=*'MONITOR'] [*--in-frame=*'FRAME_PATH'|*--floating*|*--tiling*] [*--title*]::
+list_clients [*--tag=*'TAG'|*--monitor=*'MONITOR'] [*--frame=*'FRAME_PATH'|*--floating*|*--tiling*] [*--title*]::
     Lists the window ids of all clients on the given 'TAG' or 'MONITOR' (or the
     current if unspecified). In addition to that, one can restrict to clients in
-    a specific frame (*--in-frame=*) or to tiled or floated clients.
+    a specific frame (*--frame=*) or to tiled or floated clients.
     The output is one line per client; if *--title* is given, then in addition
     to every client's window id, its window title is printed in the same line.
 

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -215,6 +215,13 @@ list_keybinds::
 
 WARNING: Tabs within command parameters are not escaped!
 
+list_clients [*--on-tag=*'TAG'|*--on-monitor=*'MONITOR'] [*--in-frame=*'FRAME_PATH'|*--floating*|*--tiling*] [*--title*]::
+    Lists the window ids of all clients on the given 'TAG' or 'MONITOR' (or the
+    current if unspecified). In addition to that, one can restrict to clients in
+    a specific frame (*--in-frame=*) or to tiled or floated clients.
+    The output is one line per client; if *--title* is given, then in addition
+    to every client's window id, its window title is printed in the same line.
+
 lock::
     Increases the 'monitors_locked' setting. Use this if you want to do multiple
     window actions at once (i.e. without repainting between the single steps).

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -259,7 +259,7 @@ bool ArgParse::tryParseFlag(const string& inputToken)
  * @param the token
  * @return A flag or a nullptr
  */
-ArgParse::Flag* ArgParse::findFlag(const std::string& inputToken)
+ArgParse::Flag* ArgParse::findFlag(const string& inputToken)
 {
     string needle = inputToken;
     size_t separatorPos = inputToken.find("=");

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -234,7 +234,7 @@ void ArgParse::completion(Completion& complete)
 }
 
 /**
- * @brief try parse a flag, possibly throwing an exception
+ * @brief try to parse a flag, possibly throwing an exception
  * on a parse error.
  * @param argument token from a Input object
  * @return whether the token was a flag

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -253,7 +253,7 @@ int complete_against_commands(int argc, char** argv, int position,
             arguments.push_back(argv[i]);
         }
         // the new completion context has the command name removed
-        Completion completion(arguments, position - 1, g_shell_quoting, output);
+        Completion completion(arguments, position - 1, "", g_shell_quoting, output);
         it->second.complete(completion);
         return completion.noParameterExpected() ?
             HERBST_NO_PARAMETER_EXPECTED

--- a/src/completion.cpp
+++ b/src/completion.cpp
@@ -134,7 +134,7 @@ void Completion::mergeResultsFrom(Completion& source)
     }
 }
 
-void Completion::withPrefix(const std::string& prependPrefix, std::function<void (Completion&)> callback)
+void Completion::withPrefix(const string& prependPrefix, function<void (Completion&)> callback)
 {
     Completion withPrefix(
         args_,

--- a/src/completion.cpp
+++ b/src/completion.cpp
@@ -7,6 +7,7 @@
 
 #include "utils.h"
 
+using std::function;
 using std::string;
 
 /** Construct a completion context
@@ -15,9 +16,10 @@ using std::string;
  * index        The index of the argument to complete
  * shellOutput  Wether the output is shell encoded, see class description
  */
-Completion::Completion(ArgList args, size_t index, bool shellOutput, Output output)
+Completion::Completion(ArgList args, size_t index, const string& prepend, bool shellOutput, Output output)
     : args_(args)
     , index_(index)
+    , prepend_(prepend)
     , output_(output)
     , shellOutput_(shellOutput)
 {
@@ -29,7 +31,7 @@ Completion::Completion(ArgList args, size_t index, bool shellOutput, Output outp
 }
 
 Completion::Completion(const Completion& other)
-    : Completion(other.args_, other.index_, other.shellOutput_, other.output_)
+    : Completion(other.args_, other.index_, other.prepend_, other.shellOutput_, other.output_)
 {
 }
 
@@ -37,8 +39,8 @@ void Completion::operator=(const Completion& other) {
 }
 
 void Completion::full(const string& word) {
-    if (prefixOf(needle_, word)) {
-        output_ << escape(word) << (shellOutput_ ? " \n" : "\n");
+    if (prefixOf(needle_, prepend_ + word)) {
+        output_ << escape(prepend_ + word) << (shellOutput_ ? " \n" : "\n");
         // std::cout << "add " << word << endl;
     } else {
         // std::cout << needle_ << " not prefix of " << word << endl;
@@ -72,10 +74,10 @@ bool Completion::prefixOf(const string& shorter, const string& longer)
 }
 
 void Completion::partial(const string& word) {
-    if (prefixOf(needle_, word)) {
+    if (prefixOf(needle_, prepend_ + word)) {
         // partial completions never end with a space, regardless of
         // shellOutput mode
-        output_ << escape(word) << "\n";
+        output_ << escape(prepend_ + word) << "\n";
     }
 }
 
@@ -110,6 +112,7 @@ Completion Completion::shifted(size_t offset) const {
     return Completion(
         ArgList(args_.begin() + offset, args_.end()),
         index_ - offset,
+        prepend_,
         shellOutput_,
         output_);
 }
@@ -118,15 +121,30 @@ Completion Completion::shifted(size_t offset) const {
 void Completion::completeCommands(size_t offset) {
     Completion thisShifted = shifted(offset);
     Commands::complete(thisShifted);
+    mergeResultsFrom(thisShifted);
+}
 
-    if (thisShifted.ifInvalidArguments()) {
-        thisShifted.invalidArguments();
+void Completion::mergeResultsFrom(Completion& source)
+{
+    if (source.ifInvalidArguments()) {
+        source.invalidArguments();
     }
-    if (thisShifted.noParameterExpected()) {
-        thisShifted.none();
+    if (source.noParameterExpected()) {
+        source.none();
     }
 }
 
+void Completion::withPrefix(const std::string& prependPrefix, std::function<void (Completion&)> callback)
+{
+    Completion withPrefix(
+        args_,
+        index_,
+        prepend_ + prependPrefix,
+        shellOutput_,
+        output_);
+    callback(withPrefix);
+    mergeResultsFrom(withPrefix);
+}
 
 void Completion::invalidArguments() {
     invalidArgument_ = true;

--- a/src/completion.h
+++ b/src/completion.h
@@ -1,6 +1,8 @@
 #ifndef HLWM_COMPLETION
 #define HLWM_COMPLETION
 
+#include <functional>
+
 #include "arglist.h"
 #include "commandio.h"
 
@@ -25,7 +27,7 @@ void complete(Completion& completion);
  */
 class Completion {
 public:
-    Completion(ArgList args, size_t index, bool shellOutput, Output output);
+    Completion(ArgList args, size_t index, const std::string& prepend, bool shellOutput, Output output);
 
     //! the given word is a possible argument, e.g. full("status")
     void full(const std::string& word);
@@ -70,6 +72,7 @@ public:
     friend void Commands::complete(Completion& completion);
 
     void completeCommands(size_t offset);
+    void withPrefix(const std::string& prependPrefix, std::function<void(Completion&)> callback);
 private:
     /** The intended use is to pass the completion state as the reference and
      * to return possible completions via this Completion object. This is why
@@ -78,6 +81,7 @@ private:
      */
     void operator=(const Completion& other);
     Completion(const Completion& other);
+    void mergeResultsFrom(Completion& source);
 
     Completion shifted(size_t offset) const;
     std::string escape(const std::string& str);
@@ -85,6 +89,7 @@ private:
     ArgList args_;
     size_t index_;
     std::string needle_;
+    std::string prepend_; //! a string that is prepended to all completion results
     Output output_;
     bool   shellOutput_;
     bool   noParameterExpected_ = false;

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -17,6 +17,8 @@
 #include "tagmanager.h"
 #include "xconnection.h"
 
+using std::shared_ptr;
+using std::function;
 using std::string;
 using std::endl;
 
@@ -358,7 +360,7 @@ void GlobalCommands::listClientsCommand(CallOrComplete invoc)
             onTag = onMonitor->tag;
         }
         // now, onTag is set in any case.
-        std::function<void(Client*)> printClient = [&](Client* c) {
+        function<void(Client*)> printClient = [&](Client* c) {
             if (floating && !c->is_client_floated()) {
                 return;
             }
@@ -380,7 +382,7 @@ void GlobalCommands::listClientsCommand(CallOrComplete invoc)
         if (inFrame == noFrameDefined) {
             onTag->foreachClient(printClient);
         } else {
-            std::shared_ptr<Frame> frame = onTag->frame->lookup(inFrame);
+            shared_ptr<Frame> frame = onTag->frame->lookup(inFrame);
             frame->foreachClient(printClient);
         }
         return 0;

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -344,12 +344,12 @@ void GlobalCommands::listClientsCommand(CallOrComplete invoc)
     bool tiling = false;
     string noFrameDefined = "#NoFrameDefined";
     string inFrame = noFrameDefined;
-    ArgParse().flags({ {"--on-tag=", onTag}
-                     , {"--on-monitor=", onMonitor}
+    ArgParse().flags({ {"--tag=", onTag}
+                     , {"--monitor=", onMonitor}
                      , {"--title", &showTitle}
                      , {"--floating", &floating}
                      , {"--tiling", &tiling}
-                     , {"--in-frame=", inFrame}
+                     , {"--frame=", inFrame}
                      })
             .command(invoc, [&](Output output) {
         if (!onTag) {

--- a/src/globalcommands.h
+++ b/src/globalcommands.h
@@ -45,6 +45,8 @@ public:
     void lowerCommand(CallOrComplete invoc);
 
     void focusNthCommand(CallOrComplete invoc);
+
+    void listClientsCommand(CallOrComplete invoc);
 private:
     Root& root_;
 };

--- a/src/layout.h
+++ b/src/layout.h
@@ -79,12 +79,12 @@ public:
     friend class HSTag; // for HSTag::foreachClient()
     DynAttribute_<std::string> frameIndexAttr_;
     std::string frameIndex() const;
+    void foreachClient(ClientAction action);
 public: // soon will be protected:
     virtual std::shared_ptr<FrameSplit> isSplit() { return std::shared_ptr<FrameSplit>(); };
     virtual std::shared_ptr<FrameLeaf> isLeaf() { return std::shared_ptr<FrameLeaf>(); };
 protected:
     void relayout();
-    void foreachClient(ClientAction action);
     HSTag* tag_;
     Settings* settings_;
     std::weak_ptr<FrameSplit> parent_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,6 +169,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
         {"pad",            { monitors, &MonitorManager::padCommand }},
         {"raise",          { global_cmds, &GlobalCommands::raiseCommand }},
         {"lower",          { global_cmds, &GlobalCommands::lowerCommand }},
+        {"list_clients",   { global_cmds, &GlobalCommands::listClientsCommand }},
         {"rule",           {rules, &RuleManager::addRuleCommand,
                                    &RuleManager::addRuleCompletion}},
         {"unrule",         {rules, &RuleManager::unruleCommand,

--- a/tests/test_global_commands.py
+++ b/tests/test_global_commands.py
@@ -264,3 +264,115 @@ def test_focus_nth_completion(hlwm):
     assert '-1' in hlwm.complete(['focus_nth'])
 
     hlwm.command_has_all_args(['focus_nth', '0'])
+
+
+def test_list_clients_without_args(hlwm):
+    assert hlwm.call('list_clients').stdout.splitlines() == []
+
+    winid1, _ = hlwm.create_client()
+    assert hlwm.call('list_clients').stdout.splitlines() == [winid1]
+
+    winid2, _ = hlwm.create_client()
+    assert sorted(hlwm.call('list_clients').stdout.splitlines()) == sorted([winid1, winid2])
+
+
+def test_list_clients_with_title(hlwm):
+    winid, _ = hlwm.create_client(title="my\ntitle")
+    for cmd in ['list_clients --title', 'list_clients --on-monitor=0 --title']:
+        assert hlwm.call(cmd).stdout.splitlines() == [winid + ' my title']
+
+
+@pytest.mark.parametrize("on_monitor", [False, True])
+def test_list_clients_on_tag_or_on_monitor(hlwm, on_monitor):
+    hlwm.create_client()  # a dummy client that should not appear in the output
+
+    hlwm.call('add othertag')
+    flag = '--on-tag=othertag'
+    if on_monitor:
+        hlwm.call('add_monitor 800x600+800+0 othertag mymonitor')
+        flag = '--on-monitor=mymonitor'
+    hlwm.call('rule tag=othertag')
+    winid1, _ = hlwm.create_client()
+    winid2, _ = hlwm.create_client()
+
+    assert sorted(hlwm.call(['list_clients', flag]).stdout.splitlines()) \
+        == sorted([winid1, winid2])
+
+
+def test_list_clients_floating_tiling(hlwm):
+    tiling, _ = hlwm.create_client()
+
+    hlwm.call('rule floating=on')
+    floating, _ = hlwm.create_client()
+
+    assert hlwm.call(['list_clients', '--floating']).stdout == floating + '\n'
+    assert hlwm.call(['list_clients', '--tiling']).stdout == tiling + '\n'
+
+
+def test_list_clients_in_frame(hlwm):
+    clients = hlwm.create_clients(4)
+
+    layout = f'''
+        (split vertical:0.5:0
+            (clients max:0 {clients[0]} {clients[1]})
+            (clients max:0 {clients[2]} {clients[3]}))
+    '''.strip()
+    hlwm.call(['load', layout])
+
+    def list_clients(flags):
+        return sorted(hlwm.call(['list_clients'] + flags).stdout.splitlines())
+
+    assert list_clients(['--in-frame=']) == sorted(clients)
+    assert list_clients(['--in-frame=@']) == sorted(clients[0:2])
+    assert list_clients(['--in-frame=0']) == sorted(clients[0:2])
+    assert list_clients(['--in-frame=1']) == sorted(clients[2:4])
+
+
+def test_list_clients_invalid_arg(hlwm):
+    hlwm.call_xfail('list_clients --foo') \
+        .expect_stderr('Unknown.*--foo')
+
+    hlwm.call_xfail('list_clients --on-tag') \
+        .expect_stderr('Unknown.*--on-tag')
+
+    hlwm.call_xfail('list_clients --on-tag=') \
+        .expect_stderr('no such tag')
+
+    hlwm.call('add sometag')
+    hlwm.call('add_monitor 800x600+800+0 sometag somemonitor')
+
+    hlwm.call_xfail('list_clients --on-tag=foobar') \
+        .expect_stderr('no such tag.*foobar')
+
+    hlwm.call_xfail('list_clients --on-tag=somemonitor') \
+        .expect_stderr('no such tag.*somemonitor')
+
+    hlwm.call_xfail('list_clients --on-monitor=sometag') \
+        .expect_stderr('No such monitor.*sometag')
+
+
+def test_list_clients_completion(hlwm):
+    assert '--title' in hlwm.complete(['list_clients', '--ti'], position=1)
+
+    hlwm.call('add sometag')
+    hlwm.call('add_monitor 800x600+800+0 sometag somemonitor')
+    results = hlwm.complete(['list_clients'], partial=True, evaluate_escapes=True)
+    assert '--on-tag=sometag' in results
+    assert '--on-monitor=somemonitor' in results
+    assert '--tiling' in results
+    assert '--floating' in results
+    assert '--in-frame=' in results
+
+    # it makes sense to pass more than one flag:
+    assert '--title' in hlwm.complete(['list_clients', '--on-tag=sometag', '--ti'], position=2)
+
+    all_args = [
+        'list_clients',
+        '--on-tag=sometag',
+        '--on-monitor=somemonitor',  # redundant anyways
+        '--title',
+        '--floating',
+        '--tiling',
+        '--in-frame=',
+    ]
+    hlwm.command_has_all_args(all_args)

--- a/tests/test_global_commands.py
+++ b/tests/test_global_commands.py
@@ -278,7 +278,7 @@ def test_list_clients_without_args(hlwm):
 
 def test_list_clients_with_title(hlwm):
     winid, _ = hlwm.create_client(title="my\ntitle")
-    for cmd in ['list_clients --title', 'list_clients --on-monitor=0 --title']:
+    for cmd in ['list_clients --title', 'list_clients --monitor=0 --title']:
         assert hlwm.call(cmd).stdout.splitlines() == [winid + ' my title']
 
 
@@ -287,10 +287,10 @@ def test_list_clients_on_tag_or_on_monitor(hlwm, on_monitor):
     hlwm.create_client()  # a dummy client that should not appear in the output
 
     hlwm.call('add othertag')
-    flag = '--on-tag=othertag'
+    flag = '--tag=othertag'
     if on_monitor:
         hlwm.call('add_monitor 800x600+800+0 othertag mymonitor')
-        flag = '--on-monitor=mymonitor'
+        flag = '--monitor=mymonitor'
     hlwm.call('rule tag=othertag')
     winid1, _ = hlwm.create_client()
     winid2, _ = hlwm.create_client()
@@ -322,32 +322,32 @@ def test_list_clients_in_frame(hlwm):
     def list_clients(flags):
         return sorted(hlwm.call(['list_clients'] + flags).stdout.splitlines())
 
-    assert list_clients(['--in-frame=']) == sorted(clients)
-    assert list_clients(['--in-frame=@']) == sorted(clients[0:2])
-    assert list_clients(['--in-frame=0']) == sorted(clients[0:2])
-    assert list_clients(['--in-frame=1']) == sorted(clients[2:4])
+    assert list_clients(['--frame=']) == sorted(clients)
+    assert list_clients(['--frame=@']) == sorted(clients[0:2])
+    assert list_clients(['--frame=0']) == sorted(clients[0:2])
+    assert list_clients(['--frame=1']) == sorted(clients[2:4])
 
 
 def test_list_clients_invalid_arg(hlwm):
     hlwm.call_xfail('list_clients --foo') \
         .expect_stderr('Unknown.*--foo')
 
-    hlwm.call_xfail('list_clients --on-tag') \
-        .expect_stderr('Unknown.*--on-tag')
+    hlwm.call_xfail('list_clients --tag') \
+        .expect_stderr('Unknown.*--tag')
 
-    hlwm.call_xfail('list_clients --on-tag=') \
+    hlwm.call_xfail('list_clients --tag=') \
         .expect_stderr('no such tag')
 
     hlwm.call('add sometag')
     hlwm.call('add_monitor 800x600+800+0 sometag somemonitor')
 
-    hlwm.call_xfail('list_clients --on-tag=foobar') \
+    hlwm.call_xfail('list_clients --tag=foobar') \
         .expect_stderr('no such tag.*foobar')
 
-    hlwm.call_xfail('list_clients --on-tag=somemonitor') \
+    hlwm.call_xfail('list_clients --tag=somemonitor') \
         .expect_stderr('no such tag.*somemonitor')
 
-    hlwm.call_xfail('list_clients --on-monitor=sometag') \
+    hlwm.call_xfail('list_clients --monitor=sometag') \
         .expect_stderr('No such monitor.*sometag')
 
 
@@ -357,22 +357,22 @@ def test_list_clients_completion(hlwm):
     hlwm.call('add sometag')
     hlwm.call('add_monitor 800x600+800+0 sometag somemonitor')
     results = hlwm.complete(['list_clients'], partial=True, evaluate_escapes=True)
-    assert '--on-tag=sometag' in results
-    assert '--on-monitor=somemonitor' in results
+    assert '--tag=sometag' in results
+    assert '--monitor=somemonitor' in results
     assert '--tiling' in results
     assert '--floating' in results
-    assert '--in-frame=' in results
+    assert '--frame=' in results
 
     # it makes sense to pass more than one flag:
-    assert '--title' in hlwm.complete(['list_clients', '--on-tag=sometag', '--ti'], position=2)
+    assert '--title' in hlwm.complete(['list_clients', '--tag=sometag', '--ti'], position=2)
 
     all_args = [
         'list_clients',
-        '--on-tag=sometag',
-        '--on-monitor=somemonitor',  # redundant anyways
+        '--tag=sometag',
+        '--monitor=somemonitor',  # redundant anyways
         '--title',
         '--floating',
         '--tiling',
-        '--in-frame=',
+        '--frame=',
     ]
     hlwm.command_has_all_args(all_args)


### PR DESCRIPTION
For the new command 'list_clients' the main challenge was to extend
ArgParse by command line flags that take arguments. To make the
completion work, I also had to extend the completion objects by a
'prepend' string that is prepended to every completion result.

This implements the main feature request of #831 and also includes the
functionality of the rejected PR #1249.