### PR TITLE
Print error message on too many arguments

### DIFF
--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -130,7 +130,14 @@ bool ArgParse::parsingFails(Input& input, Output& output)
  */
 bool ArgParse::parsingAllFails(Input& input, Output& output)
 {
-    return parsingFails(input, output) || unparsedTokens(input, output);
+    if (parsingFails(input, output)) {
+        return true;
+    }
+    if (unparsedTokens(input, output)) {
+        output.perror() << "too many arguments" << endl;
+        return true;
+    }
+    return false;
 }
 
 bool ArgParse::unparsedTokens(Input& input, Output& output)

--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -738,7 +738,7 @@ int MetaCommands::helpCommand(Input input, Output output)
         object->ls(output);
     }
     if (!helpFound) {
-        output << "No help found for \'" << needle << "\'" << endl;
+        output.perror() << "No help found for \'" << needle << "\'" << endl;
         return HERBST_INVALID_ARGUMENT;
     }
     return 0;

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -728,6 +728,17 @@ def test_help_on_objects(hlwm, path='', depth=8):
         test_help_on_objects(hlwm, path=newpath, depth=depth - 1)
 
 
+def test_help_invalid_arg(hlwm):
+    hlwm.call_xfail('help too many args') \
+        .expect_stderr('too many arguments')
+
+    hlwm.call_xfail('help') \
+        .expect_stderr('not enough arguments')
+
+    hlwm.call_xfail('help certainly_an_invalid_arg') \
+        .expect_stderr("No help found for 'certainly_an_invalid_arg'")
+
+
 def test_watch_no_arguments(hlwm):
     hlwm.call_xfail('watch').expect_stderr(
         'Expected one argument, but got only 0 arguments.'


### PR DESCRIPTION
If ArgParse::parsingAllFails() notices too many arguments, print a
message to the error channel. This affects e.g. 'hc help'.