### PR TITLE
Add 'floating_geometry' rule consequence

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,8 @@ Current git version
   * The 'cycle' command now also cycles through floating windows.
   * The 'rule' command now reports errors already during rule creation.
   * In rule consequences, 'toggle' is not allowed anymore.
+  * New rule consequences:
+    - 'floating_geometry' for setting the attribute of the same name
   * The python bindings automatically convert from and to python's types
   * Bug fixes:
     - Fix mistakenly transparent borders of argb clients

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1372,6 +1372,10 @@ Each 'CONSEQUENCE' consists of a 'NAME'='VALUE' pair. Valid 'NAMES' are:
       as possible. If there are multiple options with the least overlap, then
       the position with the least overlap to tiling windows is chosen.
 
++floating_geometry+::
+    Sets the client's +floating_geometry+ attribute. The 'VALUE' is a rectangle,
+    interpreted relatively to the monitor.
+
 A rule's behaviour can be configured by some special 'FLAGS':
 
     * +not+: negates the next 'CONDITION'.

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -345,6 +345,15 @@ void ClientManager::setSimpleClientAttributes(Client* client, const ClientChange
     if (changes.keysInactive.has_value()) {
         client->keysInactive_ = changes.keysInactive.value();
     }
+    if (changes.floatingGeometry.has_value()) {
+        Rectangle geo = changes.floatingGeometry.value();
+        // do not simply copy the geometry to the attribute
+        // but possibly apply the size hints:
+        if (client->sizehints_floating_()) {
+            client->applysizehints(&geo.width, &geo.height);
+        }
+        client->float_size_ = geo;
+    }
 }
 
 int ClientManager::applyRulesCmd(Input input, Output output) {
@@ -394,6 +403,12 @@ int ClientManager::applyChanges(Client* client, ClientChanges changes, Output ou
     }
     // do the simple attributes first
     setSimpleClientAttributes(client, changes);
+    bool clientNeedsRelayout = false;
+    if (changes.floatingGeometry.has_value()) {
+        // if the floating geometry changed, make sure
+        // that the client's possition is updated
+        clientNeedsRelayout = true;
+    }
     if (changes.fullscreen.has_value()) {
         client->fullscreen_ = changes.fullscreen.value();
     }
@@ -424,13 +439,19 @@ int ClientManager::applyChanges(Client* client, ClientChanges changes, Output ou
         }
         TagManager* tagman = Root::get()->tags();
         tagman->moveClient(client, tag, changes.tree_index, changes.focus);
+        clientNeedsRelayout = false; // the above relayouts the tag
     } else if (changes.focus && (client != focus())) {
         // focus the client
         client->tag()->focusClient(client);
         Root::get()->monitors->relayoutTag(client->tag());
+        clientNeedsRelayout = false; // the above relayouts the tag
     }
     if (monitor && switch_tag && tag) {
         monitor_set_tag(monitor, tag);
+    }
+    if (clientNeedsRelayout) {
+        // if the client still has not been resized yet:
+        Root::get()->monitors->relayoutTag(client->tag());
     }
     return 0;
 }

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -71,6 +71,7 @@ const std::map<string, function<Consequence::Applier(const string&)>> Consequenc
     { "switchtag",      setMember(&ClientChanges::switchtag) },
     { "manage",         setMember(&ClientChanges::manage) },
     { "floating",       setOptionalMember(&ClientChanges::floating) },
+    { "floating_geometry", setOptionalMember(&ClientChanges::floatingGeometry) },
     { "pseudotile",     setOptionalMember(&ClientChanges::pseudotile) },
     { "fullscreen",     setOptionalMember(&ClientChanges::fullscreen) },
     { "ewmhrequests",   setOptionalMember(&ClientChanges::ewmhRequests) },

--- a/src/rules.h
+++ b/src/rules.h
@@ -95,6 +95,7 @@ public:
     std::experimental::optional<RegexStr> keysInactive; // Which keymask rule should be applied for this client
 
     std::experimental::optional<bool> floating;
+    std::experimental::optional<Rectangle> floatingGeometry;
     std::experimental::optional<bool> pseudotile;
     std::experimental::optional<bool> ewmhRequests;
     std::experimental::optional<bool> ewmhNotify;


### PR DESCRIPTION
This makes it possible to set the floating_geometry client attribute via
the rule system.

This closes #1157 and #1266.