### PR TITLE
Update floating geometry if size hints change

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,12 @@ herbstluftwm NEWS -- History of user-visible changes
 See the link:MIGRATION[] file for changes that introduced incompatibility to
 older versions.
 
+Current git version
+-------------------
+
+  * Bug fixes:
+    - Update floating geometry if a client's size hints change
+
 Release 0.9.3 on 2021-05-15
 ---------------------------
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -343,10 +343,10 @@ void Client::resize_tiling(Rectangle rect, bool isFocused, bool minimalDecoratio
 
 /**
  * @brief Update the given window size according to the client's size hints
- * @param width
- * @param height
- * @param If set, always apply the size hints. If not set, only
- * apply the size hints if the according sizehints_/floating_sizehints_tiling_
+ * @param w width
+ * @param h height
+ * @param force If set, always apply the size hints. If not set, only
+ * apply the size hints if the according sizehints_floating_ / sizehints_tiling_
  * attribute is set
  * @return whether the size changed
  */

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -334,8 +334,16 @@ void Client::resize_tiling(Rectangle rect, bool isFocused, bool minimalDecoratio
     dec->resize_outline(rect, scheme);
 }
 
-// from dwm.c
-bool Client::applysizehints(int *w, int *h) {
+/**
+ * @brief Update the given window size according to the client's size hints
+ * @param width
+ * @param height
+ * @param If set, always apply the size hints. If not set, only
+ * apply the size hints if the according sizehints_/floating_sizehints_tiling_
+ * attribute is set
+ * @return whether the size changed
+ */
+bool Client::applysizehints(int* w, int* h, bool force) {
     bool baseismin;
 
     /* set minimum possible */
@@ -347,7 +355,7 @@ bool Client::applysizehints(int *w, int *h) {
     if (*w < WINDOW_MIN_WIDTH) {
         *w = WINDOW_MIN_WIDTH;
     }
-    bool sizehints = (this->is_client_floated() || this->pseudotile_)
+    bool sizehints = force || (this->is_client_floated() || this->pseudotile_)
                         ? this->sizehints_floating_
                         : this->sizehints_tiling_;
     if (sizehints) {
@@ -633,7 +641,7 @@ void Client::floatingGeometryChanged()
 {
     Rectangle geom = float_size_();
     if (sizehints_floating_()) {
-        applysizehints(&geom.width, &geom.height);
+        applysizehints(&geom.width, &geom.height, true);
         float_size_ = geom;
     }
     if (is_client_floated()) {

--- a/src/client.h
+++ b/src/client.h
@@ -118,7 +118,7 @@ public:
     void lower();
 
     void send_configure(bool force);
-    bool applysizehints(int *w, int *h);
+    bool applysizehints(int* w, int* h, bool force = false);
     void updatesizehints();
 
     void set_visible(bool visible);

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -361,7 +361,7 @@ void ClientManager::setSimpleClientAttributes(Client* client, const ClientChange
         // do not simply copy the geometry to the attribute
         // but possibly apply the size hints:
         if (client->sizehints_floating_()) {
-            client->applysizehints(&geo.width, &geo.height);
+            client->applysizehints(&geo.width, &geo.height, true);
         }
         client->float_size_ = geo;
     }

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -537,6 +537,9 @@ void XMainLoop::propertynotify(XPropertyEvent* ev) {
                 client->update_wm_hints();
             } else if (ev->atom == XA_WM_NORMAL_HINTS) {
                 client->updatesizehints();
+                Rectangle geom = client->float_size_;
+                client->applysizehints(&geom.width, &geom.height, true);
+                client->float_size_ = geom;
                 Monitor* m = find_monitor_with_tag(client->tag());
                 if (m) {
                     m->applyLayout();


### PR DESCRIPTION
If the size hints of a client change, then its floating geometry must be
updated. Also, this must happen even if the client is not floated at the
moment. To accomplish the latter, the applysizehints() function is
extended by an optional `force` parameter. The new test case verifies
both the floating and non-floating case.

This fixes #1322.