### PR TITLE
Fix exec error message in spawn command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -265,7 +265,7 @@ int custom_hook_emit(Input input) {
 
 static void execvp_helper(char *const command[]) {
     execvp(command[0], command);
-    std::cerr << "herbstluftwm: execvp \"" << command << "\"";
+    std::cerr << "herbstluftwm: execvp \"" << command[0] << "\"";
     perror(" failed");
 }
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -5,3 +5,13 @@ def test_spawn(hlwm, hlwm_process):
         assert proc.returncode == 0
         assert not proc.stderr
         assert not proc.stdout
+
+
+def test_spawn_command_not_exist(hlwm, hlwm_process):
+    cmdname = 'this_command_does_not_exist'
+    with hlwm_process.wait_stderr_match(f'execvp "{cmdname}" failed'):
+        cmd = ['spawn', cmdname]
+        proc = hlwm.unchecked_call(cmd, read_hlwm_output=False)
+        assert proc.returncode == 0
+        assert not proc.stderr
+        assert not proc.stdout


### PR DESCRIPTION
Print the correct command name if exec fails (instead of the memory
address). The new test case verifies that this does not happen again.

This fixes #1302.