### PR TITLE
Use correct comparison function in 'complete'

### DIFF
--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -544,7 +544,7 @@ template <typename T> int parse_and_compare(string a, string b, Output o) {
         try {
             vals.push_back(Converter<T>::parse(x));
         } catch(std::exception& e) {
-            o << "cannot parse \"" << x << "\" to "
+            o.perror() << "cannot parse \"" << x << "\" to "
               << typeid(T).name() << ": " << e.what() << endl;
             return (int) HERBST_INVALID_ARGUMENT;
         }

--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -393,7 +393,7 @@ static std::map<string, function<Attribute*(string)>> name2constructor {
 Attribute* MetaCommands::newAttributeWithType(string typestr, string attr_name, Output output) {
     auto it = name2constructor.find(typestr);
     if (it == name2constructor.end()) {
-        output << "error: unknown type \"" << typestr << "\"";
+        output.perror() << "unknown type \"" << typestr << "\"";
         return nullptr;
     }
     auto attr = it->second(attr_name);
@@ -599,7 +599,8 @@ int MetaCommands::compare_cmd(Input input, Output output)
         comparator = it->second;
     }
     if (oper.first && !comparator.first) {
-        output << "operator \"" << Converter<CompareOperator>::str(oper) << "\" "
+        output.perror()
+            << "operator \"" << Converter<CompareOperator>::str(oper) << "\" "
             << "only allowed for numeric types, but the attribute "
             << path << " is of non-numeric type "
             << Entity::typestr(a->type()) << endl;

--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -587,7 +587,7 @@ int MetaCommands::compare_cmd(Input input, Output output)
     std::map<Type, pair<bool, function<int(string,string,Output)>>> type2compare {
         // map a type name to "is it numeric" and a comperator function
         { Type::INT,      { true,  parse_and_compare<int> }, },
-        { Type::ULONG,    { true,  parse_and_compare<int> }, },
+        { Type::ULONG,    { true,  parse_and_compare<unsigned long> }, },
         { Type::BOOL,     { false, parse_and_compare<bool> }, },
         { Type::COLOR,    { false, parse_and_compare<Color> }, },
     };

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -337,6 +337,19 @@ def test_compare_invalid_operator(hlwm):
     hlwm.call_xfail('compare monitors.count -= 1') \
         .expect_stderr('Cannot.* "-=": Expecting one of: =, !=,')
 
+    hlwm.call_xfail('compare tags.focus.name gt 23') \
+        .expect_stderr('operator "gt" only.* numeric types')
+
+
+def test_compare_invalid_argument(hlwm):
+    hlwm.call_xfail('compare monitors.focus.lock_tag = notboolean') \
+        .expect_stderr('cannot parse "notboolean".*only.*are valid booleans')
+
+
+def test_compare_completion(hlwm):
+    assert '!=' in hlwm.complete('compare tags.count')
+    hlwm.command_has_all_args(['compare', 'tags.count', '=', '23'])
+
 
 def test_compare_fallback_string_equal(hlwm):
     hlwm.call('set_layout max')


### PR DESCRIPTION
Thanks to the coverage reported, I've noticed that the function
parse_and_compare<unsigned long> was not used at all. The mistake was
introduced in 698dcd74ddbe96e96429c5ce874b2d099fd8c3cd.

It is hard to write a test case for it, but I've added some test case of
other yet non-covered parts of the error handling and completion of
'compare'.
