### PR TITLE
Include <limits> for std::numeric_limits

### DIFF
--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -1,6 +1,7 @@
 #include "floating.h"
 
 #include <algorithm>
+#include <limits>
 #include <climits>
 #include <cstdlib>
 #include <unordered_set>

--- a/src/floating.cpp
+++ b/src/floating.cpp
@@ -1,9 +1,9 @@
 #include "floating.h"
 
 #include <algorithm>
-#include <limits>
 #include <climits>
 #include <cstdlib>
+#include <limits>
 #include <unordered_set>
 
 #include "client.h"

--- a/src/rectangle.cpp
+++ b/src/rectangle.cpp
@@ -1,6 +1,7 @@
 #include "rectangle.h"
 
 #include <X11/Xutil.h>
+#include <limits>
 #include <queue>
 
 #include "ipc-protocol.h"


### PR DESCRIPTION
This fixes a compilation error on Gentoo with GCC 11[1], complaining
about an undefined std::numeric_limits in the namespace std. According
to cppreference std::numeric_limits requires including <limits>. This
adds the include to floating.cpp, where the error occurred, and also to
rectangle.cpp (which also uses std::numeric_limits but did not have the
include).

[1] https://bugs.gentoo.org/787848