### PR TITLE
Set X11 property for client's floating state

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,12 @@ herbstluftwm NEWS -- History of user-visible changes
 See the link:MIGRATION[] file for changes that introduced incompatibility to
 older versions.
 
+Current git version
+-------------------
+
+  * New client attribute 'floating_effectively' and associated X11 properties
+    'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'
+
 Release 0.9.3 on 2021-05-15
 ---------------------------
 

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1635,8 +1635,8 @@ independent from their indices and can be modified using the *raise_monitor*
 command. The current stack is illustrated by the *stack* command.
 
 [[EWMH]]
-EWMH
-----
+EWMH and X11 Properties
+-----------------------
 As far as possible, herbstluftwm tries to be EWMH compliant. That includes:
 
   - Information about tag names and client lists is provided.
@@ -1644,6 +1644,10 @@ As far as possible, herbstluftwm tries to be EWMH compliant. That includes:
     other windows.
   - Client requests like getting focused are only processed if the setting
     'focus_stealing_prevention' is disabled.
+
+Moreover, herbstluftwm sets the X11 properties 'HLWM_FLOATING_WINDOW' and
+'HLWM_TILING_WINDOW' to indicate whether a window is in floating or tiling mode,
+that is, the value of the client's 'floating_effectively' attribute.
 
 ENVIRONMENT VARIABLES
 ---------------------

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -42,6 +42,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , floating_(this,  "floating", false)
     , fullscreen_(this,  "fullscreen", false)
     , minimized_(this,  "minimized", false)
+    , floating_effectively_(this,  "floating_effectively", false)
     , title_(this,  "title", "")
     , tag_str_(this,  "tag", &Client::tagName)
     , parent_frame_(*this,  "parent_frame", &Client::parentFrame)
@@ -133,7 +134,13 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     minimized_.setDoc(
                 "whether this client is minimized (also called "
                 "iconified).");
-    floating_.setDoc("whether this client is floated above the tiled clients.");
+    floating_.setDoc("whether this client is set as a (single-window) floating client. "
+                     "If set, the client is floated above the tiled clients.");
+    floating_effectively_.setDoc(
+                "whether this client is in the floating state currently. "
+                "This is the case if the client\'s tag is set to floating mode or "
+                "if the client itself is set as floating. Its value is also indicated "
+                "via the X11 properties HLWM_FLOATING_WINDOW and HLWM_TILING_WINDOW.");
     pseudotile_.setDoc(
                 "if activated, the client always has its floating "
                 "window size, even if it is in tiling mode.");

--- a/src/client.h
+++ b/src/client.h
@@ -65,6 +65,7 @@ public:
     Attribute_<bool> floating_;
     Attribute_<bool> fullscreen_;
     Attribute_<bool> minimized_;
+    Attribute_<bool> floating_effectively_;
     Attribute_<std::string> title_;  // or also called window title; this is never NULL
     DynAttribute_<std::string> tag_str_;
     DynChild_<FrameLeaf> parent_frame_;

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -163,6 +163,7 @@ void ClientManager::add(Client* client)
         this->clientStateChanged.emit(client);
     });
     addChild(client, client->window_id_str);
+    clientAdded.emit(client);
 }
 
 void ClientManager::setDragged(Client* client) {

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -51,6 +51,7 @@ public:
 
     Signal_<HSTag*> needsRelayout;
     Signal_<Client*> clientStateChanged; //! floating or minimized changed
+    Signal_<Client*> clientAdded;
     Link_<Client> focus;
     Link_<Client> dragged;
 

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -148,6 +148,7 @@ public:
     void updateActiveWindow(Window win);
     void updateCurrentDesktop();
     void updateWindowState(Client* client);
+    void updateFloatingState(Client* client);
     void updateFrameExtents(Window win, int left, int right, int top, int bottom);
     bool isWindowStateSet(Window win, Atom hint);
     bool isFullscreenSet(Window win);
@@ -186,6 +187,8 @@ private:
     void readInitialEwmhState();
     Atom wmatom(WM proto);
     Atom wmatom_[(int)WM::Last] = {};
+    Atom hlwmFloatingWindow_; //! x11 property set on floated clients
+    Atom hlwmTilingWindow_; //! x11 property set on tiled clients
 
     //! array with Window-IDs in initial mapping order for _NET_CLIENT_LIST
     std::vector<Window> netClientList_;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -152,6 +152,7 @@ void HSTag::applyClientState(Client* client)
     if (!hasVisibleFloatingClients()) {
         floating_focused = false;
     }
+    client->floating_effectively_ = floating() || client->floating_();
     bool client_becomes_visible = !client->minimized_() && this->visible();
     if (client_becomes_visible) {
         needsRelayout_.emit();
@@ -290,6 +291,7 @@ void HSTag::insertClient(Client* client, string frameIndex, bool focus)
         }
         target->insertClient(client, focus);
     }
+    client->floating_effectively_ = floating() || client->floating_();
 }
 
 void HSTag::insertClientSlice(Client* client)
@@ -570,6 +572,9 @@ void HSTag::onGlobalFloatingChange(bool newState)
             stack->sliceRemoveLayer(slice, LAYER_FLOATING);
         }
     }
+    frame->root_->foreachClient([newState] (Client* client) {
+        client->floating_effectively_ = newState || client->floating_();
+    });
     needsRelayout_.emit();
 }
 

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -308,6 +308,16 @@ void XConnection::setPropertyCardinal(Window w, Atom property, const vector<long
                     (unsigned char*)(value.data()), value.size());
 }
 
+/**
+ * @brief wrapper around XDeleteProperty
+ * @param w
+ * @param property
+ */
+void XConnection::deleteProperty(Window w, Atom property)
+{
+    XDeleteProperty(m_display, w, property);
+}
+
 std::experimental::optional<Window> XConnection::getTransientForHint(Window win)
 {
     Window master;

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -53,6 +53,7 @@ public:
     void setPropertyString(Window w, Atom property, const std::vector<std::string>& value);
     void setPropertyWindow(Window w, Atom property, const std::vector<Window>& value);
     void setPropertyCardinal(Window w, Atom property, const std::vector<long>& value);
+    void deleteProperty(Window w, Atom property);
     std::experimental::optional<Window> getTransientForHint(Window win);
     std::vector<Window> queryTree(Window window);
     static void setExitOnError(bool exitOnError);


### PR DESCRIPTION
The purpose of this change is to indicate a clients effective floating
state via X11 properties to make use of it in rules of X11 compositors.

The change happens in two steps: The first step is a new read-only
attribute `floating_effectively` which combines the client's single
window floating state with its tag's floating state. This attribute is
tested semantically. The second step is simply a signal connection that
sets or removes the X11 properties HLWM_FLOATING_WINDOW and
HLWM_TILING_WINDOW, depending on the value of `floating_effectively`.

This closes #1172.