### PR TITLE
Write 'command not found' to the error channel

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -86,7 +86,7 @@ int CommandTable::callCommand(Input args, Output out) const {
     const auto cmd = map.find(args.command());
 
     if (cmd == map.end()) {
-        out << "error: Command \"" << args.command() << "\" not found" << endl;
+        out.error() << "error: Command \"" << args.command() << "\" not found" << endl;
         return HERBST_COMMAND_NOT_FOUND;
     }
     // new channels object to have the command name updated

--- a/tests/test_herbstluftwm.py
+++ b/tests/test_herbstluftwm.py
@@ -154,5 +154,6 @@ def test_command_not_found(hlwm):
     message = f'Command "{command}" not found'
     hlwm.call_xfail(command).expect_stderr(message)
     hlwm.call_xfail(f'{command} argument').expect_stderr(message)
-    hlwm.call_xfail(f'chain , echo foo , {command} argument , anothercmd') \
-        .expect_stderr(message)
+    call = hlwm.unchecked_call(f'chain , echo foo , {command} argument , anothercmd')
+    assert re.search(message, call.stderr)
+    assert re.search('foo', call.stdout)

--- a/tests/test_herbstluftwm.py
+++ b/tests/test_herbstluftwm.py
@@ -147,3 +147,12 @@ def test_herbstluftwm_version_flags():
         assert proc.stderr == ''
         # look for some flag on stdout:
         assert re.search('herbstluftwm', proc.stdout)
+
+
+def test_command_not_found(hlwm):
+    command = 'nonexistentcommand'
+    message = f'Command "{command}" not found'
+    hlwm.call_xfail(command).expect_stderr(message)
+    hlwm.call_xfail(f'{command} argument').expect_stderr(message)
+    hlwm.call_xfail(f'chain , echo foo , {command} argument , anothercmd') \
+        .expect_stderr(message)


### PR DESCRIPTION
This is yet another error message that belongs to the new error channel.