### PR TITLE
Add client attribute 'decoration_geometry'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ Current git version
 
   * New client attribute 'floating_effectively' and associated X11 properties
     'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'
+  * New read-only client attribute 'decoration_geometry'.
 
 Release 0.9.3 on 2021-05-15
 ---------------------------

--- a/python/herbstluftwm/types.py
+++ b/python/herbstluftwm/types.py
@@ -75,6 +75,10 @@ class Rectangle:
         """the top left corner of the rectangle"""
         return Point(self.x, self.y)
 
+    def bottomright(self) -> Point:
+        """the bottom right corner of the rectangle"""
+        return Point(self.x + self.width, self.y + self.height)
+
     def center(self) -> Point:
         """the center of the rectangle, forced to integer coordinates"""
         return self.topleft() + self.size() // 2

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -59,6 +59,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , window_class_(this, "class", &Client::getWindowClass)
     , window_instance_(this, "instance", &Client::getWindowInstance)
     , content_geometry_(this, "content_geometry", {})
+    , decoration_geometry_(this, "decoration_geometry", &Client::decorationGeometry)
     , manager(cm)
     , theme(*cm.theme)
     , settings(*cm.settings)
@@ -159,8 +160,12 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
                 "the geometry of the application content, that is, not taking "
                 "the decoration into account. "
                 "Also, this is the last window geometry that "
-                "was reported to the client application."
-     );
+                "was reported to the client application.");
+    decoration_geometry_.setDoc(
+                "the geometry of the client, taking the window decoration "
+                "into account. "
+                "The position is the global window position, that is, "
+                "relative to the top left corner of the entire screen");
 }
 
 void Client::init_from_X() {
@@ -646,6 +651,11 @@ void Client::floatingGeometryChanged()
     if (is_client_floated()) {
         needsRelayout.emit(tag());
     }
+}
+
+Rectangle Client::decorationGeometry()
+{
+    return dec->last_outer();
 }
 
 string Client::getWindowClass()

--- a/src/client.h
+++ b/src/client.h
@@ -82,6 +82,7 @@ public:
     DynAttribute_<std::string> window_class_;
     DynAttribute_<std::string> window_instance_;
     Attribute_<Rectangle> content_geometry_;
+    DynAttribute_<Rectangle> decoration_geometry_;
 
 public:
     void init_from_X();
@@ -133,6 +134,7 @@ public:
     void updateEwmhState();
 private:
     void floatingGeometryChanged();
+    Rectangle decorationGeometry();
     std::string getWindowClass();
     std::string getWindowInstance();
     std::string triggerRelayoutMonitor();


### PR DESCRIPTION
This adds a new read-only client attribute `decoration_geometry` that I
would have liked to have for many test cases.