### PR TITLE
utils: Remove unused method

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -258,20 +258,3 @@ string posix_sh_escape(const string& source) {
     }
     return target;
 }
-
-void posix_sh_compress_inplace(char* str) {
-    int offset = 0;
-    for (int i = 0; true ; i++) {
-        if (str[i] == '\\' && str[i + 1] ) {
-            str[i + offset] = str[i + 1];
-            i++;
-            offset --;
-        } else {
-            str[i + offset] = str[i];
-        }
-        if (!str[i]) {
-            break;
-        }
-    }
-}
-

--- a/src/utils.h
+++ b/src/utils.h
@@ -81,9 +81,6 @@ std::string utf8_string_at(const std::string& str, size_t offset);
 // returns an posix sh escaped string or NULL if there is nothing to escape
 // if a new string is returned, then the caller has to free it
 std::string posix_sh_escape(const std::string& source);
-// does the reverse action to posix_sh_escape by modifing the string
-void posix_sh_compress_inplace(char* str);
-
 
 /**
  *  Substitute for std::make_unique in C++11


### PR DESCRIPTION
posix_sh_compress_inplace seems unused, posix_sh_escape on the other
hand is not.