### PR TITLE
Move text drawing to own function

### DIFF
--- a/src/decoration.h
+++ b/src/decoration.h
@@ -8,6 +8,7 @@
 #include "x11-types.h"
 
 class Client;
+class FontData;
 class Settings;
 class DecorationScheme;
 class XConnection;
@@ -40,6 +41,9 @@ private:
     void redrawPixmap();
     void updateFrameExtends();
     unsigned long get_client_color(Color color);
+
+    void drawText(Pixmap& pix, GC& gc, const FontData& fontData,
+                  const Color& color, Point2D position, const std::string& text);
 
     Window                  decwin = 0; // the decoration window
     const DecorationScheme* last_scheme = {};


### PR DESCRIPTION
Encapsulate the text drawing in a separate function, the existing test
cases should cover most of it.