### PR TITLE
Auto-convert attributes to/from python types

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,7 @@ Current git version
   * New command 'attr_type' printing the type of a given attribute.
   * Relative values for integer attributes ('+=N' and '-=N')
   * The 'cycle' command now also cycles through floating windows.
+  * The python bindings automatically convert from and to python's types
   * Bug fixes:
     - Fix mistakenly transparent borders of argb clients
   * New dependency: xrender

--- a/python/herbstluftwm/types.py
+++ b/python/herbstluftwm/types.py
@@ -48,3 +48,81 @@ class Rectangle:
         are adjusted by the provided deltas.
         """
         return Rectangle(self.x + dx, self.y + dy, self.width + dw, self.height + dh)
+
+
+class HlwmType:
+    """
+    Wrapper functions for converting between python types and types
+    in herbstluftwm.
+    """
+    def __init__(self, name, from_user_str, to_user_str, is_instance):
+        # a hlwm type should define the following
+        self.name = name  # type: str
+        # a callback for parsing
+        self.from_user_str = from_user_str  # of type: str -> T
+        # a callback for printing
+        self.to_user_str = to_user_str  # of type: T -> str
+        # a predicate whether a python variable has this type:
+        self.is_instance = is_instance  # of type: Anything -> bool
+
+    @staticmethod
+    def by_name(type_name):
+        """Given the full name of a hlwm type, return
+        the metadata
+        python type"""
+        for t in hlwm_types():
+            if t.name == type_name:
+                return t
+        return None
+
+    @staticmethod
+    def by_type_of_variable(python_variable):
+        """Given a variable, detect its type
+        """
+        for t in hlwm_types():
+            if t.is_instance(python_variable):
+                return t
+        return None
+
+
+def hlwm_types():
+    """
+    Return a list of HlwmType objects.
+
+    Unfortunately, the order matters for the is_instance() predicate: Here, the
+    first matching type in the list must be used. (This is because
+    `isinstance(True, int)` is true)
+    """
+    types = [
+        HlwmType('bool',
+                 bool_from_user_str,
+                 lambda b: 'true' if b else 'false',
+                 lambda x: isinstance(x, bool)),
+
+        HlwmType('int', int, str, lambda x: isinstance(x, int)),
+
+        # there is no uint in python, so we just convert it to 'int'
+        HlwmType('uint', int, str, lambda x: False),
+
+        HlwmType('rectangle',
+                 Rectangle.from_user_str,
+                 Rectangle.to_user_str,
+                 lambda x: isinstance(x, Rectangle)),
+
+        HlwmType('string',
+                 lambda x: x,
+                 lambda x: x,
+                 lambda x: isinstance(x, str)),
+    ]
+
+    return types
+
+
+def bool_from_user_str(bool_string):
+    """Parse a the string description of a hlwm boolean to
+    a python boolean"""
+    if bool_string.lower() in ['true', 'on']:
+        return True
+    if bool_string.lower() in ['false', 'off']:
+        return False
+    raise Exception(f'"{bool_string}" is not a boolean')

--- a/python/herbstluftwm/types.py
+++ b/python/herbstluftwm/types.py
@@ -125,7 +125,7 @@ def hlwm_types():
 
 
 def bool_from_user_str(bool_string):
-    """Parse a the string description of a hlwm boolean to
+    """Parse a string description of a hlwm boolean to
     a python boolean"""
     if bool_string.lower() in ['true', 'on']:
         return True

