### PR TITLE
Client alias 'longest-minimized' and 'last-minimized'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,8 @@ Current git version
     settings for compatibility).
   * New object 'types' containing documentation on (attribute-) types.
   * New command 'attr_type' printing the type of a given attribute.
+  * New client alias 'last-minimized' and 'longest-minimized' for focusing
+    and unminimizing minimized clients.
   * Relative values for integer attributes ('+=N' and '-=N')
   * The 'cycle' command now also cycles through floating windows.
   * The 'rule' command now reports errors already during rule creation.

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1416,6 +1416,10 @@ follows:
   - +urgent+ references some window that is urgent.
   - +0x+'HEXID' -- where 'HEXID' is some hexadecimal number -- references the
     window with hexadecimal X11 window id 'HEXID'.
+  - +longest-minimized+ references the minimized window on the focused tag
+    that has been minimized for the longest time.
+  - +latest-minimized+ references the minimized window on the focused tag
+    that has been minimized most recently.
   - 'DECID' -- where 'DECID' is some decimal number -- references the window
     with the decimal X11 window id 'DECID'.
 

--- a/share/autostart
+++ b/share/autostart
@@ -86,14 +86,7 @@ hc keybind $Mod-s floating toggle
 hc keybind $Mod-f fullscreen toggle
 hc keybind $Mod-Shift-f set_attr clients.focus.floating toggle
 hc keybind $Mod-Shift-m set_attr clients.focus.minimized true
-hc keybind $Mod-Shift-Control-m jumpto last-minimized
-# restore all minimized windows of the focused tag
-hc keybind $Mod-Ctrl-m foreach CLIENT clients. \
-     sprintf MINATT "%c.minimized" CLIENT \
-     sprintf TAGATT "%c.tag" CLIENT and \
-       , compare MINATT "=" "true" \
-       , substitute FOCUS "tags.focus.name" compare TAGATT "=" FOCUS \
-       , set_attr MINATT false
+hc keybind $Mod-Control-m jumpto last-minimized
 hc keybind $Mod-p pseudotile toggle
 # The following cycles through the available layouts within a frame, but skips
 # layouts, if the layout change wouldn't affect the actual window positions.

--- a/share/autostart
+++ b/share/autostart
@@ -86,6 +86,7 @@ hc keybind $Mod-s floating toggle
 hc keybind $Mod-f fullscreen toggle
 hc keybind $Mod-Shift-f set_attr clients.focus.floating toggle
 hc keybind $Mod-Shift-m set_attr clients.focus.minimized true
+hc keybind $Mod-Shift-Control-m jumpto last-minimized
 # restore all minimized windows of the focused tag
 hc keybind $Mod-Ctrl-m foreach CLIENT clients. \
      sprintf MINATT "%c.minimized" CLIENT \

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -95,7 +95,11 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
         updateEwmhState();
         hook_emit({"fullscreen", fullscreen_() ? "on" : "off", WindowID(window_).str()});
     });
-    minimized_.changed().connect(this, &Client::updateEwmhState);
+    minimized_.changed().connect([this]() {
+        static long long minimizedTick = 0;
+        minimizedLastChange_ = minimizedTick++;
+        this->updateEwmhState();
+    });
 
     float_size_.setWritable();
     float_size_.changedByUser().connect(this, &Client::floatingGeometryChanged);

--- a/src/client.h
+++ b/src/client.h
@@ -43,6 +43,8 @@ public:
     int         ignore_unmaps_ = 0;  // Ignore one unmap for each reparenting
                                 // action, because reparenting creates an unmap
                                 // notify event
+    //! the last time when minimized_ was changed (with discrete time ticks).
+    long long int minimizedLastChange_ = 0;
     // for size hints
     float mina_ = 0;
     float maxa_ = 0;

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -110,11 +110,20 @@ Client* ClientManager::parse(const string& identifier)
         }
         throw std::invalid_argument("No client is urgent");
     }
