### PR TITLE
Extend IPC protocol by error channel

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -11,6 +11,11 @@ The command 'cycle_value' now expects an attribute path instead of a settings
 name. For compatibility reasons, passing settings name directly (without the
 prefix +settings.+) is still supported.
 
+In ipc commands, herbstclient prints error messages always on stderr and normal
+output always on stdout. Before, both were printed to the same channel,
+either to stdout or stderr depending on the command's exit status. This
+mainly affects combined commands.
+
 Only for people using the git-version: During the development of 0.9.3, the
 'content_geometry' attribute of clients initially had the name
 'geometry_reported'.

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ older versions.
 Current git version
 -------------------
 
+  * herbstclient prints error messages always on stderr and normal output
+    always on stdout (before, both were printed to the same channel).
   * True transparency support for frame and client decorations (requires a
     compositor like picom, compton, or xcompmgr)
   * Colors contain alpha-values (format #RRGGBBAA)

--- a/ipc-client/ipc-client.c
+++ b/ipc-client/ipc-client.c
@@ -20,12 +20,19 @@ struct HCConnection {
     Display*    display;
     bool        own_display; // if we have to close it on disconnect
     Window      hook_window;
+    //! if we already listen for events on the hook window
+    bool        hook_window_listen;
+    //! if the server sets an error channel
+    bool        server_has_error_channel;
     Window      client_window;
     Atom        atom_args;
     Atom        atom_output;
+    Atom        atom_error;
     Atom        atom_status;
     Window      root;
 };
+
+static Window get_hook_window(Display* display);
 
 HCConnection* hc_connect() {
     Display* display = XOpenDisplay(NULL);
@@ -49,7 +56,25 @@ HCConnection* hc_connect_to_display(Display* display) {
     con->root = DefaultRootWindow(con->display);
     con->atom_args = XInternAtom(con->display, HERBST_IPC_ARGS_ATOM, False);
     con->atom_output = XInternAtom(con->display, HERBST_IPC_OUTPUT_ATOM, False);
+    con->atom_error = XInternAtom(con->display, HERBST_IPC_ERROR_ATOM, False);
     con->atom_status = XInternAtom(con->display, HERBST_IPC_STATUS_ATOM, False);
+
+    con->hook_window = get_hook_window(con->display);
+    // check whether the server supports the error channel
+    if (con->hook_window) {
+        long* value;
+        Atom type;
+        int format;
+        unsigned long items, bytes;
+        int status = XGetWindowProperty(con->display, con->hook_window,
+                                        XInternAtom(con->display, HERBST_IPC_HAS_ERROR, False),
+                                        0, 1, False, XA_CARDINAL, &type, &format, &items,
+                                        &bytes, (unsigned char**)&value);
+        con->server_has_error_channel = items > 0;
+        if (status == Success) {
+            XFree(value);
+        }
+    }
     return con;
 }
 
@@ -90,7 +115,7 @@ bool hc_create_client_window(HCConnection* con) {
 }
 
 bool hc_send_command(HCConnection* con, int argc, char* argv[],
-                     char** ret_out, int* ret_status) {
+                     char** ret_out, char** ret_err, int* ret_status) {
     if (!hc_create_client_window(con)) {
         return false;
     }
@@ -104,8 +129,17 @@ bool hc_send_command(HCConnection* con, int argc, char* argv[],
     int command_status = 0;
     XEvent event;
     char* output = NULL;
-    bool output_received = false, status_received = false;
-    while (!output_received || !status_received) {
+    char* error = NULL;
+    bool output_received = false;
+    bool error_received = false;
+    bool status_received = false;
+    if (!con->server_has_error_channel) {
+        // if the server does not support the error channel,
+        // then just simulate an empty error channel
+        error = strdup("");
+        error_received = true;
+    }
+    while (!output_received || !error_received || !status_received) {
         XNextEvent(con->display, &event);
         if (event.type != PropertyNotify) {
             // got an event of wrong type
@@ -121,11 +155,24 @@ bool hc_send_command(HCConnection* con, int argc, char* argv[],
             output = read_window_property(con->display, con->client_window,
                                           con->atom_output);
             if (!output) {
-                fprintf(stderr, "could not get WindowProperty \"%s\"\n",
+                fprintf(stderr, "could not get window property \"%s\"\n",
                                 HERBST_IPC_OUTPUT_ATOM);
+                // if we have received the error channel earlier:
+                free(error);
                 return false;
             }
             output_received = true;
+        } else if (!error_received && pe->atom == con->atom_error) {
+            error = read_window_property(con->display, con->client_window,
+                                          con->atom_error);
+            if (!error) {
+                fprintf(stderr, "could not get window property \"%s\"\n",
+                                HERBST_IPC_ERROR_ATOM);
+                // if we have received the output channel earlier:
+                free(output);
+                return false;
+            }
+            error_received = true;
         }
         else if (!status_received && pe->atom == con->atom_status) {
             long* value;
@@ -139,6 +186,8 @@ bool hc_send_command(HCConnection* con, int argc, char* argv[],
                     // if could not get window property
                 fprintf(stderr, "could not get WindowProperty \"%s\"\n",
                                 HERBST_IPC_STATUS_ATOM);
+                free(output);
+                free(error);
                 return false;
             }
             command_status = *value;
@@ -148,6 +197,7 @@ bool hc_send_command(HCConnection* con, int argc, char* argv[],
     }
     *ret_status = command_status;
     *ret_out = output;
+    *ret_err = error;
     return true;
 }
 
@@ -192,19 +242,23 @@ static Window get_hook_window(Display* display) {
 }
 
 bool hc_check_running(HCConnection* con) {
-    return get_hook_window(con->display) != 0;
+    return con->hook_window;
 }
 
 bool hc_hook_window_connect(HCConnection* con) {
-    if (con->hook_window) {
+    if (con->hook_window_listen) {
         return true;
     }
-    con->hook_window = get_hook_window(con->display);
     if (!con->hook_window) {
-        return false;
+        con->hook_window = get_hook_window(con->display);
+        if (!con->hook_window) {
+            return false;
+        }
     }
+    // connect to events on the window
     long mask = StructureNotifyMask|PropertyChangeMask;
     XSelectInput(con->display, con->hook_window, mask);
+    con->hook_window_listen = true;
     return true;
 }
 

--- a/ipc-client/ipc-client.c
+++ b/ipc-client/ipc-client.c
@@ -184,7 +184,7 @@ bool hc_send_command(HCConnection* con, int argc, char* argv[],
                     XA_ATOM, &type, &format, &items, &bytes, (unsigned char**)&value)
                 || format != 32) {
                     // if could not get window property
-                fprintf(stderr, "could not get WindowProperty \"%s\"\n",
+                fprintf(stderr, "could not get window property \"%s\"\n",
                                 HERBST_IPC_STATUS_ATOM);
                 free(output);
                 free(error);

--- a/ipc-client/ipc-client.h
+++ b/ipc-client/ipc-client.h
@@ -32,7 +32,7 @@ bool hc_create_client_window(HCConnection* con);
  * @param the returned error channel (needs to be free'd by the caller on success)
  * @param the returned exit status
  * @return whether the reply was received successfully.
- * if false is returned, then none of the ret_⎄-pointers is set.
+ * if false is returned, then none of the ret_...-pointers is set.
  */
 bool hc_send_command(HCConnection* con, int argc, char* argv[],
                      char** ret_out, char** ret_err, int* ret_status);

--- a/ipc-client/ipc-client.h
+++ b/ipc-client/ipc-client.h
@@ -23,8 +23,19 @@ void hc_disconnect(HCConnection* con);
 /* ensure there is a client window for sending commands */
 bool hc_create_client_window(HCConnection* con);
 
+/**
+ * @brief send a command and wait for its reply to arrive
+ * @param the connection to hlwm
+ * @param number of arguments of the ipc call
+ * @param the arguments of the ipc call
+ * @param the returned output channel (needs to be free'd by the caller on success)
+ * @param the returned error channel (needs to be free'd by the caller on success)
+ * @param the returned exit status
+ * @return whether the reply was received successfully.
+ * if false is returned, then none of the ret_⎄-pointers is set.
+ */
 bool hc_send_command(HCConnection* con, int argc, char* argv[],
-                     char** ret_out, int* ret_status);
+                     char** ret_out, char** ret_err, int* ret_status);
 
 bool hc_hook_window_connect(HCConnection* con);
 bool hc_next_hook(HCConnection* con, int* argc, char** argv[]);

--- a/python/herbstluftwm/__init__.py
+++ b/python/herbstluftwm/__init__.py
@@ -59,12 +59,20 @@ class Herbstluftwm:
 
         return proc
 
-    def call(self, cmd):
+    def call(self, cmd, allowed_stderr=None):
         """call the command and expect it to have exit code zero
-        and no output on stderr"""
+        and no output on stderr.
+        if allowed_stderr is set, then it should be a regex object
+        (something with .match) that matches every line the command
+        writes to stderr.
+        """
         proc = self.unchecked_call(cmd)
         assert proc.returncode == 0
-        assert not proc.stderr
+        if allowed_stderr is None:
+            assert not proc.stderr
+        else:
+            for line in proc.stderr.splitlines():
+                assert allowed_stderr.match(line)
         return proc
 
     @property

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -364,7 +364,7 @@ int ClientManager::applyRulesCmd(Input input, Output output) {
     } else {
         Client* client = this->client(winid);
         if (!client) {
-            output << "No such (managed) client: " << winid << "\n";
+            output.perror() << "No such (managed) client: " << winid << "\n";
             return HERBST_INVALID_ARGUMENT;
         }
         return applyRules(client, output);
@@ -389,7 +389,7 @@ int ClientManager::applyChanges(Client* client, ClientChanges changes, Output ou
     if (changes.manage == false) {
         // only make unmanaging clients possible as soon as it is
         // possible to make them managed again
-        output << "Unmanaging clients not yet possible.\n";
+        output.perror() << "Unmanaging clients not yet possible.\n";
         return HERBST_INVALID_ARGUMENT;
     }
     // do the simple attributes first
@@ -463,7 +463,7 @@ int ClientManager::applyTmpRuleCmd(Input input, Output output)
         // to only one client
         Client* client = this->client(clientStr);
         if (!client) {
-            output << "No such (managed) client: " << clientStr << "\n";
+            output.perror() << "No such (managed) client: " << clientStr << "\n";
             return HERBST_INVALID_ARGUMENT;
         }
         (*applyTo)[client->x11Window()] = client;

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -633,10 +633,10 @@ int FrameTree::cycleFrameCommand(Input input, Output output) {
     try {
         delta = std::stoi(s);
     } catch (std::invalid_argument const& e) {
-        output << "invalid argument: " << e.what() << endl;
+        output.perror() << "invalid argument: " << e.what() << endl;
         return HERBST_INVALID_ARGUMENT;
     } catch (std::out_of_range const& e) {
-        output << "out of range: " << e.what() << endl;
+        output.perror() << "out of range: " << e.what() << endl;
         return HERBST_INVALID_ARGUMENT;
     }
     cycle_frame(delta);
@@ -690,23 +690,23 @@ int FrameTree::loadCommand(Input input, Output output) {
                << endl;
         std::regex whitespace ("[ \n\t]");
         // print the layout again
-        output << "\"" << std::regex_replace(layoutString, whitespace, string(" "))
+        output.error() << "\"" << std::regex_replace(layoutString, whitespace, string(" "))
                << "\"" << endl;
         // and underline the token
         int token_len = std::max((size_t)1, parsingResult.error_->first.second.size());
-        output << " " // for the \" above
+        output.error() << " " // for the \" above
                << string(parsingResult.error_->first.first, ' ')
                << string(token_len, '~')
                << endl;
         return HERBST_INVALID_ARGUMENT;
     }
     if (!parsingResult.unknownWindowIDs_.empty()) {
-        output << "Warning: Unknown window IDs";
+        output.perror() << "Warning: Unknown window IDs";
         for (const auto& e : parsingResult.unknownWindowIDs_) {
-            output << " " << WindowID(e.second).str()
+            output.error() << " " << WindowID(e.second).str()
                    << "(\'" << e.first.second << "\')";
         }
-        output << endl;
+        output.error() << endl;
     }
     // apply the new frame tree
     tag->frame->applyFrameTree(tag->frame->root_, parsingResult.root_);

--- a/src/globalcommands.cpp
+++ b/src/globalcommands.cpp
@@ -172,7 +172,7 @@ int GlobalCommands::cycleValueCommand(Input input, Output output)
         attr = root_.settings->deepAttribute(attr_path);
     }
     if (!attr) {
-        output << "No such attribute: " << attr_path << endl;
+        output.perror() << "No such attribute: " << attr_path << endl;
         return HERBST_INVALID_ARGUMENT;
     }
     auto msg = attr->cycleValue(input.begin(), input.end());
@@ -208,11 +208,11 @@ void GlobalCommands::usePreviousCommand(CallOrComplete invoc)
         HSAssert(tag);
         int ret = monitor_set_tag(monitor, tag);
         if (ret != 0) {
-            output << "use_previous: Could not change tag";
+            output.perror() << "Could not change tag";
             if (monitor->lock_tag()) {
-                output << " (monitor is locked)";
+                output.error() << " (monitor is locked)";
             }
-            output << "\n";
+            output.error() << "\n";
         }
         return ret;
     });

--- a/src/ipc-protocol.h
+++ b/src/ipc-protocol.h
@@ -5,8 +5,16 @@
 //#define HERBST_IPC_READY "HERBST_IPC_READY"
 //#define HERBST_IPC_ATOM  "_HERBST_IPC"
 #define HERBST_IPC_ARGS_ATOM "_HERBST_IPC_ARGS"
+//! the (utf8 text) atom containing the output channel
 #define HERBST_IPC_OUTPUT_ATOM "_HERBST_IPC_OUTPUT"
+//! the (utf8 text) atom containing the error channel
+#define HERBST_IPC_ERROR_ATOM "_HERBST_IPC_ERROR"
 #define HERBST_IPC_STATUS_ATOM "_HERBST_IPC_EXIT_STATUS"
+
+/** if this (integer) atom present and non-empty on the hook window,
+ *  then the ipc reply has an error channel.
+ */
+#define HERBST_IPC_HAS_ERROR "_HERBST_IPC_HAS_ERROR"
 
 #define HERBST_HOOK_CLASS "HERBST_HOOK_CLASS"
 #define HERBST_HOOK_WIN_ID_ATOM "__HERBST_HOOK_WIN_ID"

--- a/src/ipc-protocol.h
+++ b/src/ipc-protocol.h
@@ -11,7 +11,7 @@
 #define HERBST_IPC_ERROR_ATOM "_HERBST_IPC_ERROR"
 #define HERBST_IPC_STATUS_ATOM "_HERBST_IPC_EXIT_STATUS"
 
-/** if this (integer) atom present and non-empty on the hook window,
+/** if this (integer) atom is present and non-empty on the hook window,
  *  then the ipc reply has an error channel.
  */
 #define HERBST_IPC_HAS_ERROR "_HERBST_IPC_HAS_ERROR"

--- a/src/keymanager.cpp
+++ b/src/keymanager.cpp
@@ -103,6 +103,7 @@ int KeyManager::removeKeybindCommand(Input input, Output output) {
             regrabAll();
         } else {
             output.perror() << "Key \"" << arg << "\" is not bound\n";
+            return HERBST_INVALID_ARGUMENT;
         }
     }
 

--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -109,7 +109,7 @@ Attribute* MetaCommands::getAttribute(string path, Output output) {
     auto attr_path = Object::splitPath(path);
     auto child = root.child(attr_path.first);
     if (!child) {
-        output << "No such object " << attr_path.first.join('.') << endl;
+        output.perror() << "No such object " << attr_path.first.join('.') << endl;
         return nullptr;
     }
     Attribute* a = child->attribute(attr_path.second);
@@ -121,7 +121,7 @@ Attribute* MetaCommands::getAttribute(string path, Output output) {
             // equip object_path with quotes
             object_path = "Object \"" + object_path + "\"";
         }
-        output << object_path
+        output.perror() << object_path
                << " has no attribute \"" << attr_path.second << "\""
                << endl;
         return nullptr;
@@ -136,7 +136,7 @@ int MetaCommands::print_object_tree_command(Input in, Output output) {
     }
     auto child = root.child(path);
     if (!child) {
-        output << "No such object " << Path(path).join('.') << endl;
+        output.perror() << "No such object " << Path(path).join('.') << endl;
         return HERBST_INVALID_ARGUMENT;
     }
     child->printTree(output, Path(path).join('.'));

--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -130,7 +130,7 @@ int MouseManager::dragCommand(Input input, Output output)
     }
     Client* client = Root::get()->clients->client(winid);
     if (!client) {
-        output << "Could not find client \"" << winid << "\"\n";
+        output.perror() << "Could not find client \"" << winid << "\"\n";
         return HERBST_INVALID_ARGUMENT;
     }
     MouseFunction action = string2mousefunction(mouseAction.c_str());

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -136,7 +136,7 @@ Object* Object::child(Path path, Output output) {
     while (!path.empty()) {
         cur = cur->child(path.front());
         if (!cur) {
-            output << "Object \"" << cur_path << "\""
+            output.perror() << "Object \"" << cur_path << "\""
                 << " has no child named \"" << path.front()
                 << "\"" << endl;
             return nullptr;
@@ -275,7 +275,8 @@ Attribute* Object::deepAttribute(const string &path, Output output) {
     }
     Attribute* a = attribute_owner->attribute(attr_path.second);
     if (!a) {
-        output << "Object \"" << attr_path.first.join()
+        output.perror()
+            << "Object \"" << attr_path.first.join()
             << "\" has no attribute \"" << attr_path.second
             << "\"."
             << endl;

--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -46,7 +46,7 @@ int RuleManager::parseRule(Input input, Output output, Rule& rule, bool& prepend
         if (arg == "not" || arg == "!") {
             // Make sure there is another argument coming:
             if (argIter + 1 == input.end()) {
-                output << "Expected another argument after \""<< arg << "\" flag\n";
+                output.perror() << "Expected another argument after \""<< arg << "\" flag\n";
                 return HERBST_INVALID_ARGUMENT;
             }
 
@@ -152,7 +152,7 @@ int RuleManager::unruleCommand(Input input, Output output) {
         // Remove rule specified by argument
         auto removedCount = removeRules(arg);
         if (removedCount == 0) {
-            output << "Couldn't find any rules with label \"" << arg << "\"";
+            output.perror() << "Couldn't find any rules with label \"" << arg << "\"";
             return HERBST_INVALID_ARGUMENT;
         }
     }

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -50,7 +50,7 @@ bool Rule::addCondition(string name, char op, const char* value, bool negated, O
     cond.conditionCreationTime = get_monotonic_timestamp();
 
     if (op != '=' && name == "maxage") {
-        output << "rule: Condition maxage only supports the = operator\n";
+        output.perror() << "Condition maxage only supports the = operator\n";
         return false;
     }
     switch (op) {
@@ -58,7 +58,7 @@ bool Rule::addCondition(string name, char op, const char* value, bool negated, O
             if (name == "maxage") {
                 cond.value_type = CONDITION_VALUE_TYPE_INTEGER;
                 if (1 != sscanf(value, "%d", &cond.value_integer)) {
-                    output << "rule: Cannot parse integer from \"" << value << "\"\n";
+                    output.perror() << "Cannot parse integer from \"" << value << "\"\n";
                     return false;
                 }
             } else {
@@ -73,7 +73,7 @@ bool Rule::addCondition(string name, char op, const char* value, bool negated, O
             try {
                 cond.value_reg_exp = std::regex(value, std::regex::extended);
             } catch(std::regex_error& err) {
-                output << "rule: Cannot parse value \"" << value
+                output.perror() << "Cannot parse value \"" << value
                         << "\" from condition \"" << name
                         << "\": \"" << err.what() << "\"\n";
                 return false;
@@ -83,7 +83,7 @@ bool Rule::addCondition(string name, char op, const char* value, bool negated, O
         }
 
         default:
-            output << "rule: Unknown rule condition operation \"" << op << "\"\n";
+            output.perror() << "Unknown rule condition operation \"" << op << "\"\n";
             return false;
             break;
     }
@@ -108,7 +108,7 @@ bool Rule::addConsequence(string name, char op, const char* value, Output output
             break;
 
         default:
-            output << "rule: Unknown rule consequence operation \"" << op << "\"\n";
+            output.perror() << "Unknown rule consequence operation \"" << op << "\"\n";
             return false;
             break;
     }
@@ -121,12 +121,12 @@ bool Rule::addConsequence(string name, char op, const char* value, Output output
 
 bool Rule::setLabel(char op, string value, Output output) {
     if (op != '=') {
-        output << "rule: Unknown rule label operation \"" << op << "\"\n";
+        output.perror() << "Unknown rule label operation \"" << op << "\"\n";
         return false;
     }
 
     if (value.empty()) {
-        output << "rule: Rule label cannot be empty\n";
+        output.perror() << "Rule label cannot be empty\n";
         return false;
     }
 

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -315,7 +315,7 @@ int HSTag::focusInDir(Direction direction, bool external_only, Output output)
         }
     }
     if (!neighbour_found) {
-        output << "focus: No neighbour found\n";
+        output.perror() << "No neighbour found\n";
         return HERBST_FORBIDDEN;
     }
     return 0;
@@ -341,7 +341,7 @@ int HSTag::shiftInDir(Direction direction, bool external_only, Output output)
 {
     Client* currentClient = focusedClient();
     if (!currentClient) {
-        output << "shift: No client focused\n";
+        output.perror() << "No client focused\n";
         return HERBST_FORBIDDEN;
     }
     bool success = true;
@@ -368,7 +368,7 @@ int HSTag::shiftInDir(Direction direction, bool external_only, Output output)
     if (success) {
         return 0;
     } else {
-        output << "shift: No neighbour found\n";
+        output.perror() << "No neighbour found\n";
         return HERBST_FORBIDDEN;
     }
 }
@@ -382,7 +382,7 @@ void HSTag::cycleAllCommand(CallOrComplete invoc)
               .command(invoc,
                        [&] (Output output) {
         if (delta < -1 || delta > 1) {
-            output << "argument out of range." << endl;
+            output.perror() << "argument out of range." << endl;
             return HERBST_INVALID_ARGUMENT;
         }
         if (delta == 0) {

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -398,7 +398,7 @@ int TagManager::floatingCmd(Input input, Output output) {
     } else {
         string msg = tag->floating.change(newValue);
         if (!msg.empty()) {
-            output << msg << "\n";
+            output.perror() << msg << "\n";
             return HERBST_INVALID_ARGUMENT;
         }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ BINDIR = os.path.join(os.path.abspath(os.environ['PWD']))
 COPY_ENV_WHITELIST = ['LSAN_OPTIONS']
 
 # time in seconds to wait for a process to shut down
-PROCESS_SHUTDOWN_TIME = 5
+PROCESS_SHUTDOWN_TIME = 10
 
 
 def extend_env_with_whitelist(environment):

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -51,6 +51,9 @@ def create_panel(hlwm):
     x11 = conftest.X11(display)
     _, winid = x11.create_client(geometry=(0, 0, 800, 30),
                                  window_type='_NET_WM_WINDOW_TYPE_DOCK')
+    # write the x11 bridge to a variable with a long life-span to avoid
+    # that the garbage-collection closes it (this would close the panel).
+    create_panel.x11 = x11
     return f'panels.{winid}'
 
 

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -251,7 +251,7 @@ class IpcServer:
 
         self.hc_requests = []  # list of running 'hc' callers
 
-    def wait_for_hc(self, timeout = 5):
+    def wait_for_hc(self, timeout=5):
         """wait for some herbstclient to connect"""
         while timeout >= 0:
             self.display.sync()
@@ -299,9 +299,9 @@ class IpcServer:
 @contextlib.contextmanager
 def hc_context(args=['echo', 'ping']):
     proc = subprocess.Popen([HC_PATH] + args,
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE,
-                          universal_newlines=True)
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            universal_newlines=True)
     yield proc
     proc.wait(3)
 

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -228,7 +228,7 @@ def test_ensure_newline(hlwm):
 
 
 class IpcServer:
-    """A simply re-implementation of the ipc server
+    """A simple re-implementation of the ipc server
     for testing error-branches in herbstclient
     """
     OUTPUT = '_HERBST_IPC_OUTPUT'

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -56,9 +56,8 @@ def test_keyunbind_all(hlwm, method, keyboard):
 
 
 def test_keyunbind_nonexistent_binding(hlwm):
-    unbind = hlwm.call('keyunbind n')
-
-    assert unbind.stdout == 'keyunbind: Key "n" is not bound\n'
+    hlwm.call_xfail('keyunbind n') \
+        .expect_stderr('keyunbind: Key "n" is not bound\n')
 
 
 def test_trigger_single_key_binding(hlwm, keyboard):

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1129,13 +1129,19 @@ def test_focus_edge_shift_edge(hlwm, command):
 
     # we're on the leftmost frame
     layout_before = hlwm.call('dump').stdout
-    hlwm.call([command, 'left'])
+
+    proc = hlwm.unchecked_call([command, 'left'])
+    # we don't check stderr, because currently, the commands
+    # print 'no neighbour found' in any case
+    assert proc.returncode == 0
+
     assert hlwm.attr.tags.focus.tiling.focused_frame.index() == '00'
     assert layout_before == hlwm.call('dump').stdout
     assert hlwm.get_attr('monitors.focus.index') == '0'
 
     # focus_edge/shift_edge goes to the rightmost frame
-    hlwm.call([command, 'right'])
+    proc = hlwm.unchecked_call([command, 'right'])
+    assert proc.returncode == 0
     # we're still on the first monitor
     assert hlwm.get_attr('monitors.focus.index') == '0'
     # but in the right-most frame

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 from test_layout import verify_frame_objects_via_dump
 
 
@@ -96,9 +97,10 @@ def test_full_layouts(hlwm, layout):
     "(clients vertical:0 1713)",
 ])
 def test_load_invalid_winids(hlwm, layout):
-    p = hlwm.call(['load', layout])
+    message = 'load: Warning: Unknown window IDs'
+    p = hlwm.call(['load', layout], allowed_stderr=re.compile(message)) \
 
-    assert p.stdout.startswith("Warning: Unknown window IDs")
+    assert p.stderr.startswith(message)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -77,7 +77,7 @@ def test_set_attr_can_not_set_writable(hlwm):
 def test_substitute_missing_attribute__command_treated_as_attribute(hlwm):
     call = hlwm.call_xfail('substitute X echo X')
 
-    assert call.stderr == 'The root object has no attribute "echo"\n'
+    assert call.stderr == 'substitute: The root object has no attribute "echo"\n'
 
 
 def test_substitute_command_missing(hlwm):
@@ -118,7 +118,7 @@ def test_sprintf_nested(hlwm):
 def test_sprintf_too_few_attributes__command_treated_as_attribute(hlwm):
     call = hlwm.call_xfail('sprintf X %s/%s tags.count echo X')
 
-    assert call.stderr == 'The root object has no attribute "echo"\n'
+    assert call.stderr == 'sprintf: The root object has no attribute "echo"\n'
 
 
 def test_sprintf_too_few_attributes_in_total(hlwm):
@@ -385,7 +385,8 @@ def test_chain_return_code(hlwm):
 
     assert p1.returncode > 1
     assert p1.returncode == p2.returncode
-    assert p2.stderr[0:5] == 'line\n'
+    assert p2.stdout[0:5] == 'line\n'
+    assert p2.stderr.split(':')[1:] == p1.stderr.split(':')[1:]
 
 
 def test_chain_nested(hlwm):
@@ -399,13 +400,13 @@ def test_chain_nested(hlwm):
 def test_chain_and_1(hlwm):
     proc = hlwm.unchecked_call('and , echo foo , false , echo bar')
     assert proc.returncode == 1
-    assert proc.stderr == 'foo\n'
+    assert proc.stdout == 'foo\n'
 
 
 def test_chain_and_2(hlwm):
     proc = hlwm.unchecked_call('and , echo foo , true , echo bar , false , echo baz')
     assert proc.returncode == 1
-    assert proc.stderr == 'foo\nbar\n'
+    assert proc.stdout == 'foo\nbar\n'
 
 
 def test_chain_or(hlwm):
@@ -521,8 +522,10 @@ def test_mktemp_complete(hlwm):
 def test_negate_command(hlwm):
     assert hlwm.call('! false').stdout == ''
     assert hlwm.call('! ! echo f').stdout == 'f\n'
-    hlwm.call_xfail('! echo test') \
-        .expect_stderr('test')
+    proc = hlwm.unchecked_call('! echo test')
+    assert proc.returncode == 1
+    assert proc.stdout == 'test\n'
+    assert proc.stderr == ''
 
 
 def test_negate_complete_cmd(hlwm):
@@ -604,10 +607,11 @@ def test_foreach_tag_merge(hlwm):
     # the second loop iteration for 'othertag'
     expected = [
         'tags.by-name.default',
-        'merge_tag: Cannot parse argument "othertag": no such tag: othertag',
         'tags.by-name.othertag'
     ]
-    proc = hlwm.call('foreach T tags.by-name chain , merge_tag othertag , echo T')
+    error = 'merge_tag: Cannot parse argument "othertag": no such tag: othertag'
+    proc = hlwm.call('foreach T tags.by-name chain , merge_tag othertag , echo T',
+                     allowed_stderr=re.compile(error))
     assert sorted(proc.stdout.splitlines()) == sorted(expected)
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -97,14 +97,16 @@ def test_add_rule_with_misformatted_argument(hlwm, command):
 def test_cannot_add_rule_with_empty_label(hlwm, command):
     call = hlwm.call_xfail(f'{command} label= class=Foo tag=bar')
 
-    assert call.stderr == 'rule: Rule label cannot be empty\n'
+    commandname = command.split(' ')[0]
+    assert call.stderr == f'{commandname}: Rule label cannot be empty\n'
 
 
 @pytest.mark.parametrize('command', ['rule', 'apply_tmp_rule --all'])
 def test_cannot_use_tilde_operator_for_rule_label(hlwm, command):
     call = hlwm.call_xfail(f'{command} label~bla class=Foo tag=bar')
 
-    assert call.stderr == 'rule: Unknown rule label operation "~"\n'
+    commandname = command.split(' ')[0]
+    assert call.stderr == f'{commandname}: Unknown rule label operation "~"\n'
 
 
 @pytest.mark.parametrize('command', ['rule', 'apply_tmp_rule --all'])
@@ -140,10 +142,11 @@ def test_rule_parse_error_printed_at_client(hlwm, command, rulearg, errormsg):
     else:
         full_cmd += [rulearg]
 
-    proc = hlwm.call(full_cmd)
-    # since the command does not fail, the error
+    proc = hlwm.unchecked_call(full_cmd)
+
+    # the command does not fail, but the error
     # message appears on stdout
-    assert re.search(errormsg, proc.stdout)
+    assert re.search(errormsg, proc.stderr)
 
 
 @pytest.mark.parametrize('method', ['-F', '--all'])
@@ -176,9 +179,8 @@ def test_remove_labeled_rule(hlwm):
 
 
 def test_remove_nonexistent_rule(hlwm):
-    call = hlwm.call_xfail('unrule nope')
-
-    assert call.stderr == 'Couldn\'t find any rules with label "nope"'
+    call = hlwm.call_xfail('unrule nope') \
+        .expect_stderr('Couldn\'t find any rules with label "nope"')
 
 
 def test_singleuse_rule_disappears_after_matching(hlwm):
@@ -276,7 +278,7 @@ def test_not_flag(hlwm):
 def test_condition_must_come_after_negation(hlwm, negation):
     call = hlwm.call_xfail(['rule', negation])
 
-    assert call.stderr == f'Expected another argument after "{negation}" flag\n'
+    assert call.stderr == f'rule: Expected another argument after "{negation}" flag\n'
 
 
 def test_condition_string_match(hlwm):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -179,7 +179,7 @@ def test_remove_labeled_rule(hlwm):
 
 
 def test_remove_nonexistent_rule(hlwm):
-    call = hlwm.call_xfail('unrule nope') \
+    hlwm.call_xfail('unrule nope') \
         .expect_stderr('Couldn\'t find any rules with label "nope"')
 
 
@@ -952,7 +952,9 @@ def test_apply_tmp_rule_parse_error(hlwm, hlwm_process):
     # unparseable argument.. In the future, this should be a proper error
     # message for 'apply_tmp_rule'!
     hlwm.create_client()
-    hlwm.call('apply_tmp_rule --all focus=not-a-bool')
+    proc = hlwm.unchecked_call('apply_tmp_rule --all focus=not-a-bool')
+    assert re.search('Invalid argument "not-a-bool" for rule consequence "focus"', proc.stderr)
+    assert proc.stdout == ''
 
 
 def test_smart_placement_within_monitor(hlwm):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -145,7 +145,7 @@ def test_rule_parse_error_printed_at_client(hlwm, command, rulearg, errormsg):
     proc = hlwm.unchecked_call(full_cmd)
 
     # the command does not fail, but the error
-    # message appears on stdout
+    # message appears on stderr
     assert re.search(errormsg, proc.stderr)
 
 


### PR DESCRIPTION
This makes the ipc protocol and herbstclient support the error channel.
In order to make herbstclient compatible with old herbstluftwm ipc
server implementations, the error channel support is indicated by an
atom on hlwm's ipc server window (which is so far only used for the hook
system). Conversely, an old herbstclient version should also work more
or less with the new herbstluftwm ipc server: it simply ignores the
error channel.

Due to this change, a few more missing `output.perror()` calls surfaced,
affecting implementation and test cases.

In order to test the new herbstclient, the test suite features a
minimalist ipc server implementation which can be used to simulate wrong
behaviour and thus to stress the error handling in the client.