### PR TITLE
Support error output channel internally

### DIFF
--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -4,6 +4,7 @@
 
 #include "completion.h"
 
+using std::endl;
 using std::function;
 using std::pair;
 using std::string;
@@ -31,17 +32,18 @@ bool ArgParse::parsingFails(Input& input, Output& output)
     }
     optionalArguments += flags_.size();
     if (input.size() < mandatoryArguments) {
-        output << input.command() << ": Expected ";
+        output.error() << output.command() << ": Expected ";
         if (optionalArguments) {
-            output << "between " << mandatoryArguments
+            output.error()
+                   << "between " << mandatoryArguments
                    << " and " << (optionalArguments + mandatoryArguments)
                    << " arguments";
         } else if (mandatoryArguments == 1) {
-            output  << "one argument";
+            output.error() << "one argument";
         } else {
-            output  << mandatoryArguments << " arguments";
+            output.error() << mandatoryArguments << " arguments";
         }
-        output << ", but got only " << input.size() << " arguments.";
+        output.error() << ", but got only " << input.size() << " arguments." << endl;
         errorCode_ = HERBST_NEED_MORE_ARGS;
         return true;
     }
@@ -64,7 +66,7 @@ bool ArgParse::parsingFails(Input& input, Output& output)
             }  catch (std::exception& e) {
                 // if there is a parse error however, then
                 // stop entire parsing process
-                output << input.command() << ": Cannot parse flag \""
+                output.perror() << "Cannot parse flag \""
                        << valueString << "\": " << e.what() << "\n";
                 errorCode_ = HERBST_INVALID_ARGUMENT;
                 return true;
@@ -90,7 +92,7 @@ bool ArgParse::parsingFails(Input& input, Output& output)
         try {
             arg.tryParse_(valueString);
         }  catch (std::exception& e) {
-            output << input.command() << ": Cannot parse argument \""
+            output.perror() << "Cannot parse argument \""
                    << valueString << "\": " << e.what() << "\n";
             errorCode_ = HERBST_INVALID_ARGUMENT;
             return true;
@@ -106,7 +108,7 @@ bool ArgParse::parsingFails(Input& input, Output& output)
                 break;
             }
         }  catch (std::exception& e) {
-            output << input.command() << ": Cannot parse flag \""
+            output.perror() << "Cannot parse flag \""
                    << input.front() << "\": " << e.what() << "\n";
             errorCode_ = HERBST_INVALID_ARGUMENT;
             return true;
@@ -135,8 +137,8 @@ bool ArgParse::unparsedTokens(Input& input, Output& output)
 {
     string extraToken;
     if (input >> extraToken) {
-        output << input.command()
-           << ": Unknown argument or flag \""
+        output.perror()
+           << "Unknown argument or flag \""
            << extraToken << "\" given.\n";
         errorCode_ = HERBST_INVALID_ARGUMENT;
         return true;

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -191,7 +191,8 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
     if (additionalRules) {
         additionalRules(changes);
     }
-    changes = Root::get()->rules()->evaluateRules(client, std::cerr, changes);
+    auto stdio = OutputChannels::stdio();
+    changes = Root::get()->rules()->evaluateRules(client, stdio, changes);
     if (!changes.manage || force_unmanage) {
         // map it... just to be sure
         XMapWindow(X_->display(), win);
@@ -557,7 +558,7 @@ int ClientManager::clientSetAttribute(string attribute,
         }
         string error_message = a->change(value);
         if (!error_message.empty()) {
-            output << input.command() << ": illegal argument \""
+            output.perror() << "illegal argument \""
                    << value << "\": "
                    << error_message << endl;
             return HERBST_INVALID_ARGUMENT;

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -89,8 +89,9 @@ int CommandTable::callCommand(Input args, Output out) const {
         out << "error: Command \"" << args.command() << "\" not found" << endl;
         return HERBST_COMMAND_NOT_FOUND;
     }
-
-    return cmd->second(args, out);
+    // new channels object to have the command name updated
+    OutputChannels channels(args.command(), out.output(), out.error());
+    return cmd->second(args, channels);
 }
 
 namespace Commands {

--- a/src/command.h
+++ b/src/command.h
@@ -88,7 +88,6 @@ public:
             std::pair<Input, Output> io = {input, output};
             int exitCode = 0;
             CallOrComplete invoc;
-            invoc.command_ = input.command();
             invoc.inputOutput_ = &io;
             invoc.exitCode_ = &exitCode;
             callOrCompl(invoc);

--- a/src/commandio.cpp
+++ b/src/commandio.cpp
@@ -1,9 +1,9 @@
 #include "commandio.h"
 
+#include <iostream>
+
 #include "completion.h"
 #include "globals.h"
-
-#include <iostream>
 
 using std::string;
 using std::endl;

--- a/src/commandio.cpp
+++ b/src/commandio.cpp
@@ -1,8 +1,12 @@
 #include "commandio.h"
 
 #include "completion.h"
+#include "globals.h"
+
+#include <iostream>
 
 using std::string;
+using std::endl;
 
 Input &Input::operator>>(string &val)
 {
@@ -31,4 +35,13 @@ void Input::replace(const string &from, const string &to)
             *command_ = to;
         }
     }
+}
+
+OutputChannels OutputChannels::stdio() {
+    return OutputChannels(WINDOW_MANAGER_NAME, std::cout, std::cerr);
+}
+
+std::ostream& OutputChannels::perror()
+{
+    return error_ << commandName_ << ": ";
 }

--- a/src/commandio.h
+++ b/src/commandio.h
@@ -119,7 +119,6 @@ protected:
  */
 class CallOrComplete {
 public:
-    //! the name of the command that is called.
     static CallOrComplete complete(Completion& complete) {
         CallOrComplete invoc;
         invoc.complete_ = &complete;

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -672,7 +672,7 @@ int FrameTree::loadCommand(Input input, Output output) {
         input >> tagName >> layoutString;
         tag = find_tag(tagName.c_str());
         if (!tag) {
-            output << input.command() << ": Tag \"" << tagName << "\" not found\n";
+            output.perror() << "Tag \"" << tagName << "\" not found\n";
             return HERBST_INVALID_ARGUMENT;
         }
     } else if (input.size() == 1) {
@@ -684,7 +684,7 @@ int FrameTree::loadCommand(Input input, Output output) {
     assert(tag != nullptr);
     FrameParser parsingResult(layoutString);
     if (parsingResult.error_) {
-        output << input.command() << ": Syntax error at "
+        output.perror() << "Syntax error at "
                << parsingResult.error_->first.first << ": "
                << parsingResult.error_->second << ":"
                << endl;
@@ -810,7 +810,7 @@ int FrameTree::cycleLayoutCommand(Input input, Output output) {
         try {
             delta = Converter<int>::parse(deltaStr);
         } catch (const std::exception& e) {
-            output << input.command() << ": " << e.what();
+            output.perror() << e.what() << endl;
             return HERBST_INVALID_ARGUMENT;
         }
     }
@@ -829,7 +829,7 @@ int FrameTree::cycleLayoutCommand(Input input, Output output) {
         try {
             layout_index = (int)Converter<LayoutAlgorithm>::parse(*(input.begin() + idx));
         } catch (const std::exception& e) {
-            output << input.command() << ": " << e.what();
+            output.perror() << e.what() << endl;
             return HERBST_INVALID_ARGUMENT;
         }
     } else {
@@ -1039,7 +1039,7 @@ int FrameTree::dumpLayoutCommand(Input input, Output output) {
         if (!tagName.empty()) {
             HSTag* tag = find_tag(tagName.c_str());
             if (!tag) {
-                output << input.command() << ": Tag \"" << tagName << "\" not found\n";
+                output.perror() << "Tag \"" << tagName << "\" not found\n";
                 return HERBST_INVALID_ARGUMENT;
             }
             tree = tag->frame();

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -120,11 +120,11 @@ void GlobalCommands::useTagCommand(CallOrComplete invoc)
         Monitor* monitor = root_.monitors->focus();
         int ret = monitor_set_tag(monitor, tag);
         if (ret != 0) {
-            output << invoc.command() << ": Could not change tag";
+            output.perror() << "Could not change tag";
             if (monitor->lock_tag) {
-                output << " (monitor " << monitor->index() << " is locked)";
+                output.error() << " (monitor " << monitor->index() << " is locked)";
             }
-            output << "\n";
+            output.error() << "\n";
         }
         return ret;
     });
@@ -141,18 +141,18 @@ void GlobalCommands::useTagByIndexCommand(CallOrComplete invoc)
                      [&] (Output output) -> int {
         HSTag* tag = root_.tags->byIndexStr(indexStr, skipVisible);
         if (!tag) {
-            output << invoc.command() <<
-                ": Invalid index \"" << indexStr << "\"\n";
+            output.perror() <<
+                "Invalid index \"" << indexStr << "\"\n";
             return HERBST_INVALID_ARGUMENT;
         }
         Monitor* monitor = root_.monitors->focus();
         int ret = monitor_set_tag(monitor, tag);
         if (ret != 0) {
-            output << invoc.command() << ": Could not change tag";
+            output.perror() << "Could not change tag";
             if (monitor->lock_tag) {
-                output << " (monitor " << monitor->index() << " is locked)";
+                output.error() << " (monitor " << monitor->index() << " is locked)";
             }
-            output << "\n";
+            output.error() << "\n";
         }
         return ret;
     });
@@ -177,8 +177,8 @@ int GlobalCommands::cycleValueCommand(Input input, Output output)
     }
     auto msg = attr->cycleValue(input.begin(), input.end());
     if (!msg.empty()) {
-        output << input.command()
-               << ": Invalid value for \""
+        output.perror()
+               << "Invalid value for \""
                << attr_path << "\": "
                << msg << endl;
         return HERBST_INVALID_ARGUMENT;

--- a/src/hlwmcommon.cpp
+++ b/src/hlwmcommon.cpp
@@ -3,7 +3,6 @@
 #include <sstream>
 
 #include "clientmanager.h"
-#include "command.h"
 #include "root.h"
 
 using std::make_pair;
@@ -22,17 +21,5 @@ Client* HlwmCommon::client(Window window) {
 
 const std::unordered_map<Window, Client*>& HlwmCommon::clients() {
     return root_->clients->clients();
-}
-
-//! wrapper around Commands::call()
-pair<int,string> HlwmCommon::callCommand(const vector<string>& call) {
-    // the call consists of the command and its arguments
-    std::ostringstream output;
-    auto input =
-        (call.empty())
-        ? Input("", call)
-        : Input(call[0], vector<string>(call.begin() + 1, call.end()));
-    int status = Commands::call(input, output);
-    return make_pair(status, output.str());
 }
 

--- a/src/hlwmcommon.h
+++ b/src/hlwmcommon.h
@@ -17,7 +17,6 @@ public:
     //! The Client object for a window or nullptr if unmanaged.
     Client* client(Window window);
     const std::unordered_map<Window, Client*>& clients();
-    static std::pair<int,std::string> callCommand(const std::vector<std::string>& call);
 private:
     Root* root_;
 };

--- a/src/ipc-server.cpp
+++ b/src/ipc-server.cpp
@@ -63,8 +63,17 @@ bool IpcServer::handleConnection(Window win, CallHandler callback) {
     }
     auto result = callback(arguments);
     // send output back
-    int status = result.first;
-    const string& output = result.second;
+    int status = result.exitCode;
+    string output;
+    // concatenate 'normal' and error output
+    if (!result.error.empty()) {
+        output = result.error;
+        // ensure that the error output ends with a newline
+        if (*result.error.rbegin() != '\n') {
+            output += "\n";
+        }
+    }
+    output += result.output;
     // Mark this command as executed
     XDeleteProperty(X.display(), win, X.atom(HERBST_IPC_ARGS_ATOM));
     X.setPropertyString(win, X.atom(HERBST_IPC_OUTPUT_ATOM), output);

--- a/src/ipc-server.h
+++ b/src/ipc-server.h
@@ -13,7 +13,7 @@ class IpcServer {
 public:
     class CallResult {
     public:
-        int exitCode;
+        int exitCode = 0;
         std::string output;
         std::string error;
     };

--- a/src/ipc-server.h
+++ b/src/ipc-server.h
@@ -11,10 +11,16 @@ class XConnection;
 
 class IpcServer {
 public:
+    class CallResult {
+    public:
+        int exitCode;
+        std::string output;
+        std::string error;
+    };
     //! a callback that handles a call, represented by a vector of strings. The
     // callback can produce some output and return a status code.
     // This is the counterpart of hc_send_command() in ipc-client/ipc-client.h
-    using CallHandler = std::function<std::pair<int,std::string>(const std::vector<std::string>&)>;
+    using CallHandler = std::function<CallResult(const std::vector<std::string>&)>;
     IpcServer(XConnection& xconnection);
     ~IpcServer();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -384,8 +384,11 @@ static void parse_arguments(int argc, char** argv, Globals& g) {
                 /* ignore recognized long option */
                 break;
             case 'v':
-                version(std::cout);
-                exit(0);
+                {
+                    auto stdio = OutputChannels::stdio();
+                    version(stdio);
+                    exit(0);
+                }
             case 'c':
                 g_autostart_path = optarg;
                 break;

--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -803,7 +803,7 @@ int MetaCommands::silentCommand(Input input, Output output) {
     stringstream dummyOutput;
     // discard output and error channel
     // TODO: pass through the error channel as soon as
-    // the ipc-protocoll supports it.
+    // the ipc-protocol supports it.
     OutputChannels discardOutputChannels(output.command(), dummyOutput, dummyOutput);
     // drop output but pass exit code
     return Commands::call(input.fromHere(), discardOutputChannels);

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -300,7 +300,7 @@ int Monitor::move_cmd(Input input, Output output) {
     }
     auto new_rect = Rectangle::fromStr(input.front());
     if (new_rect.width < WINDOW_MIN_WIDTH || new_rect.height < WINDOW_MIN_HEIGHT) {
-        output << input.command() << ": Rectangle is too small\n";
+        output.perror() << "Rectangle is too small\n";
         return HERBST_INVALID_ARGUMENT;
     }
     // else: just move it:
@@ -347,7 +347,7 @@ int Monitor::renameCommand(Input input, Output output) {
     }
     string error = name.change(new_name);
     if (!error.empty()) {
-        output << input.command() << ": " << error << "\n";
+        output.perror() << error << endl;
         return HERBST_INVALID_ARGUMENT;
     } else {
         return 0;

--- a/src/monitormanager.cpp
+++ b/src/monitormanager.cpp
@@ -221,8 +221,8 @@ function<int(Input, Output)> MonitorManager::byFirstArg(MonitorCommand cmd)
         } else {
             monitor = byString(monitor_name);
             if (!monitor) {
-                output << input.command() <<
-                    ": Monitor \"" << monitor_name << "\" not found!\n";
+                output.perror() <<
+                    "Monitor \"" << monitor_name << "\" not found!\n";
                 return HERBST_INVALID_ARGUMENT;
             }
         }
@@ -331,7 +331,7 @@ void MonitorManager::removeMonitorCommand(CallOrComplete invoc)
     ArgParse().mandatory(monitor).command(invoc,
         [&] (Output output) {
             if (size() <= 1) {
-                output << invoc.command() << ": Can't remove the last monitor\n";
+                output.perror() << "Can't remove the last monitor\n";
                 return HERBST_FORBIDDEN;
             }
             this->removeMonitor(monitor);
@@ -385,12 +385,12 @@ void MonitorManager::addMonitorCommand(CallOrComplete invoc)
             tag = tags_->unusedTag();
         }
         if (!tag) {
-            output << invoc.command() << ": There are not enough free tags\n";
+            output.perror() << "There are not enough free tags\n";
             return HERBST_TAG_IN_USE;
         }
         if (find_monitor_with_tag(tag)) {
-            output << invoc.command() <<
-                ": Tag \"" << tag->name() << "\" is already being viewed on a monitor\n";
+            output.perror() <<
+                "Tag \"" << tag->name() << "\" is already being viewed on a monitor\n";
             return HERBST_TAG_IN_USE;
         }
         string error = Monitor::atLeastMinWindowSize(geo);
@@ -402,7 +402,7 @@ void MonitorManager::addMonitorCommand(CallOrComplete invoc)
             }
         }
         if (!error.empty()) {
-            output << invoc.command() << ": " << error << "\n";
+            output.perror() << error << "\n";
             return HERBST_INVALID_ARGUMENT;
         }
         auto monitor = addMonitor(geo, tag);
@@ -622,8 +622,8 @@ int MonitorManager::setMonitorsCommand(Input input, Output output) {
         Rectangle rect = Rectangle::fromStr(rectangleString);
         if (rect.width == 0 || rect.height == 0)
         {
-            output << input.command()
-                   << ": Rectangle invalid or too small: "
+            output.perror()
+                   << "Rectangle invalid or too small: "
                    << rectangleString << endl;
             return HERBST_INVALID_ARGUMENT;
         }
@@ -635,7 +635,7 @@ int MonitorManager::setMonitorsCommand(Input input, Output output) {
     int status = setMonitors(templates);
 
     if (status == HERBST_TAG_IN_USE) {
-        output << input.command() << ": There are not enough free tags\n";
+        output.perror() << "There are not enough free tags\n";
     } else if (status == HERBST_INVALID_ARGUMENT) {
         return HERBST_NEED_MORE_ARGS;
     }
@@ -720,7 +720,7 @@ int MonitorManager::detectMonitorsCommand(Input input, Output output)
         } else if (arg == "--no-disjoin") {
             disjoin = false;
         } else {
-            output << input.command() << ": unknown flag \"" << arg << "\"\n";
+            output.perror() << "unknown flag \"" << arg << "\"\n";
             return HERBST_INVALID_ARGUMENT;
         }
     }
@@ -769,7 +769,7 @@ int MonitorManager::detectMonitorsCommand(Input input, Output output)
         // apply it
         int ret = g_monitors->setMonitors(monitor_rects);
         if (ret == HERBST_TAG_IN_USE) {
-            output << input.command() << ": There are not enough free tags\n";
+            output.perror() << "There are not enough free tags" << endl;
         }
         return ret;
     }
@@ -883,7 +883,7 @@ int MonitorManager::raiseMonitorCommand(Input input, Output output) {
     input >> monitorName;
     Monitor* monitor = string_to_monitor(monitorName.c_str());
     if (!monitor) {
-        output << input.command() << ": Monitor \"" << monitorName << "\" not found!\n";
+        output.perror() << "Monitor \"" << monitorName << "\" not found!\n";
         return HERBST_INVALID_ARGUMENT;
     }
     monitorStack_.raise(monitor);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -126,7 +126,8 @@ Object* Object::child(const string &name) {
 
 Object* Object::child(Path path) {
     std::ostringstream out;
-    return child(path, out);
+    OutputChannels channels("", out, out);
+    return child(path, channels);
 }
 
 Object* Object::child(Path path, Output output) {
@@ -262,7 +263,8 @@ void Object::printTree(Output output, string rootLabel) {
 
 Attribute* Object::deepAttribute(const string &path) {
     std::ostringstream output;
-    return deepAttribute(path, output);
+    OutputChannels channels("", output, output);
+    return deepAttribute(path, channels);
 }
 
 Attribute* Object::deepAttribute(const string &path, Output output) {

--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -61,7 +61,7 @@ int RuleManager::parseRule(Input input, Output output, Rule& rule, bool& prepend
         try {
             std::tie(lhs, oper, rhs) = tokenizeArg(arg);
         } catch (std::invalid_argument &error) {
-            output << input.command() << ": " << error.what() << endl;
+            output.perror() << error.what() << endl;
             return HERBST_INVALID_ARGUMENT;
         }
 
@@ -77,7 +77,7 @@ int RuleManager::parseRule(Input input, Output output, Rule& rule, bool& prepend
         // Check if lhs is a consequence name
         if (Consequence::appliers.count(lhs)) {
             if (oper == '~') {
-                output << input.command() << ": Operator ~ not valid for consequence \"" << lhs << "\"\n";
+                output.perror() << "Operator ~ not valid for consequence \"" << lhs << "\"\n";
                 return HERBST_INVALID_ARGUMENT;
             }
 
@@ -98,7 +98,7 @@ int RuleManager::parseRule(Input input, Output output, Rule& rule, bool& prepend
             continue;
         }
 
-        output << input.command() << ": Unknown argument \"" << arg << "\"\n";
+        output.perror() << "Unknown argument \"" << arg << "\"\n";
         return HERBST_INVALID_ARGUMENT;
     }
 

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -179,7 +179,8 @@ bool Rule::evaluate(Client* client, ClientChanges& changes, Output output)
             try {
                 Consequence::appliers.at(cons.name)(&cons, client, &changes);
             } catch (std::exception& e) {
-                output << "Invalid argument \"" << cons.value
+                output.error()
+                       << "Invalid argument \"" << cons.value
                        << "\" for rule consequence \"" << cons.name << "\": "
                        << e.what() << "\n";
             }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -206,14 +206,13 @@ int Settings::set_cmd(Input input, Output output) {
 
     auto attr = attribute(set_name);
     if (!attr) {
-        output << input.command() <<
-            ": Setting \"" << set_name << "\" not found\n";
+        output.perror() << "Setting \"" << set_name << "\" not found\n";
         return HERBST_SETTING_NOT_FOUND;
     }
     auto msg = attr->change(value);
     if (!msg.empty()) {
-        output << input.command()
-               << ": Invalid value \"" << value
+        output.perror()
+               << "Invalid value \"" << value
                << "\" for setting \"" << set_name << "\": "
                << msg << endl;
         return HERBST_INVALID_ARGUMENT;
@@ -243,15 +242,14 @@ int Settings::toggle_cmd(Input argv, Output output) {
     auto set_name = argv.front();
     auto attr = attribute(set_name);
     if (!attr) {
-        output << argv.command() <<
-            ": Setting \"" << set_name << "\" not found\n";
+        output.perror() << "Setting \"" << set_name << "\" not found\n";
         return HERBST_SETTING_NOT_FOUND;
     }
     if (attr->type() == Type::BOOL) {
         attr->change("toggle");
     } else {
-        output << argv.command()
-            << ": Setting \"" << set_name
+        output.perror()
+            << "Setting \"" << set_name
             << "\" is not of type bool\n";
         return HERBST_INVALID_ARGUMENT;
     }
@@ -276,8 +274,7 @@ int Settings::get_cmd(Input argv, Output output) {
     }
     auto attr = attribute(argv.front());
     if (!attr) {
-        output << argv.command() <<
-            ": Setting \"" << argv.front() << "\" not found\n";
+        output.perror() << "Setting \"" << argv.front() << "\" not found\n";
         return HERBST_SETTING_NOT_FOUND;
     }
     output << attr->str();

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -494,7 +494,7 @@ int HSTag::resizeCommand(Input input, Output output)
         }
     } else {
         if (!frame->resizeFrame(delta, direction)) {
-            output << input.command() << ": No neighbour found\n";
+            output.perror() << "No neighbour found\n";
             return HERBST_FORBIDDEN;
         }
     }

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -122,7 +122,7 @@ void TagManager::addCommand(CallOrComplete invoc)
             .command(invoc, [&](Output output) {
         if (tagName.empty()) {
             string error = "An empty tag name is not permitted";
-            output << invoc.command() << ": " << error << "\n";
+            output.perror() << error << "\n";
             return HERBST_INVALID_ARGUMENT;
         }
         HSTag* tag = add_tag(tagName);
@@ -139,7 +139,7 @@ void TagManager::mergeTagCommand(CallOrComplete invoc) {
             .command(invoc,
                      [&] (Output output) {
         if (!mergeTag(tagToRemove, targetTag)) {
-            output << invoc.command() << ": Cannot merge the currently viewed tag\n";
+            output.perror() << "Cannot merge the currently viewed tag\n";
             return HERBST_TAG_IN_USE;
         }
         return HERBST_EXIT_SUCCESS;
@@ -195,7 +195,7 @@ void TagManager::tag_rename_command(CallOrComplete invoc) {
                      [&] (Output output) {
         auto error = tag->name.change(new_name);
         if (!error.empty()) {
-            output << invoc.command() << ": " << error << "\n";
+            output.perror() << error << "\n";
             return HERBST_INVALID_ARGUMENT;
         }
         return HERBST_EXIT_SUCCESS;
@@ -320,7 +320,7 @@ void TagManager::tag_move_window_by_index_command(CallOrComplete invoc) {
                      [&] (Output output) {
         HSTag* tag = byIndexStr(tagIndex, skip_visible);
         if (!tag) {
-            output << invoc.command() << ": Invalid index \"" << tagIndex << "\"\n";
+            output.perror() << "Invalid index \"" << tagIndex << "\"\n";
             return HERBST_INVALID_ARGUMENT;
         }
         moveFocusedClient(tag);
@@ -389,7 +389,7 @@ int TagManager::floatingCmd(Input input, Output output) {
     if (!tagName.empty()) {
         tag = find(tagName);
         if (!tag) {
-            output << input.command() << ": Tag \"" << tagName << "\" not found\n";
+            output.perror() << "Tag \"" << tagName << "\" not found\n";
             return HERBST_INVALID_ARGUMENT;
         }
     }

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -587,7 +587,7 @@ IpcServer::CallResult XMainLoop::callCommand(const vector<string>& call)
     // the call consists of the command and its arguments
     std::ostringstream output;
     std::ostringstream error;
-    std::string commandName = (call.empty()) ? "" : call[0];
+    string commandName = (call.empty()) ? "" : call[0];
     auto input =
         (call.empty())
         ? Input("", call)

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -3,6 +3,7 @@
 #include <X11/X.h>
 #include <X11/Xlib.h>
 
+#include "ipc-server.h"
 #include "x11-types.h"
 
 class Client;
@@ -46,6 +47,8 @@ private:
     void unmapnotify(XUnmapEvent* event);
 
     bool duringEnterNotify_ = false; //! whether we are in enternotify()
+
+    static IpcServer::CallResult callCommand(const std::vector<std::string>& call);
 
 
     // handlers of events from hlwm

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -608,7 +608,7 @@ def test_foreach_tag_merge(hlwm):
         'tags.by-name.othertag'
     ]
     proc = hlwm.call('foreach T tags.by-name chain , merge_tag othertag , echo T')
-    assert proc.stdout.splitlines() == expected
+    assert sorted(proc.stdout.splitlines()) == sorted(expected)
 
 
 def test_foreach_exit_code_success(hlwm):


### PR DESCRIPTION
In the command system, the 'Output' parameter now also carries an error
channel and the command name (in addition to the standard output
channel). This is accomplished with a new class OutputChannels in
commandio.h (and Output = OutputChannels&).

So far, this only affects the command system, but not the IPC interface,
which thus simply concatenates the two output channels in the reply to
'herbstclient'.

Thus, we can now print error messages to this dedicated channel and have
the error message prefixed with the command name automatically. Most of
the diff consists of migrating the error message printing to the new
perror(), which does the prefixing.

As a bonus, CallOrComplete does not need the command name anymore.

Also, HlwmCommon::callCommand() was only used in XMainLoop, so I have
used it there.