+    if (identifier == "last-minimized" || identifier == "longest-minimized") {
+        bool oldest = identifier == "longest-minimized";
+        Client *c = Root::get()->tags()->focus_->minimizedClient(oldest);
+        if (c) {
+            return c;
+        } else {
+            throw std::invalid_argument("No client is minimized");
+        }
+    }
     Window win = {};
     try {
         win = Converter<WindowID>::parse(identifier);
     } catch (const std::exception&) {
-        throw std::invalid_argument("Invalid format, expecting 0xWINID or \'urgent\' or \'\'");
+        throw std::invalid_argument("Invalid format, expecting 0xWINID or a description, e.g. \'urgent\'.");
     }
     auto entry = clients_.find(win);
     if (entry != clients_.end()) {
@@ -136,6 +145,8 @@ Client* ClientManager::client(const string &identifier) {
 void ClientManager::completeEntries(Completion& complete)
 {
     complete.full("urgent");
+    complete.full("last-minimized");
+    complete.full("longest-minimized");
     for (const auto& it : clients_) {
         complete.full(Converter<WindowID>::str(it.first));
     }

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -227,6 +227,38 @@ void HSTag::focusFrame(shared_ptr<FrameLeaf> frameToFocus)
     needsRelayout_.emit();
 }
 
+/**
+ * @brief Find a minimized client on this tag
+ * @param if oldest is true, return the client that's minimized
+ * for the longest time, otherwise, return the most recently minimized client
+ * @return A pointer to the minimized client and nullptr
+ * if there is no minimized client on this tag.
+ */
+Client* HSTag::minimizedClient(bool oldest)
+{
+    Client* chosen = nullptr;
+    for (Client* c : floating_clients_) {
+        if (!c->minimized_()) {
+            continue;
+        }
+        // always pick c if chosen is still null
+        bool cIsBetter = chosen == nullptr;
+        if (oldest) {
+            // looking for the longest minimized client
+            // by the lazy `||` we are safe if chosen == nullptr
+            cIsBetter = cIsBetter || c->minimizedLastChange_ < chosen->minimizedLastChange_;
+        } else {
+            // looking for the most recently minimized client
+            // by the lazy `||` we are safe if chosen == nullptr
+            cIsBetter = cIsBetter || c->minimizedLastChange_ > chosen->minimizedLastChange_;
+        }
+        if (cIsBetter) {
+            chosen = c;
+        }
+    }
+    return chosen;
+}
+
 Client *HSTag::focusedClient()
 {
     if (floating_focused()) {

--- a/src/tag.h
+++ b/src/tag.h
@@ -55,6 +55,7 @@ public:
     bool hasVisibleFloatingClients() const;
     void foreachClient(std::function<void(Client*)> loopBody);
     void focusFrame(std::shared_ptr<FrameLeaf> frameToFocus);
+    Client* minimizedClient(bool oldest);
     Client* focusedClient();
     std::string oldName_;  // Previous name of the tag, in case it got renamed
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -183,11 +183,18 @@ def test_minimized_client_completions(hlwm):
 
 
 def test_minimized_client_invalid_arg(hlwm):
-    hlwm.call_xfail('jumpto longest-minimized') \
-        .expect_stderr('No client is minimized')
+    for _ in range(0, 2):
+        hlwm.call_xfail('jumpto longest-minimized') \
+            .expect_stderr('No client is minimized')
 
-    hlwm.call_xfail('jumpto last-minimized') \
-        .expect_stderr('No client is minimized')
+        hlwm.call_xfail('jumpto last-minimized') \
+            .expect_stderr('No client is minimized')
+
+        # the error does not change if we add another
+        # non-minimized floating client:
+        non_min, _ = hlwm.create_client()
+        hlwm.attr.clients[non_min].floating = True
+        hlwm.attr.clients[non_min].minimized = False
 
 
 @pytest.mark.parametrize("ewmhstate", [True, False])

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -160,6 +160,12 @@ def test_jumpto_longest_minimized_last_minimized(hlwm, noop, arg, expected_idx):
         hlwm.attr.clients[clients[2 + expected_idx]].minimized = True
         hlwm.attr.clients[another_client].minimized = False
 
+    # also minimize another client but put it on another tag:
+    hlwm.call('add othertag')
+    hlwm.call('rule tag=othertag')
+    on_other_tag, _ = hlwm.create_client()
+    hlwm.attr.clients[on_other_tag].minimized = True
+
     hlwm.call(['jumpto', arg])
 
     assert hlwm.attr.clients.focus.winid() == clients[expected_idx]

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -160,9 +160,14 @@ def test_jumpto_longest_minimized_last_minimized(hlwm, noop, arg, expected_idx):
         hlwm.attr.clients[clients[2 + expected_idx]].minimized = True
         hlwm.attr.clients[another_client].minimized = False
 
-    # also minimize another client but put it on another tag:
+    # Add some more clients that should not interfere with the minimized aliases:
+    # 1. add another floating client that's not minimized
+    other_float, _ = hlwm.create_client()
+    hlwm.attr.clients[other_float].floating = True
+    hlwm.attr.clients[other_float].minimized = False
+    # 2. minimize another client but put it on another tag:
     hlwm.call('add othertag')
-    hlwm.call('rule tag=othertag')
+    hlwm.call('rule once tag=othertag')
     on_other_tag, _ = hlwm.create_client()
     hlwm.attr.clients[on_other_tag].minimized = True
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,4 +1,5 @@
 import pytest
+import random
 from herbstluftwm.types import Rectangle
 
 
@@ -134,6 +135,48 @@ def test_urgent_jumpto_resets_urgent_flag(hlwm, x11, explicit_winid):
 
     assert hlwm.get_attr('clients.focus.winid') == winid
     assert hlwm.get_attr('clients.focus.urgent') == 'false'
+
+
+@pytest.mark.parametrize("arg,expected_idx", [
+    ('longest-minimized', 0),
+    ('last-minimized', -1),
+])
+@pytest.mark.parametrize("noop", [True, False])
+def test_jumpto_longest_minimized_last_minimized(hlwm, noop, arg, expected_idx):
+    clients = hlwm.create_clients(5)
+    another_client, _ = hlwm.create_client()
+
+    random.shuffle(clients)  # use a different order than creation order
+
+    if noop:
+        hlwm.attr.clients[clients[2]].minimized = False  # should not change anything
+
+    for c in clients:
+        hlwm.attr.clients[c].minimized = True
+
+    if noop:
+        # should not change anything if we re-write the attribute
+        # of some other client:
+        hlwm.attr.clients[clients[2 + expected_idx]].minimized = True
+        hlwm.attr.clients[another_client].minimized = False
+
+    hlwm.call(['jumpto', arg])
+
+    assert hlwm.attr.clients.focus.winid() == clients[expected_idx]
+    assert hlwm.attr.clients.focus.minimized() is False
+
+
+def test_minimized_client_completions(hlwm):
+    assert 'last-minimized' in hlwm.complete('jumpto')
+    assert 'longest-minimized' in hlwm.complete('jumpto')
+
+
+def test_minimized_client_invalid_arg(hlwm):
+    hlwm.call_xfail('jumpto longest-minimized') \
+        .expect_stderr('No client is minimized')
+
+    hlwm.call_xfail('jumpto last-minimized') \
+        .expect_stderr('No client is minimized')
 
 
 @pytest.mark.parametrize("ewmhstate", [True, False])

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -167,8 +167,8 @@ def test_completable_commands(hlwm, request, run_destructives):
     }
     allowed_stderr = re.compile('({})'.format('|'.join([
         'A (monitor|tag) with the name.*already exists',
-        'No such.*client: urgent',  # for apply_rules
-        'Could not find client "(urgent|)"',  # for drag
+        'No such.*client: (urgent|longest-minimized|last-minimized)',  # for apply_rules
+        'Could not find client "(urgent|longest-minimized|last-minimized|)"',  # for drag
         'No neighbour found',  # for resize and similar commands
         r'There are no \(non-minimized\) floating windows; cannot focus',  # for floating_focused
     ])))

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -136,7 +136,7 @@ def test_raise_lower_invalid_arg(hlwm):
         hlwm.call_xfail([command, 'foobar']) \
             .expect_stderr('Window id is not numeric') \
             .expect_stderr('; or:') \
-            .expect_stderr("expecting 0xWINID or 'urgent'")
+            .expect_stderr("expecting 0xWINID or a description")
 
         hlwm.call_xfail([command, '01two']) \
             .expect_stderr('invalid characters at position 2')

--- a/www/faq.txt
+++ b/www/faq.txt
@@ -457,4 +457,20 @@ fi
 ----
 
 
+Q: How can I unminimize all minimized clients?
+----------------------------------------------
+The following keybinding unminimizes all clients on the current tag:
+-----
+hc keybind Mod4-Ctrl-m \
+   substitute FOCUS "tags.focus.name" \
+   foreach CLIENT clients. \
+     sprintf MINATT "%c.minimized" CLIENT \
+     sprintf TAGATT "%c.tag" CLIENT and \
+       , compare MINATT "=" "true" \
+       , compare TAGATT "=" FOCUS \
+       , set_attr MINATT false
+-----
+It iterates over all clients, compares its +tag+ attribute sets the +minimized+
+attribute to +false+.
+
 


### PR DESCRIPTION
This adds client aliases for accessing the longest and the most recently
minimized client, and thus provides a native way to un-minimize clients
with key bindings (either in a lifo or fifo way). Thus, this also works
when minimizing clients via the panel and thus is more universal than
restricting to the unminimize.sh script (which was written for the lifo
unminimize).

With the new feature, we do not need the complicated binding for
unminimizing all clients anymore and we can move it to the faq (and
simplify it a bit).

This solves another feature request raised in the discussion of #1014.
