### PR TITLE
Add an "Users contributions" section on the webpage

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -50,6 +50,8 @@ faq-toc.html: faq-content.html ./gentoc.sh
 
 faq.html: faq-toc.html
 
+contrib.html: contrib.txt
+
 favicon.ico: ../share/herbstluftwm.svg
 	convert -density 256x256 -background transparent $< \
         -define icon:auto-resize -colors 256 $@

--- a/www/Makefile
+++ b/www/Makefile
@@ -50,8 +50,6 @@ faq-toc.html: faq-content.html ./gentoc.sh
 
 faq.html: faq-toc.html
 
-contrib.html: contrib.txt
-
 favicon.ico: ../share/herbstluftwm.svg
 	convert -density 256x256 -background transparent $< \
         -define icon:auto-resize -colors 256 $@

--- a/www/compose.py
+++ b/www/compose.py
@@ -23,7 +23,7 @@ tabs = OrderedDict([
         ("download", "Download"),
     ])),
     ("Users contributions", OrderedDict([
-		("contrib", "Users contributions"),
+        ("contrib", "Users contributions"),
     ])),
     # ("Wiki", "http://wiki.herbstluftwm.org"),
 ])

--- a/www/compose.py
+++ b/www/compose.py
@@ -22,6 +22,9 @@ tabs = OrderedDict([
     ("Download", OrderedDict([
         ("download", "Download"),
     ])),
+    ("Users contributions", OrderedDict([
+		("contrib", "Users contributions"),
+    ])),
     # ("Wiki", "http://wiki.herbstluftwm.org"),
 ])
 

--- a/www/contrib.txt
+++ b/www/contrib.txt
@@ -33,9 +33,7 @@ Get it from https://github.com/pjones/hlwmrc/blob/9f38a3023660c8c1b617be7689823f
 Layout save and recall fuction by u/ToPow1
 ------------------------------------------
 
-This function allow you to save your current layout and give it a name. You can save as many layouts as you like using the +zentity+ packages.
-
-The saved layouts can then called back on any TAG you like.
+This function allow you to save your current layout and give it a name. You can save as many layouts as you like using the +zentity+ packages. The saved layouts can then called back on any TAG you like.
 
 This function is done with two short bash scripts. The first to save a layout and name it, the second to list the saved layouts and print it to the current TAG.
 
@@ -43,31 +41,4 @@ I saved this scripts in my local $PATH directory and make them executable. To pr
 
 To call the scripts I add two keybinds to my HLWM autostart: hc keybind Mod1-j spawn save-layout.sh and hc keybinds Mod1-k spawn recall-layout.sh
 
-save-layout.sh
-
-----
-
-#!/usr/bin/bash
-
-LAY=`herbstclient dump`
-ENT=`echo "herbstclient load '$LAY'"` 
-
-FI=`zenity --entry --title="Save the current Layout" --text="Enter name of new Layout:" --entry-text "NewLayout"`
-
-echo "$ENT" > ~/.config/herbstluftwm/layouts/$FI 
-
-----
-
-recall-layout.sh
-
-----
-
-#!/usr/bin/bash
-
-LO=`ls -C ~/.config/herbstluftwm/layouts/`
-
-SEL=`zenity --list --title="Choose a Layout" --column="Layouts" $LO`
-
-cat ~/.config/herbstluftwm/layouts/$SEL | bash
-
-----
+Get it from https://www.reddit.com/r/herbstluftwm/comments/o13vny/layout_save_and_recall_function_for_herbstluftwm[this post on reddit!]

--- a/www/contrib.txt
+++ b/www/contrib.txt
@@ -1,40 +1,14 @@
 Users contributions
 ===================
 
+* tag_spaces by AnomalousBit: groups of tags similar to KDE Plasma activities. Get it from https://github.com/AnomalousBit/tag_spaces[github!]
+* Automatically disable focus_follows_mouse for floating windows by u/pmade. Get it from https://github.com/pjones/hlwmrc/blob/9f38a3023660c8c1b617be7689823f09115ecf75/bin/hlwm-ffm-skip-floats.sh[github!]
+* Layout save and recall fuction by u/ToPow1. Get it from https://www.reddit.com/r/herbstluftwm/comments/o13vny/layout_save_and_recall_function_for_herbstluftwm[this post on reddit!]
+
 How to contribute?
 ------------------
 
 * Clone the repo with +git clone https://github.com/herbstlufwm/herbstluftwm+
 * Open the +herbstluftwm/www/contrib.txt+ file.
 * Edit the file and add your contribution! It uses the https://powerman.name/doc/asciidoc[asciidoc format].
