### PR TITLE
Add an autostart object

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ older versions.
 Current git version
 -------------------
 
+  * New autostart object with attributes 'path', 'running', 'pid', 'last_status'
   * New client attribute 'floating_effectively' and associated X11 properties
     'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'
   * New read-only client attribute 'decoration_geometry'.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(herbstluftwm PRIVATE
     arglist.cpp arglist.h
     argparse.cpp argparse.h
     attribute.cpp attribute.h attribute_.h
+    autostart.cpp autostart.h
     byname.cpp byname.h
     child.h
     client.cpp client.h

--- a/src/autostart.cpp
+++ b/src/autostart.cpp
@@ -1,0 +1,89 @@
+#include "autostart.h"
+#include "globals.h"
+
+#include <unistd.h>
+
+using std::pair;
+using std::string;
+
+Autostart::Autostart(const string& autostartFromCmdLine, const string& globalAutostart)
+    : autostart_path_(this, "path", autostartFromCmdLine)
+    , global_autostart_path_(this, "global_path", globalAutostart)
+    , pid_(this, "pid", 0)
+    , running_(this, "running", false)
+    , last_status_(this, "last_status", 0)
+{
+    autostart_path_.setWritable();
+    autostart_path_.setDoc(
+                "Custom path to the user\'s autostart path. "
+                "If it is empty, then the autostart in $XDG_CONFIG_HOME "
+                "or $HOME is used.");
+    global_autostart_path_.setDoc("Path of the system-wide autostart, used as a fallback.");
+    pid_.setDoc(
+                "the process id of the last autostart invokation. "
+                "Even if the autostart is not running anymore, its pid "
+                "is still present here.");
+    running_.setDoc("whether the autostart process (with \'pid\') is still running.");
+    last_status_.setDoc(
+                "the exit status of the last autostart run. "
+                "if the autostart is still \'running\', then this "
+                "status corresponds to the exit status of the previous "
+                "autostart invocation."
+    );
+}
+
+void Autostart::reloadCmd()
+{
+    string path;
+    if (!autostart_path_().empty()) {
+        path = autostart_path_();
+    } else {
+        // find right directory
+        char* xdg_config_home = getenv("XDG_CONFIG_HOME");
+        if (xdg_config_home) {
+            path = xdg_config_home;
+        } else {
+            char* home = getenv("HOME");
+            if (!home) {
+                HSWarning("Will not run autostart file. "
+                          "Neither $HOME or $XDG_CONFIG_HOME is set.\n");
+                return;
+            }
+            path = string(home) + "/.config";
+        }
+        path += "/" HERBSTLUFT_AUTOSTART;
+    }
+    pid_t pid = fork();
+    if (0 == pid) {
+        // in the child
+        if (g_display) {
+            close(ConnectionNumber(g_display));
+        }
+        setsid();
+        execl(path.c_str(), path.c_str(), nullptr);
+
+        const char* global_autostart = global_autostart_path_->c_str();
+        HSDebug("Cannot execute %s, falling back to %s\n", path.c_str(), global_autostart);
+        execl(global_autostart, global_autostart, nullptr);
+
+        fprintf(stderr, "herbstluftwm: execvp \"%s\"", global_autostart);
+        perror(" failed");
+        exit(EXIT_FAILURE);
+    } else {
+        // in the parent process
+        pid_ = static_cast<unsigned long>(pid);
+        running_ = true;
+    }
+}
+
+void Autostart::childExited(pair<pid_t, int> childInfo)
+{
+    if (childInfo.first <= 0) {
+        return;
+    }
+    unsigned long pidUnsigned = static_cast<unsigned long>(childInfo.first);
+    if (pidUnsigned == pid_()) {
+        running_ = false;
+        last_status_ = childInfo.second;
+    }
+}

--- a/src/autostart.cpp
+++ b/src/autostart.cpp
@@ -1,7 +1,8 @@
 #include "autostart.h"
-#include "globals.h"
 
 #include <unistd.h>
+
+#include "globals.h"
 
 using std::pair;
 using std::string;

--- a/src/autostart.cpp
+++ b/src/autostart.cpp
@@ -21,7 +21,7 @@ Autostart::Autostart(const string& autostartFromCmdLine, const string& globalAut
                 "or $HOME is used.");
     global_autostart_path_.setDoc("Path of the system-wide autostart, used as a fallback.");
     pid_.setDoc(
-                "the process id of the last autostart invokation. "
+                "the process id of the last autostart invocation. "
                 "Even if the autostart is not running anymore, its pid "
                 "is still present here.");
     running_.setDoc("whether the autostart process (with \'pid\') is still running.");

--- a/src/autostart.h
+++ b/src/autostart.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "attribute_.h"
+#include "object.h"
+
+class Completion;
+
+class Autostart : public Object
+{
+public:
+    Autostart(const std::string& autostartFromCmdLine, const std::string& globalAutostart);
+    void reloadCmd();
+    int reloadCmdDummyOutput(Output) { reloadCmd(); return 0; };
+    Attribute_<std::string> autostart_path_;
+    Attribute_<std::string> global_autostart_path_;
+    Attribute_<unsigned long> pid_;
+    Attribute_<bool> running_;
+    Attribute_<int> last_status_;
+
+    //! the main should call this if a child exits:
+    void childExited(std::pair<pid_t, int> childInfo);
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -421,7 +421,7 @@ int main(int argc, char* argv[]) {
         X->tryInitTransparency();
     }
     // ignore sigchld, but set it anyway such that we don't
-    // receive anything on on stopped children (SA_NOCLDSTOP)
+    // receive anything on stopped children (SA_NOCLDSTOP)
     sigaction_signal(SIGCHLD, [](int) {});
     sigaction_signal(SIGINT,  handle_signal);
     sigaction_signal(SIGQUIT, handle_signal);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -436,6 +436,9 @@ int main(int argc, char* argv[]) {
     if (g.trueTransparency) {
         X->tryInitTransparency();
     }
+    // ignore sigchld, but set it anyway such that we don't
+    // receive anything on on stopped children (SA_NOCLDSTOP)
+    sigaction_signal(SIGCHLD, [](int) {});
     sigaction_signal(SIGINT,  handle_signal);
     sigaction_signal(SIGQUIT, handle_signal);
     sigaction_signal(SIGTERM, handle_signal);

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "autostart.h"
 #include "client.h"
 #include "clientmanager.h"
 #include "ewmh.h"
@@ -28,7 +29,8 @@ using std::shared_ptr;
 shared_ptr<Root> Root::root_;
 
 Root::Root(Globals g, XConnection& xconnection, Ewmh& ewmh, IpcServer& ipcServer)
-    : clients(*this, "clients")
+    : autostart(*this, "autostart")
+    , clients(*this, "clients")
     , keys(*this, "keys")
     , monitors(*this, "monitors")
     , mouse(*this, "mouse")
@@ -48,6 +50,7 @@ Root::Root(Globals g, XConnection& xconnection, Ewmh& ewmh, IpcServer& ipcServer
     , ewmh_(ewmh)
 {
     // initialize root children (alphabetically)
+    autostart.init(g.autostartPath, g.globalAutostartPath);
     clients.init();
     keys.init();
     monitors.init();

--- a/src/root.h
+++ b/src/root.h
@@ -8,6 +8,7 @@
 
 // new object tree root.
 
+class Autostart;
 class ClientManager; // IWYU pragma: keep
 class Ewmh;
 class FrameLeaf;
@@ -36,6 +37,8 @@ public:
     bool exitOnXlibError = false;
     bool importTagsFromEwmh = true;
     bool trueTransparency = true; // try true transparency via xrender
+    std::string autostartPath = {};
+    std::string globalAutostartPath = {}; // system-wide autostart file
 };
 
 class Root : public Object {
@@ -52,6 +55,7 @@ public:
     void shutdown();
 
     // (in alphabetical order)
+    Child_<Autostart> autostart;
     Child_<ClientManager> clients;
     Child_<KeyManager> keys;
     Child_<MonitorManager> monitors;

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -175,7 +175,7 @@ void XMainLoop::run() {
         FD_SET(x11_fd, &in_fds);
         // wait for an event or a signal
         select(x11_fd + 1, &in_fds, nullptr, nullptr, nullptr);
-        // if `select` was interrupted by a signal, then it was maybe SIGCHILD
+        // if `select` was interrupted by a signal, then it was maybe SIGCHLD
         collectZombies();
         if (aboutToQuit_) {
             break;

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -2,7 +2,9 @@
 
 #include <X11/X.h>
 #include <X11/Xlib.h>
+#include <unistd.h> // for pid_t
 
+#include "signal.h"
 #include "ipc-server.h"
 #include "x11-types.h"
 
@@ -18,6 +20,8 @@ public:
     //! quit the main loop as soon as possible
     void quit();
     using EventHandler = void (XMainLoop::*)(XEvent*);
+    //! a child process exited with the given status
+    Signal_<std::pair<pid_t, int>> childExited;
 
     void dropEnterNotifyEvents();
 private:
@@ -26,6 +30,8 @@ private:
     Root* root_;
     bool aboutToQuit_;
     EventHandler handlerTable_[LASTEvent];
+
+    void collectZombies();
     // event handlers
     void buttonpress(XButtonEvent* be);
     void buttonrelease(XButtonEvent* event);

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -4,8 +4,8 @@
 #include <X11/Xlib.h>
 #include <unistd.h> // for pid_t
 
-#include "signal.h"
 #include "ipc-server.h"
+#include "signal.h"
 #include "x11-types.h"
 
 class Client;

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,0 +1,59 @@
+import textwrap
+import time
+
+
+def run_autostart(hlwm, tmpdir, autostart_src):
+    tmpfile = tmpdir / 'custom_autostart'
+    hc_path = hlwm.HC_PATH
+    full_src = textwrap.dedent(f"""\
+    #!/usr/bin/env bash
+
+    hc() {{
+        {hc_path} "$@"
+    }}
+    """)
+    full_src += autostart_src
+
+    tmpfile.ensure()
+    tmpfile.write(full_src)
+    tmpfile.chmod(0o755)
+    hlwm.attr.autostart.path = tmpfile
+    hlwm.call('reload')
+
+    # wait for the autostart to terminate:
+    while hlwm.attr.autostart.running():
+        time.sleep(1)
+
+
+def test_autostart_pid(hlwm, tmpdir):
+    run_autostart(hlwm,
+                  tmpdir,
+                  """
+                  hc new_attr int my_pid
+                  # copy pid of bash to the attribute system
+                  hc set_attr my_pid $$
+                  """)
+    assert hlwm.attr.autostart.last_status() == 0
+    assert hlwm.attr.my_pid() == hlwm.attr.autostart.pid()
+
+
+def test_autostart_running(hlwm, tmpdir):
+    run_autostart(hlwm,
+                  tmpdir,
+                  """
+                  hc new_attr bool my_running
+                  # copy the value of 'running' during autostart execution
+                  hc substitute VALUE autostart.running set_attr my_running VALUE
+                  """)
+    assert hlwm.attr.autostart.last_status() == 0
+    assert hlwm.attr.my_running() is True
+    assert hlwm.attr.autostart.running() is False
+
+
+def test_autostart_last_status(hlwm, tmpdir):
+    run_autostart(hlwm,
+                  tmpdir,
+                  """
+                  exit 4
+                  """)
+    assert hlwm.attr.autostart.last_status() == 4

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,6 +1,67 @@
 import textwrap
 import time
 import subprocess
+import os
+import pytest
+import conftest
+from conftest import BINDIR, HlwmProcess
+
+
+def test_herbstluftwm_default_autostart(hlwm):
+    expected_tags = [str(tag) for tag in range(1, 10)]
+    default_autostart = os.path.join(os.path.abspath(BINDIR), 'share/autostart')
+    env_with_bindir_path = os.environ.copy()
+    env_with_bindir_path['PATH'] = BINDIR + ":" + env_with_bindir_path['PATH']
+    subprocess.run(['bash', '-e', default_autostart], check=True, env=env_with_bindir_path)
+
+    assert hlwm.list_children('tags.by-name') == sorted(expected_tags)
+    # Test a random setting different from the default in settings.h:
+    assert hlwm.get_attr('settings.smart_frame_surroundings') == 'true'
+
+
+@pytest.mark.parametrize("method", ['home', 'xdg', 'shortopt', 'longopt'])
+def test_autostart_path(tmpdir, method, xvfb):
+    # herbstluftwm environment:
+    env = {
+        'DISPLAY': xvfb.display,
+    }
+    args = []  # extra command line args
+    if method == 'home':
+        autostart = tmpdir / '.config' / 'herbstluftwm' / 'autostart'
+        env['HOME'] = str(tmpdir)
+    elif method == 'xdg':
+        autostart = tmpdir / 'herbstluftwm' / 'autostart'
+        env['XDG_CONFIG_HOME'] = str(tmpdir)
+    elif method == 'longopt':
+        autostart = tmpdir / 'somename'
+        args += ['--autostart', str(autostart)]
+    else:
+        autostart = tmpdir / 'somename'
+        args += ['-c', str(autostart)]
+
+    autostart.ensure()
+    autostart.write(textwrap.dedent("""
+        #!/usr/bin/env bash
+        echo "hlwm autostart test"
+    """.lstrip('\n')))
+    autostart.chmod(0o755)
+    env = conftest.extend_env_with_whitelist(env)
+    hlwm_proc = HlwmProcess('hlwm autostart test', env, args)
+
+    # TODO: verify the path as soon as we have an autostart object
+
+    hlwm_proc.shutdown()
+
+
+def test_no_autostart(xvfb):
+    # no HOME, no XDG_CONFIG_HOME
+    env = {
+        'DISPLAY': xvfb.display,
+    }
+    env = conftest.extend_env_with_whitelist(env)
+    hlwm_proc = HlwmProcess('', env, [])
+    hlwm_proc.read_and_echo_output(until_stderr='Will not run autostart file.')
+    hlwm_proc.shutdown()
 
 
 def wait_actively_for(callback):

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,8 +1,22 @@
 import textwrap
 import time
+import subprocess
 
 
-def run_autostart(hlwm, tmpdir, autostart_src):
+def wait_actively_for(callback):
+    """wait actively for the callback to return True
+    """
+    left_attempts = 20
+    while left_attempts > 0:
+        left_attempts -= 1
+        if callback() is True:
+            return
+        time.sleep(1)
+
+    assert False, "The returned value was not 'True'"
+
+
+def run_autostart(hlwm, tmpdir, autostart_src, wait=True):
     tmpfile = tmpdir / 'custom_autostart'
     hc_path = hlwm.HC_PATH
     full_src = textwrap.dedent(f"""\
@@ -20,9 +34,9 @@ def run_autostart(hlwm, tmpdir, autostart_src):
     hlwm.attr.autostart.path = tmpfile
     hlwm.call('reload')
 
-    # wait for the autostart to terminate:
-    while hlwm.attr.autostart.running():
-        time.sleep(1)
+    if wait:
+        # wait for the autostart to terminate:
+        wait_actively_for(lambda: not hlwm.attr.autostart.running())
 
 
 def test_autostart_pid(hlwm, tmpdir):
@@ -51,9 +65,55 @@ def test_autostart_running(hlwm, tmpdir):
 
 
 def test_autostart_last_status(hlwm, tmpdir):
+    for status in [0, 1, 2, 4, 9]:
+        run_autostart(hlwm,
+                      tmpdir,
+                      f"""
+                      exit {status}
+                      """)
+        assert hlwm.attr.autostart.last_status() == status
+
+
+def process_status(pid):
+    ps_cmd = ['ps', '-q', str(pid), '-o', 'state', '--no-headers']
+    proc = subprocess.Popen(ps_cmd,
+                            stdout=subprocess.PIPE,
+                            universal_newlines=True)
+    return proc.communicate()[0].strip()
+
+
+def test_autostart_sigstop(hlwm, tmpdir):
     run_autostart(hlwm,
                   tmpdir,
                   """
-                  exit 4
-                  """)
-    assert hlwm.attr.autostart.last_status() == 4
+                  hc new_attr string my_attr firststop
+                  kill -STOP $$
+                  hc set_attr my_attr secondstop
+                  kill -STOP $$
+                  hc set_attr my_attr final
+                  """,
+                  wait=False)
+    pid = hlwm.attr.autostart.pid()
+    # wait until the process is 'stopped'
+    wait_actively_for(lambda: process_status(pid) == 'T')
+    # then, it is still marked as 'running' in hlwm:
+    assert hlwm.attr.autostart.running() is True
+    assert hlwm.attr.my_attr() == 'firststop'
+    # resume it:
+    subprocess.run(['kill', '-CONT', str(pid)])
+
+    # wait until the process is 'stopped' again
+    wait_actively_for(lambda: process_status(pid) == 'T')
+    assert hlwm.attr.my_attr() == 'secondstop'
+
+    # then, it is still marked as 'running' in hlwm:
+    # by this we verify that the 'continuation' did not
+    # trigger the wrong signal handler
+    assert hlwm.attr.autostart.running() is True
+
+    # finally, resume it a second time and let it terminate:
+    subprocess.run(['kill', '-CONT', str(pid)])
+
+    wait_actively_for(lambda: not hlwm.attr.autostart.running())
+
+    assert hlwm.attr.my_attr() == 'final'

--- a/tests/test_herbstluftwm.py
+++ b/tests/test_herbstluftwm.py
@@ -2,8 +2,7 @@ import re
 import os
 import pytest
 import subprocess
-import textwrap
-from conftest import BINDIR, HlwmProcess, HlwmBridge
+from conftest import BINDIR, HlwmBridge
 import conftest
 import os.path
 from Xlib import X, Xatom
@@ -94,63 +93,6 @@ def test_herbstluftwm_replace(hlwm_spawner, xvfb):
     assert hlwm_new.call('echo ping').stdout == 'ping\n'
 
     hlwm_proc_new.shutdown()
-
-
-def test_herbstluftwm_default_autostart(hlwm):
-    expected_tags = [str(tag) for tag in range(1, 10)]
-    default_autostart = os.path.join(os.path.abspath(BINDIR), 'share/autostart')
-    env_with_bindir_path = os.environ.copy()
-    env_with_bindir_path['PATH'] = BINDIR + ":" + env_with_bindir_path['PATH']
-    subprocess.run(['bash', '-e', default_autostart], check=True, env=env_with_bindir_path)
-
-    assert hlwm.list_children('tags.by-name') == sorted(expected_tags)
-    # Test a random setting different from the default in settings.h:
-    assert hlwm.get_attr('settings.smart_frame_surroundings') == 'true'
-
-
-@pytest.mark.parametrize("method", ['home', 'xdg', 'shortopt', 'longopt'])
-def test_autostart_path(tmpdir, method, xvfb):
-    # herbstluftwm environment:
-    env = {
-        'DISPLAY': xvfb.display,
-    }
-    args = []  # extra command line args
-    if method == 'home':
-        autostart = tmpdir / '.config' / 'herbstluftwm' / 'autostart'
-        env['HOME'] = str(tmpdir)
-    elif method == 'xdg':
-        autostart = tmpdir / 'herbstluftwm' / 'autostart'
-        env['XDG_CONFIG_HOME'] = str(tmpdir)
-    elif method == 'longopt':
-        autostart = tmpdir / 'somename'
-        args += ['--autostart', str(autostart)]
-    else:
-        autostart = tmpdir / 'somename'
-        args += ['-c', str(autostart)]
-
-    autostart.ensure()
-    autostart.write(textwrap.dedent("""
-        #!/usr/bin/env bash
-        echo "hlwm autostart test"
-    """.lstrip('\n')))
-    autostart.chmod(0o755)
-    env = conftest.extend_env_with_whitelist(env)
-    hlwm_proc = HlwmProcess('hlwm autostart test', env, args)
-
-    # TODO: verify the path as soon as we have an autostart object
-
-    hlwm_proc.shutdown()
-
-
-def test_no_autostart(xvfb):
-    # no HOME, no XDG_CONFIG_HOME
-    env = {
-        'DISPLAY': xvfb.display,
-    }
-    env = conftest.extend_env_with_whitelist(env)
-    hlwm_proc = HlwmProcess('', env, [])
-    hlwm_proc.read_and_echo_output(until_stderr='Will not run autostart file.')
-    hlwm_proc.shutdown()
 
 
 def test_herbstluftwm_help_flags():


### PR DESCRIPTION
This adds an autostart object which allows modifying the custom
autostart path at run time and also helps querying information about the
last invoked autostart run (pid, status, running).

This closes #762.