### PR TITLE
Doc on rule floatplacement vs floating_geometry

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1374,7 +1374,10 @@ Each 'CONSEQUENCE' consists of a 'NAME'='VALUE' pair. Valid 'NAMES' are:
 
 +floating_geometry+::
     Sets the client's +floating_geometry+ attribute. The 'VALUE' is a rectangle,
-    interpreted relatively to the monitor.
+    interpreted relatively to the monitor. If +floatplacement+ is also specified
+    for the client (possibly by another rule), then only the size of the
+    +floating_geometry+ is used. In order to force the position from the
+    geometry, it is necessary to add +floatplacement=none+.
 
 A rule's behaviour can be configured by some special 'FLAGS':
 

--- a/python/herbstluftwm/types.py
+++ b/python/herbstluftwm/types.py
@@ -5,6 +5,28 @@ primarily, types used in attributes.
 """
 
 
+class Point:
+    """
+    A point on the 2D plane
+    """
+    def __init__(self, x=0, y=0):
+        self.x = x
+        self.y = y
+
+    def __add__(self, other):
+        return Point(self.x + other.x, self.y + other.y)
+
+    def __floordiv__(self, scalar):
+        """divide by scalar factor, forcing to integer coordinates"""
+        return Point(self.x // scalar, self.y // scalar)
+
+    def __eq__(self, other):
+        return self.x == other.x and self.y == other.y
+
+    def __repr__(self) -> str:
+        return f'Point({self.x}, {self.y})'
+
+
 class Rectangle:
     """
     A rectangle on the screen, defined by its size and its distance to
@@ -48,6 +70,18 @@ class Rectangle:
         are adjusted by the provided deltas.
         """
         return Rectangle(self.x + dx, self.y + dy, self.width + dw, self.height + dh)
+
+    def topleft(self) -> Point:
+        """the top left corner of the rectangle"""
+        return Point(self.x, self.y)
+
+    def center(self) -> Point:
+        """the center of the rectangle, forced to integer coordinates"""
+        return self.topleft() + self.size() // 2
+
+    def size(self) -> Point:
+        """width and height of the rectangle"""
+        return Point(self.width, self.height)
 
 
 class HlwmType:


### PR DESCRIPTION
This documents and tests the interaction of the floatplacement and
floating_geometry rule consequences. Since 'floatplacement' is not
applied by 'apply_rules' / 'apply_tmp_rules', the test case only
mentions the 'rule' command (also I've fixed a typo along the way).

For the readability in the tests, I've introduced a Point datastructure
to herbstluftwm's python bindings.