-* Send your pull request! If you want to test the site run the +make+ command (it needs asciidoc installed). Just remember to run +make clean+ before sending the pull request.
-
-tag_spaces by AnomalousBit
---------------------------
-
-+tag_spaces+ is an extension to herbstluftwm that adds a new concept called tag spaces.
-
-A Tag Space is a group of tags along with keybindings that only operate on the currently selected tag space.
-
-The current / active tag space is selected by using keybinds and can be specified by name, relative or cardinal array index.
-
-By switching to a new tag space, the default Mod+[0-9] keybinds are remapped to the selected tag space and it's first N tags are automatically displayed on your first N monitors.
-
-Get it from https://github.com/AnomalousBit/tag_spaces[github!]
-
-
-Automatically disable focus_follows_mouse for floating windows by u/pmade
--------------------------------------------------------------------------
-
-This script automatically turns off +focus_follows_mouse+ for floating windows, and turns it back on for tiled windows. Now you can use +focus_follows_mouse+ like normal but when a pesky dialog opens I have an extra step of clicking to lose focus.
-
-Get it from https://github.com/pjones/hlwmrc/blob/9f38a3023660c8c1b617be7689823f09115ecf75/bin/hlwm-ffm-skip-floats.sh[github!]
-
-Layout save and recall fuction by u/ToPow1
-------------------------------------------
-
-This function allow you to save your current layout and give it a name using the +zentity+ package. You can save as many layouts as you like and the saved layouts can then called back on any TAG you like.
-
-This function is done with two short bash scripts. The first to save a layout and name it, the second to list the saved layouts and print it to the current TAG.
-
-Get it from https://www.reddit.com/r/herbstluftwm/comments/o13vny/layout_save_and_recall_function_for_herbstluftwm[this post on reddit!]
+* Send your pull request! If you want to test the site run the +make+ command (it needs asciidoc installed). 

--- a/www/contrib.txt
+++ b/www/contrib.txt
@@ -5,10 +5,9 @@ How to contribute?
 ------------------
 
 * Clone the repo with +git clone https://github.com/herbstlufwm/herbstluftwm+
-* Open the +www+ directory and open the +contrib.txt+ file
-* Add your contribution! It uses the asciidoc format.
-* Send your pull request!
-
+* Open the +herbstluftwm/www/contrib.txt+ file.
+* Edit the file and add your contribution! It uses the https://powerman.name/doc/asciidoc[asciidoc format].
+* Send your pull request! If you want to test the site run the +make+ command (it needs asciidoc installed). Just remember to run +make clean+ before sending the pull request.
 
 tag_spaces by AnomalousBit
 --------------------------
@@ -46,7 +45,8 @@ To call the scripts I add two keybinds to my HLWM autostart: hc keybind Mod1-j s
 
 save-layout.sh
 
----
+----
+
 #!/usr/bin/bash
 
 LAY=`herbstclient dump`
@@ -55,11 +55,13 @@ ENT=`echo "herbstclient load '$LAY'"`
 FI=`zenity --entry --title="Save the current Layout" --text="Enter name of new Layout:" --entry-text "NewLayout"`
 
 echo "$ENT" > ~/.config/herbstluftwm/layouts/$FI 
----
+
+----
 
 recall-layout.sh
 
----
+----
+
 #!/usr/bin/bash
 
 LO=`ls -C ~/.config/herbstluftwm/layouts/`
@@ -67,4 +69,5 @@ LO=`ls -C ~/.config/herbstluftwm/layouts/`
 SEL=`zenity --list --title="Choose a Layout" --column="Layouts" $LO`
 
 cat ~/.config/herbstluftwm/layouts/$SEL | bash
----
+
+----

