### PR TITLE
Shorten window title to decoration width

### DIFF
--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -441,7 +441,6 @@ void Decoration::drawText(Pixmap& pix, GC& gc, const FontData& fontData, const C
     while (textLen > 0 && fontData.textwidth(text, textLen) > width) {
         textLen--;
     }
-    int w = fontData.textwidth(text, textLen);
     if (fontData.xftFont_) {
         Visual* xftvisual = visual ? visual : xcon.visual();
         Colormap xftcmap = colormap ? colormap : xcon.colormap();

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -43,7 +43,8 @@ private:
     unsigned long get_client_color(Color color);
 
     void drawText(Pixmap& pix, GC& gc, const FontData& fontData,
-                  const Color& color, Point2D position, const std::string& text);
+                  const Color& color, Point2D position, const std::string& text,
+                  int width);
 
     Window                  decwin = 0; // the decoration window
     const DecorationScheme* last_scheme = {};

--- a/src/fontdata.cpp
+++ b/src/fontdata.cpp
@@ -81,7 +81,7 @@ void FontData::initFromStr(const string& source)
  * @param glyphs Only consider that many glyphs from the given text
  * @return The width in pixels
  */
-int FontData::textwidth(const std::string& text, size_t len) const
+int FontData::textwidth(const string& text, size_t len) const
 {
     if (!s_xconnection) {
         return 0;

--- a/src/fontdata.cpp
+++ b/src/fontdata.cpp
@@ -78,7 +78,8 @@ void FontData::initFromStr(const string& source)
 /**
  * @brief compute the with of the given text
  * @param text The text
- * @param glyphs Only consider that many glyphs from the given text
+ * @param len Only consider that many glyphs or bytes from the given text,
+ *            depending on the concrete font type
  * @return The width in pixels
  */
 int FontData::textwidth(const string& text, size_t len) const
@@ -103,5 +104,5 @@ int FontData::textwidth(const string& text, size_t len) const
     if (xFontStruct_) {
         return XTextWidth(xFontStruct_, text.c_str(), len);
     }
-    return -1;
+    return 0;
 }

--- a/src/fontdata.cpp
+++ b/src/fontdata.cpp
@@ -74,3 +74,34 @@ void FontData::initFromStr(const string& source)
                 string("cannot allocate font \'") + source + "\'");
     }
 }
+
+/**
+ * @brief compute the with of the given text
+ * @param text The text
+ * @param glyphs Only consider that many glyphs from the given text
+ * @return The width in pixels
+ */
+int FontData::textwidth(const std::string& text, size_t len) const
+{
+    if (!s_xconnection) {
+        return 0;
+    }
+    if (xftFont_) {
+        XGlyphInfo info;
+        XftTextExtentsUtf8(s_xconnection->display(),
+                           xftFont_,
+                           const_cast<FcChar8*>(reinterpret_cast<const FcChar8*>(text.data())),
+                           len,
+                           &info);
+        return info.xOff;
+    }
+    if (xFontSet_) {
+        XRectangle logical;
+        Xutf8TextExtents(xFontSet_, text.c_str(), static_cast<int>(len), nullptr, &logical);
+        return logical.width;
+    }
+    if (xFontStruct_) {
+        return XTextWidth(xFontStruct_, text.c_str(), len);
+    }
+    return -1;
+}

--- a/src/fontdata.h
+++ b/src/fontdata.h
@@ -19,6 +19,7 @@ public:
     ~FontData();
 
     void initFromStr(const std::string& source);
+    int textwidth(const std::string& text, size_t len) const;
 
     struct _XftFont* xftFont_ = nullptr;
     XFontStruct* xFontStruct_ = nullptr;

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -149,7 +149,6 @@ def test_title_does_not_exceed_width(hlwm, x11, font):
         utf8titles = []
 
     for title in [w * '=', w * '|'] + utf8titles:
-        print("title = " + title)
         img = screenshot_with_title(x11, handle, title)
         # verify that the title does not span too wide to the
         # left or to the right:

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -1,4 +1,5 @@
 from conftest import RawImage
+from conftest import HlwmBridge
 import pytest
 
 font_pool = [
@@ -69,8 +70,13 @@ def screenshot_with_title(x11, win_handle, title):
     """ set the win_handle's window title and then
     take a screenshot
     """
-    win_handle.set_wm_name(title)
+    x11.set_property_textlist('_NET_WM_NAME', [title], window=win_handle)
     x11.sync_with_hlwm()
+    # double check that hlwm has updated the client's title:
+    winid = x11.winid_str(win_handle)
+    hlwm = HlwmBridge.INSTANCE
+    assert hlwm.attr.clients[winid].title() == title
+    # then, take the screenshot:
     return x11.decoration_screenshot(win_handle)
 
 
@@ -115,6 +121,59 @@ def test_title_different_letters_are_drawn(hlwm, x11, font):
 
     # then the number of pixels should have increased
     assert count1 < count2
+
+
+@pytest.mark.parametrize("font", font_pool)
+def test_title_does_not_exceed_width(hlwm, x11, font):
+    font_color = (255, 0, 0)  # a color available everywhere
+    bw = 30
+    hlwm.attr.theme.color = 'black'
+    hlwm.attr.theme.title_color = RawImage.rgb2string(font_color)
+    hlwm.attr.theme.title_height = 14
+    hlwm.attr.theme.padding_top = 0
+    hlwm.attr.theme.padding_left = 0
+    hlwm.attr.theme.padding_right = 0
+    hlwm.attr.theme.border_width = bw
+    hlwm.attr.theme.title_font = font
+    handle, winid = x11.create_client()
+
+    # set a title that is too wide to be displayed in its entirety:
+    w = hlwm.attr.clients[winid].decoration_geometry().width
+
+    if font[0] != '-':
+        # for xft fonts, also test utf8 window titles
+        utf8titles = [w * '♥']
+    else:
+        # for plain X fonts, it does not seem to work in tox/pytest
+        # (but strangely, it works in a manual Xephyr session)
+        utf8titles = []
+
+    for title in [w * '=', w * '|'] + utf8titles:
+        print("title = " + title)
+        img = screenshot_with_title(x11, handle, title)
+        # verify that the title does not span too wide to the
+        # left or to the right:
+        # find leftmost non-black pixel:
+        leftmost_font_x = None
+        for x in range(0, w):
+            for y in range(0, 14):  # only verify top `title_height`-many pixels
+                if img.pixel(x, y) != (0, 0, 0):
+                    leftmost_font_x = x
+                    break
+            if leftmost_font_x is not None:
+                break
+        # find rightmost non-black pixel:
+        rightmost_font_x = None
+        for x in range(w - 1, 0, -1):
+            for y in range(0, 14):  # only verify top `title_height`-many pixels
+                if img.pixel(x, y) != (0, 0, 0):
+                    rightmost_font_x = x
+                    break
+            if rightmost_font_x is not None:
+                break
+
+        assert leftmost_font_x >= bw
+        assert rightmost_font_x < bw + hlwm.attr.clients[winid].content_geometry().width
 
 
 @pytest.mark.parametrize("frame_bg_transparent", ['on', 'off'])


### PR DESCRIPTION
Shorten a client's title such that it is at most as wide as the window
content, i.e. such that it does not reach into window border.

The new tests verify this by looking for the leftmost and rightmost
pixels belonging to the title. Unfortunately, proper utf8 characters
work in the test suite only with xft fonts. But in a manual xephyr
session, the plain X fonts also work with utf8 characters.