### PR TITLE
Remove alpha-value from colors in panel.sh

### DIFF
--- a/share/panel.sh
+++ b/share/panel.sh
@@ -19,8 +19,9 @@ y=${geometry[1]}
 panel_width=${geometry[2]}
 panel_height=16
 font="-*-fixed-medium-*-*-*-12-*-*-*-*-*-*-*"
-bgcolor=$(hc get frame_border_normal_color)
-selbg=$(hc get window_border_active_color)
+# extract colors from hlwm and omit alpha-value
+bgcolor=$(hc get frame_border_normal_color|sed 's,^\(\#[0-9a-f]\{6\}\)[0-9a-f]\{2\}$,\1,')
+selbg=$(hc get window_border_active_color|sed 's,^\(\#[0-9a-f]\{6\}\)[0-9a-f]\{2\}$,\1,')
 selfg='#101010'
 
 ####


### PR DESCRIPTION
In panel.sh, we extract the current colors from the hlwm settings.
However, the latter possibly have alpha-values (some even have in the
default autostart). So, we need to remove these alpha-values, turning the
rgba-format into rgb.

This fixes #1282