### PR TITLE
Refine completion of the 'substitute' command

### DIFF
--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -206,9 +206,12 @@ void MetaCommands::substitute_complete(Completion& complete)
     } else if (complete == 1) {
         completeAttributePath(complete);
     } else {
-        // later, complete the identifier
-        complete.full(complete[0]);
         complete.completeCommands(2);
+        if (!complete.noParameterExpected()) {
+            // later, complete the identifier if the nested command
+            // still expects parameters
+            complete.full(complete[0]);
+        }
     }
 }
 

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -45,6 +45,15 @@ def test_substitute(hlwm):
     assert call.stdout == expected_output
 
 
+def test_substitute_completion(hlwm):
+    assert 'tags.' in hlwm.complete(['substitute', 'X'], partial=True)
+    hlwm.command_has_all_args(['substitute', 'X', 'tags.count', 'true'])
+    assert 'floating' in hlwm.complete(['substitute', 'X', 'tags.count'])
+    assert 'X' in hlwm.complete(['substitute', 'X', 'tags.count', 'floating'])
+    # the nested command has all args already, so don't complete the 'X' here:
+    hlwm.command_has_all_args(['substitute', 'X', 'tags.count', 'floating', 'on'])
+
+
 @pytest.mark.parametrize('prefix', ['set_attr settings.',
                                     'attr settings.',
                                     'cycle_value settings.',


### PR DESCRIPTION
Main purpose of this change is to have a test case for the 'substitute'
completion. While writing the test, I've noticed that the placeholder
should only be inserted if the nested command still expects an argument,
which was incorporated easily.