### PR TITLE
spawn: Print error message on exec failure

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ Current git version
   * New autostart object with attributes 'path', 'running', 'pid', 'last_status'
   * New client attribute 'floating_effectively' and associated X11 properties
     'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'
+  * The 'spawn' command now print an error message on exec failure
   * New read-only client attribute 'decoration_geometry'.
   * Bug fixes:
     - Update floating geometry if a client's size hints change

--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,7 @@ Current git version
   * New autostart object with attributes 'path', 'running', 'pid', 'last_status'
   * New client attribute 'floating_effectively' and associated X11 properties
     'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'
-  * The 'spawn' command now print an error message on exec failure
+  * The 'spawn' command now prints an error message on exec failure
   * New read-only client attribute 'decoration_geometry'.
   * The cursor shape now indicates resize options.
   * Bug fixes:

--- a/src/autostart.cpp
+++ b/src/autostart.cpp
@@ -57,9 +57,6 @@ void Autostart::reloadCmd()
     pid_t pid = fork();
     if (0 == pid) {
         // in the child
-        if (g_display) {
-            close(ConnectionNumber(g_display));
-        }
         setsid();
         execl(path.c_str(), path.c_str(), nullptr);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <vector>
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -330,7 +330,10 @@ string spawnProcess(const vector<string>& command, pid_t* retChildPid)
         int errnum = execvp_helper(command);
         // if exec failed: send the error number to the parent process
         close(readAndWriteFd[0]); // close the reading side
-        write(readAndWriteFd[1], &errnum, sizeof(errnum));
+        size_t written = write(readAndWriteFd[1], &errnum, sizeof(errnum));
+        if (written != sizeof(errnum)) {
+            std::cerr << "Failure when writing to pipe to parent process" << endl;
+        }
         close(readAndWriteFd[1]);
         exit(0);
     } else {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,7 +5,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <cstdlib>
-#include <cstring>
+#include <cstring> // for strerror()
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -18,6 +19,7 @@
 #include <mach/mach.h>
 #endif
 
+using std::endl;
 using std::shared_ptr;
 using std::stringstream;
 using std::string;

--- a/src/utils.h
+++ b/src/utils.h
@@ -108,5 +108,10 @@ std::string join_strings(const InContainer& in, const std::string& delim) {
     return out.str();
 }
 
+std::string trimRight(const std::string& source, const std::string& charsToRemove);
+
+int execvp_helper(const std::vector<std::string>& command);
+std::string spawnProcess(const std::vector<std::string>& command, pid_t* retChildPid = nullptr);
+
 #endif
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -9,9 +9,13 @@ def test_spawn(hlwm, hlwm_process):
 
 def test_spawn_command_not_exist(hlwm, hlwm_process):
     cmdname = 'this_command_does_not_exist'
-    with hlwm_process.wait_stderr_match(f'execvp "{cmdname}" failed'):
-        cmd = ['spawn', cmdname]
-        proc = hlwm.unchecked_call(cmd, read_hlwm_output=False)
-        assert proc.returncode == 0
-        assert not proc.stderr
-        assert not proc.stdout
+    hlwm.call_xfail(['spawn', cmdname]) \
+        .expect_stderr(cmdname) \
+        .expect_stderr('No such file')
+
+
+def test_spawn_command_no_permission(hlwm, tmpdir, hlwm_process):
+    dirname = str(tmpdir)
+    hlwm.call_xfail(['spawn', dirname]) \
+        .expect_stderr(dirname) \
+        .expect_stderr('Permission denied')


### PR DESCRIPTION
This encapsulates the spawning of new processes in a utility function
that either returns the pid of the child process or a error message.
Thus, the 'spawn' command now prints a meaningful error message if the
exec failed.

Formerly, we manually closed the socket for the X11 connection on every
fork. Now, the X11 socket is marked as 'CLOEXEC' (close on exec), if it
hasn't been already by XOpenDisplay(). This eliminates another instance
of the global g_display variable.

Unfortunately, I don't know how to really test the low level error
messages for pipe() and fork(). But there are test cases for the other
error messages for 'spawn' and also a new test case for 'wmexec'.

In the long run, the spawnProcess() function should also be used in the
autostart invocation in the 'reload' command to also provide an error
message there.