### PR TITLE
Update cursor shape and resize accordingly

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ Current git version
   * New client attribute 'floating_effectively' and associated X11 properties
     'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'
   * New read-only client attribute 'decoration_geometry'.
+  * The cursor shape now indicates resize options.
   * Bug fixes:
     - Update floating geometry if a client's size hints change
 

--- a/src/client.h
+++ b/src/client.h
@@ -15,6 +15,7 @@
 #include "x11-types.h"
 
 class Decoration;
+class ResizeAction;
 class DecTriple;
 class Ewmh;
 class FrameLeaf;
@@ -122,6 +123,7 @@ public:
     void send_configure(bool force);
     bool applysizehints(int* w, int* h, bool force = false);
     void updatesizehints();
+    ResizeAction possibleResizeActions();
 
     void set_visible(bool visible);
 

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -197,8 +197,8 @@ void Decoration::updateResizeAreaCursors()
         ResizeAction act = resizeAreaInfo(i);
         act = act * client_->possibleResizeActions();
         auto cursor = act.toCursorShape();
-        if (cursor == XC_left_ptr) {
-            XDefineCursor(xcon.display(), win, XCreateFontCursor(xcon.display(), cursor));
+        if (cursor.has_value()) {
+            XDefineCursor(xcon.display(), win, XCreateFontCursor(xcon.display(), cursor.value()));
         } else {
             XUndefineCursor(xcon.display(), win);
         }
@@ -600,7 +600,7 @@ Rectangle Decoration::resizeAreaGeometry(size_t idx, int borderWidth, int width,
  * to the ResizeAction or the default cursor shape
  * @return
  */
-unsigned int ResizeAction::toCursorShape() const
+std::experimental::optional<unsigned int> ResizeAction::toCursorShape() const
 {
     if (top) {
         if (left) {
@@ -624,7 +624,7 @@ unsigned int ResizeAction::toCursorShape() const
         } else if (right) {
             return XC_right_side;
         } else {
-            return XC_left_ptr;
+            return {};
         }
     }
 }

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -4,9 +4,9 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/cursorfont.h>
+#include <algorithm>
 #include <limits>
 #include <vector>
-#include <algorithm>
 
 #include "client.h"
 #include "ewmh.h"

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -119,7 +119,7 @@ void Decoration::createWindow() {
     resizeAttr.colormap = xcon.usesTransparency() ? xcon.colormap() : dec->colormap;
     resizeAttr.background_pixel = BlackPixel(display, xcon.screen());
     resizeAttr.border_pixel = BlackPixel(display, xcon.screen());
-    for (size_t i = 0; i < 12; i++) {
+    for (size_t i = 0; i < resizeAreaSize; i++) {
         Window& win = resizeArea[i];
         win = XCreateWindow(display, dec->decwin, 0, 0, 30, 30, 0,
                             0, InputOnly, xcon.visual(),
@@ -192,7 +192,7 @@ Rectangle Decoration::inner_to_outer(Rectangle rect) {
 void Decoration::updateResizeAreaCursors()
 {
     XConnection& xcon = xconnection();
-    for (size_t i = 0; i < 12; i++) {
+    for (size_t i = 0; i < resizeAreaSize; i++) {
         Window& win = resizeArea[i];
         ResizeAction act = resizeAreaInfo(i);
         act = act * client_->possibleResizeActions();
@@ -333,7 +333,7 @@ void Decoration::resize_outline(Rectangle outline, const DecorationScheme& schem
         bw = last_scheme->border_width();
     }
     Rectangle areaGeo;
-    for (size_t i = 0; i < 12; i++) {
+    for (size_t i = 0; i < resizeAreaSize; i++) {
         areaGeo = resizeAreaGeometry(i, bw, outline.width, outline.height);
         XMoveResizeWindow(xcon.display(), resizeArea[i],
                           areaGeo.x, areaGeo.y,

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -558,6 +558,11 @@ ResizeAction Decoration::resizeAreaInfo(size_t idx)
 Rectangle Decoration::resizeAreaGeometry(size_t idx, int borderWidth, int width, int height)
 {
     if (idx < 6) {
+        if (borderWidth <= 0) {
+            // ensure that the rectangles returned are not empty
+            // i.e. that they have non-zero height and width
+            borderWidth = 1;
+        }
         int w3 = width / 3;
         Rectangle geo;
         // horizontal segments:

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -49,7 +49,6 @@ Decoration::Decoration(Client* client, Settings& settings)
     : client_(client),
       settings_(settings)
 {
-    memset(resizeArea, 0, sizeof(resizeArea));
 }
 
 void Decoration::createWindow() {

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -197,7 +197,7 @@ void Decoration::updateResizeAreaCursors()
         ResizeAction act = resizeAreaInfo(i);
         act = act * client_->possibleResizeActions();
         auto cursor = act.toCursorShape();
-        if (cursor >= 0) {
+        if (cursor == XC_left_ptr) {
             XDefineCursor(xcon.display(), win, XCreateFontCursor(xcon.display(), cursor));
         } else {
             XUndefineCursor(xcon.display(), win);
@@ -597,7 +597,7 @@ Rectangle Decoration::resizeAreaGeometry(size_t idx, int borderWidth, int width,
 
 /**
  * @brief Return the x11 cursor shaper corresponding
- * to the ResizeAction or return -1 if there is no cursor
+ * to the ResizeAction or the default cursor shape
  * @return
  */
 unsigned int ResizeAction::toCursorShape() const
@@ -624,7 +624,7 @@ unsigned int ResizeAction::toCursorShape() const
         } else if (right) {
             return XC_right_side;
         } else {
-            return -1;
+            return XC_left_ptr;
         }
     }
 }

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -49,6 +49,7 @@ Decoration::Decoration(Client* client, Settings& settings)
     : client_(client),
       settings_(settings)
 {
+    memset(resizeArea, 0, sizeof(resizeArea));
 }
 
 void Decoration::createWindow() {

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -8,6 +8,7 @@
 #include "x11-types.h"
 
 class Client;
+class FontData;
 class Settings;
 class DecorationScheme;
 class XConnection;
@@ -40,6 +41,9 @@ private:
     void redrawPixmap();
     void updateFrameExtends();
     unsigned long get_client_color(Color color);
+
+    void drawText(Pixmap& pix, GC& gc, const FontData& fontData,
+                  const Color& color, Point2D position, const std::string& text);
 
     Window                  decwin = 0; // the decoration window
     const DecorationScheme* last_scheme = {};

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -88,7 +88,7 @@ private:
     Window                  bgwin = 0;
     /** 4 sides with 3 sections each.
      */
-    Window                  resizeArea[4 * 3];
+    Window                  resizeArea[4 * 3] = {};
     static ResizeAction resizeAreaInfo(size_t idx);
     Rectangle resizeAreaGeometry(size_t idx, int borderWidth, int width, int height);
 private:

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -90,9 +90,6 @@ private:
     Window                  resizeArea[4 * 3];
     static ResizeAction resizeAreaInfo(size_t idx);
     Rectangle resizeAreaGeometry(size_t idx, int borderWidth, int width, int height);
-    Window                  resizeTopLeft;
-    Window                  resizeTop;
-    Window                  resizeTopRight;
 private:
     Client* client_; // the client to decorate
     Settings& settings_;

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -4,6 +4,7 @@
 #include <X11/X.h>
 #include <map>
 
+#include "optional.h"
 #include "rectangle.h"
 #include "x11-types.h"
 
@@ -22,7 +23,7 @@ public:
     operator bool() const {
         return left || right || top || bottom;
     }
-    unsigned int toCursorShape() const;
+    std::experimental::optional<unsigned int> toCursorShape() const;
     ResizeAction operator*(const ResizeAction& other) {
         ResizeAction act;
         act.left = left && other.left;

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -87,9 +87,9 @@ private:
     // especially not repainting or background filling to avoid flicker on
     // unmap
     Window                  bgwin = 0;
-    /** 4 sides with 3 sections each.
-     */
-    Window                  resizeArea[4 * 3] = {};
+    /** 12 = 4 sides with 3 sections each. */
+    static constexpr size_t resizeAreaSize = 4 * 3;
+    Window                  resizeArea[resizeAreaSize] = {};
     static ResizeAction resizeAreaInfo(size_t idx);
     Rectangle resizeAreaGeometry(size_t idx, int borderWidth, int width, int height);
 private:

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -13,6 +13,27 @@ class Settings;
 class DecorationScheme;
 class XConnection;
 
+class ResizeAction {
+public:
+    bool left = false;
+    bool right = false;
+    bool top = false;
+    bool bottom = false;
+    operator bool() const {
+        return left || right || top || bottom;
+    }
+    unsigned int toCursorShape() const;
+    ResizeAction operator*(const ResizeAction& other) {
+        ResizeAction act;
+        act.left = left && other.left;
+        act.right = right && other.right;
+        act.top = top && other.top;
+        act.bottom = bottom && other.bottom;
+        return act;
+    }
+};
+
+
 class Decoration {
 public:
     Decoration(Client* client_, Settings& settings_);
@@ -33,7 +54,9 @@ public:
     Rectangle last_outer() const { return last_outer_rect; }
     Rectangle inner_to_outer(Rectangle rect);
 
-    bool positionTriggersResize(Point2D p);
+    void updateResizeAreaCursors();
+
+    ResizeAction positionTriggersResize(Point2D p);
 
 private:
     static Visual* check_32bit_client(Client* c);
@@ -62,6 +85,14 @@ private:
     // especially not repainting or background filling to avoid flicker on
     // unmap
     Window                  bgwin = 0;
+    /** 4 sides with 3 sections each.
+     */
+    Window                  resizeArea[4 * 3];
+    static ResizeAction resizeAreaInfo(size_t idx);
+    Rectangle resizeAreaGeometry(size_t idx, int borderWidth, int width, int height);
+    Window                  resizeTopLeft;
+    Window                  resizeTop;
+    Window                  resizeTopRight;
 private:
     Client* client_; // the client to decorate
     Settings& settings_;

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -484,7 +484,7 @@ void Ewmh::handleClientMessage(XClientMessageEvent* me) {
                 }
             } else {
                 // anything else is a resize
-                root_->mouse->mouse_initiate_resize(client, {});
+                root_->mouse->mouse_initiate_resize(client, vector<string>());
             }
             break;
         }

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -546,6 +546,21 @@ bool FrameLeaf::split(SplitAlign alignment, FixPrecDec fraction, size_t children
     return true;
 }
 
+/**
+ * @brief FrameLeaf::clientIndex
+ * @param client
+ * @return the index of the given client in this frame or -1
+ */
+int FrameLeaf::clientIndex(Client* client)
+{
+    for (size_t i = 0; i < clients.size(); i++) {
+        if (clients[i] == client) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
 
 void FrameSplit::swapChildren() {
     swap(a_,b_);
@@ -633,27 +648,33 @@ shared_ptr<Frame> FrameLeaf::neighbour(Direction direction) {
     return other;
 }
 
-//! finds the neighbour of the selected client in the specified direction
-// within the frame
-//! returns its index or -1 if there is none
-int FrameLeaf::getInnerNeighbourIndex(Direction direction) {
+/**
+ * @brief finds the neighbour of the selected client in the specified direction within the frame
+ * @param direction the direction
+ * @param startIndex the window whose neighbour shall be found or -1 for the selected window
+ * @return the index of the neighbour window or -1 if there is no neighbour
+ */
+int FrameLeaf::getInnerNeighbourIndex(Direction direction, int startIndex) {
+    if (startIndex < 0) {
+        startIndex = selection;
+    }
     int index = -1;
     int count = clientCount();
     switch (getLayout()) {
         case LayoutAlgorithm::vertical:
             if (direction == Direction::Down) {
-                index = selection + 1;
+                index = startIndex + 1;
             }
             if (direction == Direction::Up) {
-                index = selection - 1;
+                index = startIndex - 1;
             }
             break;
         case LayoutAlgorithm::horizontal:
             if (direction == Direction::Right) {
-                index = selection + 1;
+                index = startIndex + 1;
             }
             if (direction == Direction::Left) {
-                index = selection - 1;
+                index = startIndex - 1;
             }
             break;
         case LayoutAlgorithm::max:
@@ -664,26 +685,26 @@ int FrameLeaf::getInnerNeighbourIndex(Direction direction) {
             if (cols == 0) {
                 break;
             }
-            int r = selection / cols;
-            int c = selection % cols;
+            int r = startIndex / cols;
+            int c = startIndex % cols;
             switch (direction) {
                 case Direction::Down:
-                    index = selection + cols;
+                    index = startIndex + cols;
                     if (g_settings->gapless_grid() && index >= count && r == (rows - 2)) {
                         // if grid is gapless and we're in the second-last row
                         // then it means last client is below us
                         index = count - 1;
                     }
                     break;
-                case Direction::Up: index = selection - cols; break;
+                case Direction::Up: index = startIndex - cols; break;
                 case Direction::Right:
                     if (c < cols - 1) {
-                        index = selection + 1;
+                        index = startIndex + 1;
                     }
                     break;
                 case Direction::Left:
                     if (c > 0) {
-                        index = selection - 1;
+                        index = startIndex - 1;
                     }
                     break;
             }

--- a/src/layout.h
+++ b/src/layout.h
@@ -122,6 +122,7 @@ public:
     void setLayout(LayoutAlgorithm l) { layout = l; }
     int getSelection() { return selection; }
     size_t clientCount() { return clients.size(); }
+    int clientIndex(Client* client);
     std::shared_ptr<Frame> neighbour(Direction direction);
     std::vector<Client*> removeAllClients();
 
@@ -130,7 +131,7 @@ public:
 
     friend class Frame;
     void setVisible(bool visible);
-    int getInnerNeighbourIndex(Direction direction);
+    int getInnerNeighbourIndex(Direction direction, int startIndex = -1);
     DynAttribute_<int> client_count_;
     DynAttribute_<int> selectionAttr_;
     DynAttribute_<LayoutAlgorithm> algorithmAttr_;

--- a/src/mousedraghandler.cpp
+++ b/src/mousedraghandler.cpp
@@ -88,6 +88,22 @@ void MouseDragHandlerFloating::mouse_function_resize(Point2D newCursorPos) {
         left = true;
         x_diff *= -1;
     }
+    if (lockWidth) {
+        x_diff = 0;
+        if (winDragClient_->mina_ > 0 || winDragClient_->maxa_ > 0) {
+            // if the client requires an aspect ratio, (e.g. mpv)
+            // then just keep current aspect ratio of the window
+            x_diff = (y_diff * winDragStart_.width) / winDragStart_.height;
+        }
+    }
+    if (lockHeight) {
+        y_diff = 0;
+        if (winDragClient_->mina_ > 0 || winDragClient_->maxa_ > 0) {
+            // if the client requires an aspect ratio, (e.g. mpv)
+            // then just keep current aspect ratio of the window
+            y_diff = (x_diff * winDragStart_.height) / winDragStart_.width;
+        }
+    }
     // avoid an overflow
     int new_width  = winDragClient_->float_size_->width + x_diff;
     int new_height = winDragClient_->float_size_->height + y_diff;

--- a/src/mousedraghandler.h
+++ b/src/mousedraghandler.h
@@ -61,6 +61,8 @@ public:
     void mouse_function_move(Point2D newCursorPos);
     void mouse_function_resize(Point2D newCursorPos);
     void mouse_function_zoom(Point2D newCursorPos);
+    bool lockWidth = false; // when resizing, do not modify the width
+    bool lockHeight = false; // when resizing, do not modify the height
 private:
     void assertDraggingStillSafe();
 

--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -203,8 +203,8 @@ string MouseManager::mouse_initiate_resize(Client* client, const ResizeAction& r
 {
     MouseDragHandler::Constructor constructor;
     if (client->is_client_floated()) {
-        constructor = [resize](MonitorManager* monitors, Client* client) -> shared_ptr<MouseDragHandler> {
-            auto mdh = make_shared<MouseDragHandlerFloating>(monitors, client, &MouseDragHandlerFloating::mouse_function_resize);
+        constructor = [resize](MonitorManager* monitors, Client* clientInner) -> shared_ptr<MouseDragHandler> {
+            auto mdh = make_shared<MouseDragHandlerFloating>(monitors, clientInner, &MouseDragHandlerFloating::mouse_function_resize);
             mdh->lockWidth = !resize.left && !resize.right;
             mdh->lockHeight = !resize.top && !resize.bottom;
             HSDebug("lw=%d, lh=%d\n", mdh->lockWidth, mdh->lockHeight);

--- a/src/mousemanager.h
+++ b/src/mousemanager.h
@@ -13,6 +13,7 @@ class Completion;
 class ClientManager;
 class MonitorManager;
 class MouseDragHandler;
+class ResizeAction;
 struct Point2D;
 
 class MouseManager : public Object {
@@ -41,6 +42,7 @@ public:
     std::string mouse_initiate_move(Client* client, const std::vector<std::string> &cmd);
     std::string mouse_initiate_zoom(Client* client, const std::vector<std::string> &cmd);
     std::string mouse_initiate_resize(Client* client, const std::vector<std::string> &cmd);
+    std::string mouse_initiate_resize(Client* client, const ResizeAction& resize);
     std::string mouse_call_command(Client* client, const std::vector<std::string> &cmd);
 
 private:

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -444,18 +444,12 @@ void XMainLoop::mappingnotify(XMappingEvent* ev) {
 }
 
 void XMainLoop::motionnotify(XMotionEvent* event) {
-    // check if some buttons are pressed
-    if (event->state != 0) {
-        // get newest motion notification
-        while (XCheckMaskEvent(X_.display(), ButtonMotionMask, (XEvent *)event)) {
-            ;
-        }
-        Point2D newCursorPos = { event->x_root,  event->y_root };
-        root_->mouse->handle_motion_event(newCursorPos);
-    } else {
-        // if no buttons are pressed:
-        HSDebug("Motion (%d,%d)\n", event->x, event->y);
+    // get newest motion notification
+    while (XCheckMaskEvent(X_.display(), ButtonMotionMask, (XEvent *)event)) {
+        ;
     }
+    Point2D newCursorPos = { event->x_root,  event->y_root };
+    root_->mouse->handle_motion_event(newCursorPos);
 }
 
 void XMainLoop::mapnotify(XMapEvent* event) {


### PR DESCRIPTION
When the mouse cursor is at a client's window border, the cursor shape
now changes to indicate the direction in which the window resizes.
Also, I've updated the resize code itself to allow resizing where the
width or height is fixed and the client is resized only into one
dimension.

Unfortunately, the cursor preview isn't entirely correct for tiled
windows. Also does not seem to be possible to query the cursor shape in
test cases.

This closes #1138.