--- a/python/herbstluftwm/types.py
+++ b/python/herbstluftwm/types.py
@@ -94,25 +94,31 @@ def hlwm_types():
     `isinstance(True, int)` is true)
     """
     types = [
-        HlwmType('bool',
-                 bool_from_user_str,
-                 lambda b: 'true' if b else 'false',
-                 lambda x: isinstance(x, bool)),
+        HlwmType(name='bool',
+                 from_user_str=bool_from_user_str,
+                 to_user_str=lambda b: 'true' if b else 'false',
+                 is_instance=lambda x: isinstance(x, bool)),
 
-        HlwmType('int', int, str, lambda x: isinstance(x, int)),
+        HlwmType(name='int',
+                 from_user_str=int,
+                 to_user_str=str,
+                 is_instance=lambda x: isinstance(x, int)),
 
         # there is no uint in python, so we just convert it to 'int'
-        HlwmType('uint', int, str, lambda x: False),
+        HlwmType(name='uint',
+                 from_user_str=int,
+                 to_user_str=str,
+                 is_instance=lambda x: False),
 
-        HlwmType('rectangle',
-                 Rectangle.from_user_str,
-                 Rectangle.to_user_str,
-                 lambda x: isinstance(x, Rectangle)),
+        HlwmType(name='rectangle',
+                 from_user_str=Rectangle.from_user_str,
+                 to_user_str=Rectangle.to_user_str,
+                 is_instance=lambda x: isinstance(x, Rectangle)),
 
-        HlwmType('string',
-                 lambda x: x,
-                 lambda x: x,
-                 lambda x: isinstance(x, str)),
+        HlwmType(name='string',
+                 from_user_str=lambda x: x,
+                 to_user_str=lambda x: x,
+                 is_instance=lambda x: isinstance(x, str)),
     ]
 
     return types

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -377,5 +377,5 @@ def test_floating_geometry_change(hlwm, minimized, floating, x11, othertag):
         clientobj.floating_geometry = geom.to_user_str()
 
         if not minimized and not othertag:
-            assert (Rectangle.from_user_str(clientobj.content_geometry()) == geom) == floating
+            assert (clientobj.content_geometry() == geom) == floating
             assert (x11.get_absolute_top_left(handle) == (geom.x, geom.y)) == floating

--- a/tests/test_global_commands.py
+++ b/tests/test_global_commands.py
@@ -132,7 +132,7 @@ def test_cycle_value_invalid_arg(hlwm):
 
     # calling it a first time works
     hlwm.call(command)
-    assert hlwm.attr.clients.my_foo() == '2'
+    assert hlwm.attr.clients.my_foo() == 2
 
     # calling it a second time fails
     hlwm.call_xfail(command) \
@@ -202,8 +202,8 @@ def test_use_index_move_index_skip_visible(hlwm, use_or_move_index, delta, skip_
         hlwm.call('chain , add dummy , add free , add used')
 
     hlwm.call('add_monitor 800x600+800+0 used')
-    assert hlwm.attr.monitors.focus.index() == '0'
-    assert hlwm.attr.tags.focus.index() == '0'
+    assert hlwm.attr.monitors.focus.index() == 0
+    assert hlwm.attr.tags.focus.index() == 0
 
     if use_or_move_index == 'move_index':
         winid, _ = hlwm.create_client()
@@ -222,13 +222,13 @@ def test_use_index_move_index_skip_visible(hlwm, use_or_move_index, delta, skip_
     hlwm.call(cmd)
 
     if use_or_move_index == 'use_index':
-        assert hlwm.attr.monitors.focus.index() == '0'
+        assert hlwm.attr.monitors.focus.index() == 0
         assert hlwm.attr.tags.focus.name() == expected_name
     else:
         assert hlwm.attr.clients[winid].tag() == expected_name
         # however, we stay on the original tag:
-        assert hlwm.attr.monitors.focus.index() == '0'
-        assert hlwm.attr.tags.focus.index() == '0'
+        assert hlwm.attr.monitors.focus.index() == 0
+        assert hlwm.attr.tags.focus.index() == 0
 
 
 @pytest.mark.parametrize("running_clients_num", [0, 1, 5])
@@ -253,10 +253,10 @@ def test_focus_nth_last_window(hlwm):
     hlwm.create_clients(4)
     for last_idx in ['-1', '4', '2342', '-123']:
         hlwm.call(['focus_nth', '0'])  # reset
-        assert hlwm.attr.tags.focus.tiling.focused_frame.selection() == '0'
+        assert hlwm.attr.tags.focus.tiling.focused_frame.selection() == 0
 
         hlwm.call(['focus_nth', last_idx])
-        assert hlwm.attr.tags.focus.tiling.focused_frame.selection() == '3'
+        assert hlwm.attr.tags.focus.tiling.focused_frame.selection() == 3
 
 
 def test_focus_nth_completion(hlwm):

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -369,23 +369,23 @@ def test_cycle_stays_in_floating_layer(hlwm):
     for winid in floating:
         assert hlwm.attr.clients.focus.winid() == winid
         # the floating layer always stays focused
-        assert hlwm.attr.tags.focus.floating_focused() == hlwm.bool(True)
+        assert hlwm.attr.tags.focus.floating_focused() is True
         hlwm.call(['cycle', '+1'])
 
     # we're back a the first floating client:
     assert hlwm.attr.clients.focus.winid() == floating[0]
-    assert hlwm.attr.tags.focus.floating_focused() == hlwm.bool(True)
+    assert hlwm.attr.tags.focus.floating_focused() is True
 
 
 def test_cycle_empty_scope(hlwm):
-    for floating in ['on', 'off']:
+    for floating in [True, False]:
         hlwm.attr.tags.focus.floating = floating
 
         hlwm.call('cycle -1')
         hlwm.call('cycle +1')
         hlwm.call('cycle 0')
 
-        assert hlwm.attr.tags.focus.tiling.focused_frame.selection() == '0'
+        assert hlwm.attr.tags.focus.tiling.focused_frame.selection() == 0
 
 
 def test_cycle_completion(hlwm):
@@ -708,9 +708,9 @@ def test_split_invalid_arg(hlwm):
 
 
 def test_split_incomple_mode_name(hlwm):
-    assert hlwm.attr.tags.focus.frame_count() == '1'
+    assert hlwm.attr.tags.focus.frame_count() == 1
     hlwm.call(['split', 'e'])  # the same as 'explode'
-    assert hlwm.attr.tags.focus.frame_count() == '2'
+    assert hlwm.attr.tags.focus.frame_count() == 2
 
 
 def test_split_equivalent_modes(hlwm):
@@ -1537,13 +1537,13 @@ def test_shift_to_other_monitor_if_allowed_by_setting(hlwm, cross_monitor_bounds
     hlwm.create_client()
     # but the 'winid' is focused on monitor 0
     assert hlwm.attr.clients.focus.winid() == winid
-    assert hlwm.attr.monitors.focus.index() == '0'
+    assert hlwm.attr.monitors.focus.index() == 0
 
     command = ['shift', 'right']
     if cross_monitor_bounds:
         # 'winid' gets moved to the monitor on the right
         hlwm.call(command)
-        assert hlwm.attr.monitors.focus.index() == '1'
+        assert hlwm.attr.monitors.focus.index() == 1
     else:
         # the setting forbids that the window leaves the tag
         hlwm.call_xfail(command) \
@@ -1567,12 +1567,12 @@ def test_shift_to_other_monitor_floating(hlwm, floating):
     else:
         assert floating == 'off'
     assert hlwm.attr.clients.focus.winid() == winid
-    assert hlwm.attr.monitors.focus.index() == '0'
+    assert hlwm.attr.monitors.focus.index() == 0
 
     hlwm.call('shift left')
 
     assert hlwm.attr.clients.focus.winid() == winid
-    assert hlwm.attr.monitors.focus.index() == '1'
+    assert hlwm.attr.monitors.focus.index() == 1
 
 
 @pytest.mark.parametrize("floating", [True, False])
@@ -1588,21 +1588,21 @@ def test_shift_stays_on_monitor(hlwm, floating):
 
     winid, _ = hlwm.create_client(position=(0, 0))
     assert hlwm.attr.clients.focus.winid() == winid
-    assert hlwm.attr.monitors.focus.index() == '0'
+    assert hlwm.attr.monitors.focus.index() == 0
 
     # the new client is far away from the bottom edge of monitor 0.
     # so shifting it downwards makes it stay on monitor 0
     hlwm.call('shift down')
 
     assert hlwm.attr.clients.focus.winid() == winid
-    assert hlwm.attr.monitors.focus.index() == '0'
+    assert hlwm.attr.monitors.focus.index() == 0
 
     # now the client is on the bottom corner of the monitor.
     # so shifting it again will make it enter monitor 1
     hlwm.call('shift down')
 
     assert hlwm.attr.clients.focus.winid() == winid
-    assert hlwm.attr.monitors.focus.index() == '1'
+    assert hlwm.attr.monitors.focus.index() == 1
 
 
 def test_shift_no_monitor_in_direction(hlwm):
@@ -1648,9 +1648,9 @@ def test_frame_leaf_selection_change(hlwm):
 
 
 def test_frame_leaf_selection_if_empty(hlwm):
-    assert hlwm.attr.tags.focus.tiling.root.selection() == '0'
+    assert hlwm.attr.tags.focus.tiling.root.selection() == 0
     hlwm.attr.tags.focus.tiling.root.selection = 0
-    assert hlwm.attr.tags.focus.tiling.root.selection() == '0'
+    assert hlwm.attr.tags.focus.tiling.root.selection() == 0
 
     hlwm.call_xfail('attr tags.focus.tiling.root.selection 1') \
         .expect_stderr('out of range')

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -158,7 +158,7 @@ def test_move_monitor(hlwm):
 
 
 def test_move_monitor_completion(hlwm):
-    assert hlwm.get_attr('monitors.focus.geometry') in hlwm.complete('move_monitor 0')
+    assert str(hlwm.attr.monitors.focus.geometry) in hlwm.complete('move_monitor 0')
     # pads:
     assert '0' in hlwm.complete('move_monitor 0 800x600+0+0')
     assert '0' in hlwm.complete('move_monitor 0 800x600+0+0 0')

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -19,11 +19,11 @@ def test_add_monitor_requires_unfocused_tag(hlwm):
 def test_add_monitor(hlwm):
     hlwm.call('add tag2')
 
-    hlwm.call('add_monitor 800x600+40+40 tag2 monitor2')
+    hlwm.call('add_monitor 800x600+40+41 tag2 monitor2')
 
     assert hlwm.get_attr('monitors.count') == '2'
     assert hlwm.get_attr('monitors.1.name') == 'monitor2'
-    assert hlwm.attr.monitors[1].geometry() == '800x600+40+40'
+    assert hlwm.attr.monitors[1].geometry() == Rectangle(40, 41, 800, 600)
 
 
 def test_add_monitor_invalid_geometry(hlwm):
@@ -158,7 +158,7 @@ def test_move_monitor(hlwm):
 
 
 def test_move_monitor_completion(hlwm):
-    assert hlwm.attr.monitors.focus.geometry() in hlwm.complete('move_monitor 0')
+    assert hlwm.get_attr('monitors.focus.geometry') in hlwm.complete('move_monitor 0')
     # pads:
     assert '0' in hlwm.complete('move_monitor 0 800x600+0+0')
     assert '0' in hlwm.complete('move_monitor 0 800x600+0+0 0')
@@ -352,7 +352,7 @@ def test_use_previous_nothing_viewed_before(hlwm):
     # is a no-op:
     hlwm.call('use_previous')
 
-    assert hlwm.attr.monitors.focus.index() == '0'
+    assert hlwm.attr.monitors.focus.index() == 0
 
 
 def test_use_previous_on_locked_monitor(hlwm):
@@ -512,7 +512,7 @@ def test_lock_tag_switch_away(hlwm, lock_tag_cmd):
     hlwm.call('add tag2')
     hlwm.call('set_monitors 800x600+0+0 800x600+800+0')
     hlwm.call(lock_tag_cmd(0))
-    assert hlwm.attr.monitors[0].lock_tag() == hlwm.bool(True)
+    assert hlwm.attr.monitors[0].lock_tag() is True
 
     hlwm.call('focus_monitor 0')
 
@@ -538,11 +538,11 @@ def test_lock_tag_switch_to_locked(hlwm, locked):
     if locked:
         # if the monitor was locked, then the tag stays
         # on monitor 0
-        expected_monitor_index = '0'
+        expected_monitor_index = 0
     else:
         # otherwise, the tag is moved to monitor 1 because
         # of swap_monitors_to_get_tag
-        expected_monitor_index = '1'
+        expected_monitor_index = 1
     assert hlwm.attr.tags.focus.name() == tag_on_locked_monitor
     assert hlwm.attr.monitors.focus.index() == expected_monitor_index
 
@@ -554,14 +554,14 @@ def test_lock_tag_command_vs_attribute(hlwm):
 
     # no argument modifies the attribute of the focused monitor
     hlwm.call('lock_tag')
-    assert hlwm.attr.monitors[1].lock_tag() == hlwm.bool(True)
+    assert hlwm.attr.monitors[1].lock_tag() is True
     hlwm.call('unlock_tag')
-    assert hlwm.attr.monitors[1].lock_tag() == hlwm.bool(False)
+    assert hlwm.attr.monitors[1].lock_tag() is False
 
     hlwm.call('lock_tag 0')
-    assert hlwm.attr.monitors[0].lock_tag() == hlwm.bool(True)
+    assert hlwm.attr.monitors[0].lock_tag() is True
     hlwm.call('unlock_tag 0')
-    assert hlwm.attr.monitors[0].lock_tag() == hlwm.bool(False)
+    assert hlwm.attr.monitors[0].lock_tag() is False
 
 
 def test_monitor_rect_too_small(hlwm):
@@ -574,7 +574,7 @@ def test_monitor_rect_too_small(hlwm):
 def test_monitor_rect_is_updated(hlwm):
     for rect in ['500x300+30+40', '500x300-30+40', '500x300+30-40', '500x300-30-40']:
         hlwm.call(['move_monitor', 0, rect])
-        assert hlwm.attr.monitors[0].geometry() == rect
+        assert hlwm.attr.monitors[0].geometry().to_user_str() == rect
 
 
 def test_monitor_rect_parser(hlwm):
@@ -714,8 +714,8 @@ def test_pad_applied_to_floating_pos(hlwm):
         for left, up in [(10, 20), (5, 30)]:
             hlwm.attr.monitors.focus.pad_left = left
             hlwm.attr.monitors.focus.pad_up = up
-            content_geom = Rectangle.from_user_str(clientobj.content_geometry())
-            float_geom = Rectangle.from_user_str(clientobj.floating_geometry())
+            content_geom = clientobj.content_geometry()
+            float_geom = clientobj.floating_geometry()
 
             assert content_geom.width == float_geom.width
             assert content_geom.height == float_geom.height

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -1,7 +1,6 @@
 import pytest
 import re
 import math
-from herbstluftwm.types import Rectangle
 
 # Note: For unknown reasons, mouse buttons 4 and 5 (scroll wheel) do not work
 # in Xvfb when running tests in the CI. Therefore, we maintain two lists of
@@ -118,7 +117,7 @@ def test_drag_move(hlwm, x11, mouse, repeat):
     hlwm.call('true')  # sync
 
     assert x11.get_absolute_top_left(client) == (x + 12, y + 15)
-    r = Rectangle.from_user_str(hlwm.attr.clients[winid].floating_geometry())
+    r = hlwm.attr.clients[winid].floating_geometry()
     assert (r.x, r.y) == (x + 12, y + 15)
 
 
@@ -128,7 +127,7 @@ def test_drag_move_sends_configure(hlwm, x11, mouse, update_dragged):
     hlwm.attr.settings.update_dragged_clients = hlwm.bool(update_dragged)
     client, winid = x11.create_client()
     x, y = x11.get_absolute_top_left(client)
-    before = Rectangle.from_user_str(hlwm.attr.clients[winid].content_geometry())
+    before = hlwm.attr.clients[winid].content_geometry()
     assert (x, y) == (before.x, before.y)
     mouse.move_into(winid, wait=True)
 
@@ -137,7 +136,7 @@ def test_drag_move_sends_configure(hlwm, x11, mouse, update_dragged):
     mouse.click('1')  # stop dragging
     hlwm.call('true')  # sync
 
-    after = Rectangle.from_user_str(hlwm.attr.clients[winid].content_geometry())
+    after = hlwm.attr.clients[winid].content_geometry()
     assert before.adjusted(dx=12, dy=15) == after
 
 
@@ -209,7 +208,7 @@ def test_drag_resize_floating_client(hlwm, x11, mouse, live_update):
 
     client, winid = x11.create_client(geometry=(50, 50, 300, 200))
     hlwm.call(f'set_attr clients.{winid}.floating true')
-    geom_before = Rectangle.from_user_str(hlwm.attr.clients[winid].content_geometry())
+    geom_before = hlwm.attr.clients[winid].content_geometry()
     assert geom_before == x11.get_absolute_geometry(client)  # duck-typing
     assert (geom_before.width, geom_before.height) == (300, 200)
     # move cursor to the top left corner, so we change the
@@ -236,9 +235,9 @@ def test_drag_resize_floating_client(hlwm, x11, mouse, live_update):
     mouse.click('1', wait=True)
     geom_after = client.get_geometry()
     assert (geom_after.width, geom_after.height) == final_size
-    assert Rectangle.from_user_str(hlwm.attr.clients[winid].content_geometry()) \
+    assert hlwm.attr.clients[winid].content_geometry() \
         == geom_before.adjusted(dx=100, dy=120, dw=-100, dh=-120)
-    assert Rectangle.from_user_str(hlwm.attr.clients[winid].floating_geometry()) \
+    assert hlwm.attr.clients[winid].floating_geometry() \
         == geom_before.adjusted(dx=100, dy=120, dw=-100, dh=-120)
 
 

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -1,4 +1,5 @@
 import pytest
+from herbstluftwm.types import Rectangle
 from Xlib import Xatom
 
 
@@ -51,7 +52,7 @@ def test_panel_object(hlwm, x11):
     assert int(hlwm.attr.panels.count()) == 1
     assert hlwm.attr.panels[winid].instance() == 'panelinst'
     assert hlwm.attr.panels[winid]['class']() == 'panelclass'
-    assert hlwm.attr.panels[winid].geometry() == '800x30+1+0'
+    assert hlwm.attr.panels[winid].geometry() == Rectangle(1, 0, 800, 30)
     assert hlwm.attr.panels[winid].winid() == winid
 
 
@@ -73,11 +74,11 @@ def test_panel_based_on_intersection(hlwm, x11, which_pad, pad_size, geometry):
 
     assert int(hlwm.attr.monitors[0][which_pad]()) == pad_size
     for p in ["pad_left", "pad_right", "pad_up", "pad_down"]:
-        assert hlwm.attr.monitors[1][p]() == '0', \
+        assert hlwm.attr.monitors[1][p]() == 0, \
             "monitor 1 must never be affected"
         if p == which_pad:
             continue
-        assert hlwm.attr.monitors[0][p]() == '0'
+        assert hlwm.attr.monitors[0][p]() == 0
 
 
 @pytest.mark.parametrize("which_pad, pad_size, geometry, wm_strut", [
@@ -111,11 +112,11 @@ def test_panel_based_on_wmstrut(hlwm, x11, which_pad, pad_size, geometry, wm_str
 
     assert int(hlwm.attr.monitors[0][which_pad]()) == pad_size
     for p in ["pad_left", "pad_right", "pad_up", "pad_down"]:
-        assert hlwm.attr.monitors[1][p]() == '0', \
+        assert hlwm.attr.monitors[1][p]() == 0, \
             "monitor 1 must never be affected"
         if p == which_pad:
             continue
-        assert hlwm.attr.monitors[0][p]() == '0'
+        assert hlwm.attr.monitors[0][p]() == 0
 
 
 def test_panel_wm_strut_partial_on_big_screen(hlwm, x11):

--- a/tests/test_python_binds.py
+++ b/tests/test_python_binds.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import os
 import conftest
+from herbstluftwm.types import Rectangle
 
 
 def test_example(hlwm):
@@ -15,7 +16,7 @@ def test_example(hlwm):
 
 
 def test_attr_get(hlwm):
-    assert hlwm.attr.tags.focus.index() == '0'
+    assert hlwm.attr.tags.focus.index() == 0
     assert str(hlwm.attr.tags.focus.index) == '0'
 
 
@@ -39,12 +40,12 @@ def test_attr_custom_attribute(hlwm):
 
 
 def test_attr_get_dict_child(hlwm):
-    assert hlwm.attr.monitors['0'].index() == '0'
-    assert hlwm.attr.monitors[0].index() == '0'
+    assert hlwm.attr.monitors['0'].index() == 0
+    assert hlwm.attr.monitors[0].index() == 0
 
 
 def test_attr_get_dict_attribute(hlwm):
-    assert hlwm.attr.monitors['0']['index']() == '0'
+    assert hlwm.attr.monitors['0']['index']() == 0
 
 
 def test_attr_set_dict_attribute(hlwm):
@@ -86,3 +87,49 @@ def test_chain_commands_if_then_else(hlwm, value):
     output = hlwm.call(cmd).stdout
 
     assert output == expected
+
+
+def test_implicit_type_conversion_bool(hlwm):
+    hlwm.attr.my_bool = True  # implicitly creates an attribute
+    assert hlwm.attr.my_bool() is True
+    hlwm.attr.my_bool = False
+    assert hlwm.attr.my_bool() is False
+    hlwm.attr.my_bool = 'toggle'
+    assert hlwm.attr.my_bool() is True
+
+
+def test_implicit_type_conversion_int(hlwm):
+    hlwm.attr.my_int = 32
+    assert hlwm.attr.my_int() == 32
+
+    hlwm.attr.my_int = '-=40'
+
+    assert hlwm.attr.my_int() == -8
+
+
+def test_implicit_type_conversion_uint(hlwm):
+    hlwm.call('new_attr uint my_uint 32')
+    assert hlwm.attr.my_uint() == 32
+
+    hlwm.attr.my_uint = '-=40'
+
+    assert hlwm.attr.my_uint() == 0
+
+
+def test_implicit_type_conversion_string(hlwm):
+    hlwm.attr.my_str = "test"
+    assert hlwm.attr.my_str() == "test"
+
+    hlwm.attr.my_str = "foo"
+    assert hlwm.attr.my_str() == "foo"
+
+
+def test_implicit_type_conversion_rectangle(hlwm):
+    # TODO: change as soon as custom attributes support Rectangle!
+    geo = Rectangle(10, 20, 400, 500)
+    hlwm.attr.monitors.focus.geometry = geo
+    assert hlwm.attr.monitors.focus.geometry() == geo
+
+    geo = Rectangle(20, 30, 422, 522)
+    hlwm.attr.monitors.focus.geometry = geo
+    assert hlwm.attr.monitors.focus.geometry() == geo

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,6 +1,5 @@
 import pytest
 import re
-from herbstluftwm.types import Rectangle
 
 
 string_props = [
@@ -967,8 +966,7 @@ def test_smart_placement_within_monitor(hlwm):
     hlwm.attr.settings.snap_gap = 5  # something smaller than bw
     winid, _ = hlwm.create_client()
 
-    inner_geometry = Rectangle.from_user_str(
-        hlwm.attr.clients[winid].content_geometry())
+    inner_geometry = hlwm.attr.clients[winid].content_geometry()
 
     # assert that the top left corner of the decoration
     # is still within the monitor

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -324,7 +324,7 @@ def test_focused_on_other_monitor_above_fullscreen(hlwm, focus_other_monitor):
 
     if focus_other_monitor:
         hlwm.call(['jumpto', win_focused])
-        assert hlwm.attr.monitors.focus.index() == '1'
+        assert hlwm.attr.monitors.focus.index() == 1
         assert hlwm.attr.clients.focus.winid() == win_focused
         assert helper_get_stack_as_list(hlwm, strip_focus_layer=False) \
             == [win_focused, win_fullscreen]

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -32,13 +32,13 @@ def test_add_tag_completion(hlwm):
 
 
 def test_add_tag_duplicate(hlwm):
-    assert hlwm.attr.tags.count() == '1'
+    assert hlwm.attr.tags.count() == 1
     hlwm.call('add foo')
-    assert hlwm.attr.tags.count() == '2'
+    assert hlwm.attr.tags.count() == 2
     hlwm.call('add bar')
-    assert hlwm.attr.tags.count() == '3'
+    assert hlwm.attr.tags.count() == 3
     hlwm.call('add foo')
-    assert hlwm.attr.tags.count() == '3'
+    assert hlwm.attr.tags.count() == 3
 
 
 def test_use_previous(hlwm):
@@ -496,8 +496,8 @@ def test_merge_tag_minimized_into_visible_tag(hlwm):
     hlwm.attr.clients[winid].minimized = hlwm.bool(True)
     hlwm.call('use target')
 
-    assert hlwm.attr.tags['by-name'].target.visible() == hlwm.bool(True)
+    assert hlwm.attr.tags['by-name'].target.visible() is True
     hlwm.call('merge_tag source')
 
-    assert hlwm.attr.clients[winid].visible() == hlwm.bool(False)
+    assert hlwm.attr.clients[winid].visible() is False
     assert winid not in hlwm.call('dump').stdout

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -84,39 +84,39 @@ def test_type_children_names(hlwm):
 def test_int_uint_relative_but_nonnegative(hlwm, int_or_uint):
     hlwm.call(['new_attr', int_or_uint, 'my_val'])
 
-    hlwm.attr.my_val = '5'
+    hlwm.attr.my_val = 5
     hlwm.attr.my_val = '+=3'
-    assert hlwm.attr.my_val() == '8'
+    assert hlwm.attr.my_val() == 8
 
     hlwm.attr.my_val = '-=4'
-    assert hlwm.attr.my_val() == '4'
+    assert hlwm.attr.my_val() == 4
 
     hlwm.attr.my_val = '-=-2'
-    assert hlwm.attr.my_val() == '6'
+    assert hlwm.attr.my_val() == 6
 
     hlwm.attr.my_val = '+=-5'
-    assert hlwm.attr.my_val() == '1'
+    assert hlwm.attr.my_val() == 1
 
     hlwm.attr.my_val = '-=+1'
-    assert hlwm.attr.my_val() == '0'
+    assert hlwm.attr.my_val() == 0
 
 
 def test_int_negative(hlwm):
     hlwm.call(['new_attr', 'int', 'my_val', '6'])
     hlwm.attr.my_val = '+=-20'
-    assert hlwm.attr.my_val() == '-14'
+    assert hlwm.attr.my_val() == -14
 
     hlwm.attr.my_val = '-=-10'
-    assert hlwm.attr.my_val() == '-4'
+    assert hlwm.attr.my_val() == -4
 
 
 def test_uint_negative(hlwm):
     hlwm.call(['new_attr', 'uint', 'my_val', '19'])
     hlwm.attr.my_val = '+=-20'
-    assert hlwm.attr.my_val() == '0'
+    assert hlwm.attr.my_val() == 0
 
     hlwm.attr.my_val = '-=-10'
-    assert hlwm.attr.my_val() == '10'
+    assert hlwm.attr.my_val() == 10
 
 
 def test_attr_type_for_many_types(hlwm):

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -1,11 +1,11 @@
 
 
 def test_watchers_count(hlwm):
-    assert hlwm.attr.watchers.count() == '0'
+    assert hlwm.attr.watchers.count() == 0
     hlwm.call('watch clients.focus.title')
-    assert hlwm.attr.watchers.count() == '1'
+    assert hlwm.attr.watchers.count() == 1
     hlwm.call('watch clients.focus.title')
-    assert hlwm.attr.watchers.count() == '1'
+    assert hlwm.attr.watchers.count() == 1
 
 
 def test_watchers_basic_change1(hlwm, hc_idle):


### PR DESCRIPTION
In the python bindings, automatically convert the attribute values from
(resp. to) their corresponding python types when writing (resp. reading)
attributes.

This requires touching (but fortunately simplifying) a lot of assertions
in the test cases. Now, working with the contents of hlwm.attr should
feel as if one had the hlwm attributes available as python variables.

A few new test cases at the end of test_python_binds.py illustrate the
usage for all types that are available at the moment.