### PR TITLE
Move IRC channel to Libera

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -65,7 +65,7 @@ list[2] or via the irc[3].
 
 [1] https://github.com/herbstluftwm/herbstluftwm
 [2] hlwm@lists.herbstluftwm.org +
-[3] #herbstluftwm on irc.freenode.net
+[3] #herbstluftwm on irc.libera.chat
 
 Mailing list
 ------------

--- a/INSTALL
+++ b/INSTALL
@@ -37,7 +37,7 @@ https://github.com/herbstluftwm/herbstluftwm/issues or contact the mailing list.
 
 Mailing list: hlwm@lists.herbstluftwm.org
 
-For instant help join the IRC channel: #herbstluftwm on irc.freenode.net
+For instant help join the IRC channel: #herbstluftwm on irc.libera.chat
 
 ==== Installation steps ====
 If you are using a system with a package manager, we recommend to install via

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -27,7 +27,7 @@ particular the http://herbstluftwm.org/tutorial.html[herbstluftwm tutorial]
 for the first steps (also available as `man herbstluftwm-tutorial` after
 installing herbstluftwm on your system).
 
-You are welcome to join the IRC channel `#herbstluftwm` on `irc.freenode.net`.
+You are welcome to join the IRC channel `#herbstluftwm` on `irc.libera.chat`.
 
 Installation
 ------------

--- a/doc/herbstclient.txt
+++ b/doc/herbstclient.txt
@@ -85,7 +85,7 @@ See the *herbstluftwm* Github issues: https://github.com/herbstluftwm/herbstluft
 
 COMMUNITY
 ---------
-Feel free to join the IRC channel '#herbstluftwm' on 'irc.freenode.net'.
+Feel free to join the IRC channel '#herbstluftwm' on 'irc.libera.chat'.
 
 AUTHOR
 ------

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1672,7 +1672,7 @@ See the *herbstluftwm* Github issues: https://github.com/herbstluftwm/herbstluft
 
 COMMUNITY
 ---------
-Feel free to join the IRC channel '#herbstluftwm' on 'irc.freenode.net'.
+Feel free to join the IRC channel '#herbstluftwm' on 'irc.libera.chat'.
 
 AUTHOR
 ------

--- a/www/index.txt
+++ b/www/index.txt
@@ -46,7 +46,7 @@ seen link:herbstluftwm.html[online].
 
 Community & Support
 -------------------
-You are welcome to join the IRC channel +#herbstluftwm+ on +irc.freenode.net+
+You are welcome to join the IRC channel +#herbstluftwm+ on +irc.libera.chat+
 for asking question or simply to hang out with fellow herbstluftwm users and developers.
 There is also a community on reddit
 link:https://www.reddit.com/r/herbstluftwm[r/herbstluftwm].


### PR DESCRIPTION
Due to the recent policies on freenode, we move our irc channel to
libera.chat. Some irc channels on freenode mentioning 'libera.chat' in
their topic were closed forcefully.
