### PR TITLE
tests: Close stdout/stderr after subprocess.Popen

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,6 +267,7 @@ class HlwmBridge(herbstluftwm.Herbstluftwm):
         for client_proc in self.client_procs:
             client_proc.wait(PROCESS_SHUTDOWN_TIME)
         self.hc_idle.wait(PROCESS_SHUTDOWN_TIME)
+        self.hc_idle.stdout.close()
 
     def bool(self, python_bool_var):
         """convert a boolean variable into hlwm's string representation"""
@@ -448,6 +449,8 @@ class HlwmProcess:
 
         # Make sure to read and echo all remaining output (esp. ASAN messages):
         self.read_and_echo_output(until_eof=True)
+        self.proc.stdout.close()
+        self.proc.stderr.close()
 
         if self.proc.returncode is None:
             # only wait the process if it hasn't been cleaned up
@@ -524,6 +527,7 @@ class HcIdle:
         except subprocess.TimeoutExpired:
             self.proc.kill()
             self.proc.wait(PROCESS_SHUTDOWN_TIME)
+        self.proc.stdout.close()
 
 
 @pytest.fixture()

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -138,8 +138,8 @@ def test_autostart_last_status(hlwm, tmpdir):
 def process_status(pid):
     ps_cmd = ['ps', '-q', str(pid), '-o', 'state', '--no-headers']
     proc = subprocess.run(ps_cmd,
-                            stdout=subprocess.PIPE,
-                            universal_newlines=True)
+                          stdout=subprocess.PIPE,
+                          universal_newlines=True)
     return proc.stdout.strip()
 
 

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -137,10 +137,10 @@ def test_autostart_last_status(hlwm, tmpdir):
 
 def process_status(pid):
     ps_cmd = ['ps', '-q', str(pid), '-o', 'state', '--no-headers']
-    proc = subprocess.Popen(ps_cmd,
+    proc = subprocess.run(ps_cmd,
                             stdout=subprocess.PIPE,
                             universal_newlines=True)
-    return proc.communicate()[0].strip()
+    return proc.stdout.strip()
 
 
 def test_autostart_sigstop(hlwm, tmpdir):

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -111,6 +111,8 @@ def test_herbstclient_wait(hlwm, num_hooks_sent, num_hooks_recv, repeat):
         num_hooks_recv * ['matcher\tsomearg']
     proc.wait(PROCESS_SHUTDOWN_TIME)
     assert proc.returncode == 0
+    proc.stdout.close()
+    proc.stderr.close()
 
 
 @pytest.mark.parametrize('repeat', range(0, 3))  # use more repetitions to test the race-condtion
@@ -145,6 +147,8 @@ def test_lastarg_only(hlwm, repeat):
     assert proc.stdout.read().splitlines() == expected_lines
     proc.wait(PROCESS_SHUTDOWN_TIME)
     assert proc.returncode == 0
+    proc.stdout.close()
+    proc.stderr.close()
 
 
 @pytest.mark.parametrize('zero_separated', [True, False])
@@ -342,6 +346,8 @@ def hc_context(args=['echo', 'ping']):
     args_str = ' '.join(args)
     print(f'"hc {args_str}" exited with status {reply.returncode} and output: {reply.stdout}')
     print(f'"hc {args_str}" has the error output: {reply.stderr}', file=sys.stderr)
+    proc.stdout.close()
+    proc.stderr.close()
 
 
 @pytest.mark.parametrize('repeat', range(0, 10))  # number of repetitions to detect race-conditions


### PR DESCRIPTION
When using subprocess.Popen() and piping stdout or stderr, the pipe
needs to be closed on shutdown.

For the present change, I've grep'ed for all uses of subprocess.Popen()
and added the necessary close() invocations. In one occasion, I could
simply replace subprocess.Popen() / communicate() with subprocess.run()
which already takes care of this.

Unclosed file descriptors and similar issues are reported by passing
`-Wdefault` to pytest.

Reported-by: Florian Schmaus <flo@geekplace.eu>