### PR TITLE
Report rule consequence errors during rule creation

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -16,6 +16,10 @@ output always on stdout. Before, both were printed to the same channel,
 either to stdout or stderr depending on the command's exit status. This
 mainly affects combined commands.
 
+In the rules, 'toggle' can not be used anymore in rule consequences. Moreover,
+invalid arguments to rule consequences now will be reported during 'rule'
+creation, already.
+
 Only for people using the git-version: During the development of 0.9.3, the
 'content_geometry' attribute of clients initially had the name
 'geometry_reported'.

--- a/NEWS
+++ b/NEWS
@@ -35,6 +35,8 @@ Current git version
   * New command 'attr_type' printing the type of a given attribute.
   * Relative values for integer attributes ('+=N' and '-=N')
   * The 'cycle' command now also cycles through floating windows.
+  * The 'rule' command now reports errors already during rule creation.
+  * In rule consequences, 'toggle' is not allowed anymore.
   * The python bindings automatically convert from and to python's types
   * Bug fixes:
     - Fix mistakenly transparent borders of argb clients

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1313,45 +1313,43 @@ Each 'CONSEQUENCE' consists of a 'NAME'='VALUE' pair. Valid 'NAMES' are:
 
 +focus+::
     decides whether the client gets the input focus in its tag. The default is
-    *off*. 'VALUE' can be *on*, *off* or *toggle*.
+    *off*. 'VALUE' is a boolean (*on* or *off*).
 
 +switchtag+::
     if +focus+ is activated and the client is put to a not focused tag, then
     +switchtag+ tells whether the client's tag will be shown or not. If the tag
     is shown on any monitor but is not focused, the client's tag only is brought
     to the current monitor if *swap_monitors_to_get_tag* is activated. 'VALUE'
-    can be *on*, *off* or *toggle*.
+    is a boolean (*on* or *off*).
 
 +manage+::
     decides whether the client will be managed or not. The default is *on*.
-    'VALUE' can be *on*, *off* or *toggle*.
+    'VALUE' is a boolean (*on* or *off*).
 
 +index+::
     moves the window to a specified index in the tree. 'VALUE' is a
     <<FRAME_INDEX,*frame index*>>.
 
 +floating+::
-    sets the floating state of the client. 'VALUE' can be *on*, *off* or
-    *toggle*.
+    sets the floating state of the client. 'VALUE' is a boolean.
 
 +pseudotile+::
-    sets the pseudotile state of the client. 'VALUE' can be *on*, *off* or
-    *toggle*.
+    sets the pseudotile state of the client. 'VALUE' is a boolean.
 
 +ewmhrequests+::
     sets whether the window state (the fullscreen state and the demands
     attention flag) can be changed by the application via ewmh itself. This does
-    not affect the initial fullscreen state requested by the window. 'VALUE' can
-    be *on*, *off* or *toggle*, it defaults to *on*.
+    not affect the initial fullscreen state requested by the window. 'VALUE' is
+    a boolean; it defaults to *on*.
 
 +ewmhnotify+::
     sets whether hlwm should let the client know about EMWH changes (currently
     only the fullscreen state). If this is set, applications do not change to
-    their fullscreen-mode while still being fullscreen. 'VALUE' can be *on*,
-    *off* or *toggle*, it defaults to *on*.
+    their fullscreen-mode while still being fullscreen. 'VALUE' is a boolean,
+    it defaults to *on*.
 
 +fullscreen+::
-    sets the fullscreen flag of the client. 'VALUE' can be *on* or *off*.
+    sets the fullscreen flag of the client. 'VALUE' is a boolean.
 
 +hook+::
     emits the custom hook +rule+ 'VALUE' 'WINID' when this rule is triggered by

--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -66,8 +66,9 @@ int RuleManager::parseRule(Input input, Output output, Rule& rule, bool& prepend
         }
 
         // Check if lhs is a condition name