--- a/www/contrib.txt
+++ b/www/contrib.txt
@@ -1,0 +1,70 @@
+Users contributions
+===================
+
+How to contribute?
+------------------
+
+* Clone the repo with +git clone https://github.com/herbstlufwm/herbstluftwm+
+* Open the +www+ directory and open the +contrib.txt+ file
+* Add your contribution! It uses the asciidoc format.
+* Send your pull request!
+
+
+tag_spaces by AnomalousBit
+--------------------------
+
++tag_spaces+ is an extension to herbstluftwm that adds a new concept called tag spaces.
+
+A Tag Space is a group of tags along with keybindings that only operate on the currently selected tag space.
+
+The current / active tag space is selected by using keybinds and can be specified by name, relative or cardinal array index.
+
+By switching to a new tag space, the default Mod+[0-9] keybinds are remapped to the selected tag space and it's first N tags are automatically displayed on your first N monitors.
+
+Get it from https://github.com/AnomalousBit/tag_spaces[github!]
+
+
+Automatically disable focus_follows_mouse for floating windows by u/pmade
+-------------------------------------------------------------------------
+
+This script automatically turns off +focus_follows_mouse+ for floating windows, and turns it back on for tiled windows. Now you can use +focus_follows_mouse+ like normal but when a pesky dialog opens I have an extra step of clicking to lose focus.
+
+Get it from https://github.com/pjones/hlwmrc/blob/9f38a3023660c8c1b617be7689823f09115ecf75/bin/hlwm-ffm-skip-floats.sh[github!]
+
+Layout save and recall fuction by u/ToPow1
+------------------------------------------
+
+This function allow you to save your current layout and give it a name. You can save as many layouts as you like using the +zentity+ packages.
+
+The saved layouts can then called back on any TAG you like.
+
+This function is done with two short bash scripts. The first to save a layout and name it, the second to list the saved layouts and print it to the current TAG.
+
+I saved this scripts in my local $PATH directory and make them executable. To print the dialog to the screen you need to install "zenity" if you not already have it on your system. You also need to create a folder to save the layouts: $ mkdir ~/.config/herbstluftwm/layouts .
+
+To call the scripts I add two keybinds to my HLWM autostart: hc keybind Mod1-j spawn save-layout.sh and hc keybinds Mod1-k spawn recall-layout.sh
+
+save-layout.sh
+
+---
+#!/usr/bin/bash
+
+LAY=`herbstclient dump`
+ENT=`echo "herbstclient load '$LAY'"` 
+
+FI=`zenity --entry --title="Save the current Layout" --text="Enter name of new Layout:" --entry-text "NewLayout"`
+
+echo "$ENT" > ~/.config/herbstluftwm/layouts/$FI 
+---
+
+recall-layout.sh
+
+---
+#!/usr/bin/bash
+
+LO=`ls -C ~/.config/herbstluftwm/layouts/`
+
+SEL=`zenity --list --title="Choose a Layout" --column="Layouts" $LO`
+
+cat ~/.config/herbstluftwm/layouts/$SEL | bash
+---

--- a/www/contrib.txt
+++ b/www/contrib.txt
@@ -3,7 +3,7 @@ Users contributions
 
 * tag_spaces by AnomalousBit: groups of tags similar to KDE Plasma activities. Get it from https://github.com/AnomalousBit/tag_spaces[github!]
 * Automatically disable focus_follows_mouse for floating windows by u/pmade. Get it from https://github.com/pjones/hlwmrc/blob/9f38a3023660c8c1b617be7689823f09115ecf75/bin/hlwm-ffm-skip-floats.sh[github!]
-* Layout save and recall fuction by u/ToPow1. Get it from https://www.reddit.com/r/herbstluftwm/comments/o13vny/layout_save_and_recall_function_for_herbstluftwm[this post on reddit!]
+* Layout save and recall function by u/ToPow1. Get it from https://www.reddit.com/r/herbstluftwm/comments/o13vny/layout_save_and_recall_function_for_herbstluftwm[this post on reddit!]
 
 How to contribute?
 ------------------

--- a/www/contrib.txt
+++ b/www/contrib.txt
@@ -33,12 +33,8 @@ Get it from https://github.com/pjones/hlwmrc/blob/9f38a3023660c8c1b617be7689823f
 Layout save and recall fuction by u/ToPow1
 ------------------------------------------
 
-This function allow you to save your current layout and give it a name. You can save as many layouts as you like using the +zentity+ packages. The saved layouts can then called back on any TAG you like.
+This function allow you to save your current layout and give it a name using the +zentity+ package. You can save as many layouts as you like and the saved layouts can then called back on any TAG you like.
 
 This function is done with two short bash scripts. The first to save a layout and name it, the second to list the saved layouts and print it to the current TAG.
-
-I saved this scripts in my local $PATH directory and make them executable. To print the dialog to the screen you need to install "zenity" if you not already have it on your system. You also need to create a folder to save the layouts: $ mkdir ~/.config/herbstluftwm/layouts .
-
-To call the scripts I add two keybinds to my HLWM autostart: hc keybind Mod1-j spawn save-layout.sh and hc keybinds Mod1-k spawn recall-layout.sh
 
 Get it from https://www.reddit.com/r/herbstluftwm/comments/o13vny/layout_save_and_recall_function_for_herbstluftwm[this post on reddit!]


### PR DESCRIPTION
This adds a `contrib.txt` file to the `www` directory and solves #1340

I decided to add the new section as a new tab. I included instructions on how to add new contributions and I added some contributions I found at r/herbstluftwm. I have to make it clear: I didn't ask  permission from the authors to include their contributions on the webpage, I just assumed that I could do it since they had already shared it on reddit and they're using free licences. Of course, each contribution has the username of whoever shared it and (if apply) a link to their repo.

I also changed the `compose.py` files so the new section can be compiled by asciidoc.