-        if (Condition::matchers.count(lhs)) {
-            bool success = rule.addCondition(lhs, oper, rhs.c_str(), negated, output);
+        Condition::Matchers::const_iterator maybe_condition = Condition::matchers.find(lhs);
+        if (maybe_condition != Condition::matchers.end()) {
+            bool success = rule.addCondition(maybe_condition, oper, rhs.c_str(), negated, output);
             if (!success) {
                 return HERBST_INVALID_ARGUMENT;
             }
@@ -75,13 +76,14 @@ int RuleManager::parseRule(Input input, Output output, Rule& rule, bool& prepend
         }
 
         // Check if lhs is a consequence name
-        if (Consequence::appliers.count(lhs)) {
+        Consequence::Appliers::const_iterator maybe_consequence = Consequence::appliers.find(lhs);
+        if (maybe_consequence != Consequence::appliers.end()) {
             if (oper == '~') {
                 output.perror() << "Operator ~ not valid for consequence \"" << lhs << "\"\n";
                 return HERBST_INVALID_ARGUMENT;
             }
 
-            bool success = rule.addConsequence(lhs, oper, rhs.c_str(), output);
+            bool success = rule.addConsequence(maybe_consequence, rhs.c_str(), output);
             if (!success) {
                 return HERBST_INVALID_ARGUMENT;
             }

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -14,6 +14,12 @@ using std::string;
 using std::function;
 
 
+/**
+ * A helper function to define rule consequences that directly
+ * write to a member of ClientConsequences of (plain) type T.
+ *
+ * This function returns an entry of the Consequence:appliers map.
+ */
 template <typename T>
 function<Consequence::Applier(const string&)>
     setMember(T ClientChanges::* member)
@@ -26,6 +32,12 @@ function<Consequence::Applier(const string&)>
     };
 }
 
+/**
+ * A helper function to define rule consequences that directly
+ * write to a member of ClientConsequences of type optional<T>
+ *
+ * This function returns an entry of the Consequence:appliers map.
+ */
 template <typename T>
 function<Consequence::Applier(const string&)>
     setOptionalMember(std::experimental::optional<T> ClientChanges::* member)

--- a/src/rules.h
+++ b/src/rules.h
@@ -25,7 +25,8 @@ class Condition {
 public:
 
     using Matcher = std::function<bool(const Condition*, const Client*)>;
-    static const std::map<std::string, Matcher> matchers;
+    using Matchers = const std::map<std::string, Matcher>;
+    static Matchers matchers;
 
     std::string name;
     int value_type = 0;
@@ -106,28 +107,18 @@ public:
      * Consequence object is invalid.
      */
     using Applier = std::function<void(const Consequence*, const Client*, ClientChanges*)>;
-    static const std::map<std::string, Applier> appliers;
+    using Appliers = const std::map<std::string, std::function<Applier(const std::string&)>>;
+    static Appliers appliers;
 
     std::string name;
-    int value_type = 0;
     std::string value;
+    Applier apply;
 
 private:
     void applyTag(const Client* client, ClientChanges* changes) const;
     void applyIndex(const Client* client, ClientChanges* changes) const;
-    void applyFocus(const Client* client, ClientChanges* changes) const;
-    void applySwitchtag(const Client* client, ClientChanges* changes) const;
-    void applyManage(const Client* client, ClientChanges* changes) const;
-    void applyFloating(const Client* client, ClientChanges* changes) const;
-    void applyPseudotile(const Client* client, ClientChanges* changes) const;
-    void applyFullscreen(const Client* client, ClientChanges* changes) const;
-    void applyEwmhrequests(const Client* client, ClientChanges* changes) const;
-    void applyEwmhnotify(const Client* client, ClientChanges* changes) const;
     void applyHook(const Client* client, ClientChanges* changes) const;
-    void applyKeyMask(const Client* client, ClientChanges* changes) const;
-    void applyKeysInactive(const Client* client, ClientChanges* changes) const;
     void applyMonitor(const Client* client, ClientChanges* changes) const;
-    void applyFloatplacement(const Client* client, ClientChanges* changes) const;
 };
 
 class Rule {
@@ -146,8 +137,8 @@ public:
     time_t birth_time; // timestamp of at creation
 
     bool setLabel(char op, std::string value, Output output);
-    bool addCondition(std::string name, char op, const char* value, bool negated, Output output);
-    bool addConsequence(std::string name, char op, const char* value, Output output);
+    bool addCondition(const Condition::Matchers::const_iterator& it, char op, const char* value, bool negated, Output output);
+    bool addConsequence(const Consequence::Appliers::const_iterator& it, const char* value, Output output);
 
     void print(Output output);
 private:

--- a/src/rules.h
+++ b/src/rules.h
@@ -103,10 +103,13 @@ public:
 class Consequence {
 public:
     /*! An Applier modifies the given ClientChanges object, and possibly throws an
-     * exception (std::invalid_argument, std::out_of_range) if the value in the
-     * Consequence object is invalid.
+     * exception (std::invalid_argument, std::out_of_range) on run-time errors.
      */
     using Applier = std::function<void(const Consequence*, const Client*, ClientChanges*)>;
+    /*! An entry in the Appliers map returns an Applier, given the argument
+     * to the consequence and possibly throws an exception if the argument
+     * is of the wrong format.
+     */
     using Appliers = const std::map<std::string, std::function<Applier(const std::string&)>>;
     static Appliers appliers;
 

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -116,17 +116,8 @@ def test_keys_inactive(hlwm, keyboard, maskmethod, whenbind, refocus):
 
 
 def test_invalid_keys_inactive_via_rule(hlwm, keyboard):
-    hlwm.call('keybind x add anothertag')
-    # Note: In future work, we could make this fail right away. But
-    # currently, that is not the case.
-    hlwm.call('rule once keys_inactive=[b-a]')
-    hlwm.create_client()
-
-    keyboard.press('x')
-
-    # since there is no valid keys_inactive, the command must have been
-    # executed:
-    assert 'anothertag' in hlwm.list_children('tags.by-name.')
+    hlwm.call_xfail('rule once keys_inactive=[b-a]') \
+        .expect_stderr(r'Invalid .*\[b-a\].*:.*Invalid range in bracket')
 
 
 @pytest.mark.parametrize('prefix', ['', 'Mod1+'])


### PR DESCRIPTION
When creating a new rule (via the `rule` or `apply_tmp_rule` command),
then a erroneous argument to a rule consequence (e.g. an invalid regular
expression) will be reported directly and will make the rule creation
fail. This helps finding mistakes earlier. Before, herbstluftwm printed
an error message during rule usage to its stderr, which is usually not
monitored by anybody.

On the negative side, this makes it now impossible to use 'toggle' in
boolean rule consequences. But I assume nobody uses this anyway, because
the result is of course highly unpredictable. Also, no rule consequence
can fail at run time at the moment, which produces dead code in
Rule::evaluate(), but I'm keeping this to be on the safe side.

As a positive side-effect, the redundancy in the applier implementation
in the Consequence class is reduced.

This change actually simplifies the test cases, because parse errors are
now reported directly.