### PR TITLE
Resize frames in both dimensions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ Current git version
   * The 'spawn' command now prints an error message on exec failure
   * New read-only client attribute 'decoration_geometry'.
   * The cursor shape now indicates resize options.
+  * Frames can be simultaneously resized in x and y direction with the mouse.
   * Bug fixes:
     - Update floating geometry if a client's size hints change
 

--- a/python/herbstluftwm/types.py
+++ b/python/herbstluftwm/types.py
@@ -16,6 +16,13 @@ class Point:
     def __add__(self, other):
         return Point(self.x + other.x, self.y + other.y)
 
+    def __sub__(self, other):
+        return Point(self.x - other.x, self.y - other.y)
+
+    def __mul__(self, scalar):
+        """multiply with a given scalar"""
+        return Point(self.x * scalar, self.y * scalar)
+
     def __floordiv__(self, scalar):
         """divide by scalar factor, forcing to integer coordinates"""
         return Point(self.x // scalar, self.y // scalar)

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -249,6 +249,29 @@ ResizeAction Decoration::positionTriggersResize(Point2D p)
     return act;
 }
 
+/**
+ * @brief Find the most apropriate ResizeAction given the current
+ * cursor position. This is a very fuzzy version of positionTriggersResize()
+ * @param the cursor position
+ * @return
+ */
+ResizeAction Decoration::resizeFromRoughCursorPosition(Point2D cursor)
+{
+    if (!last_scheme) {
+        // this should never happen, so we just randomly pick:
+        // never resize if there is no decoration scheme
+        return ResizeAction();
+    }
+    Point2D cursorRelativeToCenter =
+            cursor - last_outer_rect.tl() - last_outer_rect.dimensions() / 2;
+    ResizeAction ra;
+    ra.left = cursorRelativeToCenter.x < 0;
+    ra.right = !ra.left;
+    ra.top = cursorRelativeToCenter.y < 0;
+    ra.bottom = !ra.top;
+    return ra;
+}
+
 void Decoration::resize_outline(Rectangle outline, const DecorationScheme& scheme)
 {
     auto inner = scheme.outline_to_inner_rect(outline);

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -250,10 +250,10 @@ ResizeAction Decoration::positionTriggersResize(Point2D p)
 }
 
 /**
- * @brief Find the most apropriate ResizeAction given the current
+ * @brief Find the most appropriate ResizeAction given the current
  * cursor position. This is a very fuzzy version of positionTriggersResize()
  * @param the cursor position
- * @return
+ * @return the suggested return action
  */
 ResizeAction Decoration::resizeFromRoughCursorPosition(Point2D cursor)
 {

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -58,6 +58,7 @@ public:
     void updateResizeAreaCursors();
 
     ResizeAction positionTriggersResize(Point2D p);
+    ResizeAction resizeFromRoughCursorPosition(Point2D cursor);
 
 private:
     static Visual* check_32bit_client(Client* c);

--- a/src/mousedraghandler.cpp
+++ b/src/mousedraghandler.cpp
@@ -10,6 +10,7 @@
 
 using std::make_shared;
 using std::shared_ptr;
+using std::weak_ptr;
 
 MouseDragHandlerFloating::MouseDragHandlerFloating(MonitorManager* monitors, Client* dragClient, DragFunction function)
   : monitors_(monitors)
@@ -214,8 +215,8 @@ void MouseDragHandlerFloating::mouse_function_zoom(Point2D newCursorPos) {
 }
 
 MouseResizeFrame::MouseResizeFrame(MonitorManager *monitors, shared_ptr<FrameLeaf> frame,
-                     std::weak_ptr<FrameSplit> splitX,
-                     std::weak_ptr<FrameSplit> splitY)
+                     weak_ptr<FrameSplit> splitX,
+                     weak_ptr<FrameSplit> splitY)
     : monitors_(monitors)
     , dragFrameX_(splitX)
     , dragFrameY_(splitY)

--- a/src/mousedraghandler.cpp
+++ b/src/mousedraghandler.cpp
@@ -1,6 +1,7 @@
 #include "mousedraghandler.h"
 
 #include "client.h"
+#include "decoration.h"
 #include "framedata.h"
 #include "layout.h"
 #include "monitormanager.h"
@@ -212,8 +213,12 @@ void MouseDragHandlerFloating::mouse_function_zoom(Point2D newCursorPos) {
     winDragClient_->resize_floating(dragMonitor_, get_current_client() == winDragClient_);
 }
 
-MouseResizeFrame::MouseResizeFrame(MonitorManager *monitors, shared_ptr<FrameLeaf> frame)
+MouseResizeFrame::MouseResizeFrame(MonitorManager *monitors, shared_ptr<FrameLeaf> frame,
+                     std::weak_ptr<FrameSplit> splitX,
+                     std::weak_ptr<FrameSplit> splitY)
     : monitors_(monitors)
+    , dragFrameX_(splitX)
+    , dragFrameY_(splitY)
 {
     dragMonitor_ = monitors_->byFrame(frame);
     dragMonitorIndex_ = dragMonitor_->index();
@@ -222,72 +227,16 @@ MouseResizeFrame::MouseResizeFrame(MonitorManager *monitors, shared_ptr<FrameLea
         throw DragNotPossible("Frame not on any monitor");
     }
     buttonDragStart_ = get_cursor_position();
-    Rectangle frameRect = frame->lastRect();
-    /* check whether the cursor is the following area:
-     *
-     * frameRect.tl() -> * -- +
-     *                   |\   .
-     *                   |A\  .
-     *                   |AA\ .
-     *                   |AAA\.
-     *                   +----* <- frameRect.br()
-     *
-     */
-    bool inBottomLeftTriangle =
-        (buttonDragStart_ - frameRect.tl())
-            .biggerSlopeThan(frameRect.br() - frameRect.tl());
-    /* check whether the cursor is the following area:
-     *
-     *                   +----* <- frameRect.tr()
-     *                   |AAA/.
-     *                   |AA/ .
-     *                   |A/  .
-     *                   |/   .
-     * frameRect.bl() -> * -- +
-     *
-     */
-    bool inTopLeftTriangle =
-        (frameRect.tr() - frameRect.bl())
-            .biggerSlopeThan(buttonDragStart_ - frameRect.bl());
-    /* with the combination of the above booleans we know in which of the
-     * following four areas the cursor is:
-     *
-     *    +----*
-     *    |\  /|
-     *    | \/ |
-     *    | /\ |
-     *    |/  \|
-     *    * -- +
-     */
-    Direction dir;
-    if (inBottomLeftTriangle && inTopLeftTriangle) {
-        dir = Direction::Left;
-    } else if (inBottomLeftTriangle) {
-        dir = Direction::Down;
-    } else if (inTopLeftTriangle) {
-        dir = Direction::Up;
-    } else {
-        dir = Direction::Right;
+    auto dfX = dragFrameX_.lock();
+    if (dfX != nullptr) {
+        dragDistanceUnitX_ = dfX->lastRect().width;
+        dragStartFractionX_ = dfX->getFraction();
     }
-    shared_ptr<Frame> neighbour = frame->neighbour(dir);
-    if (!neighbour) {
-        throw DragNotPossible("No neighbour frame in the direction of the cursor");
+    auto dfY = dragFrameY_.lock();
+    if (dfY != nullptr) {
+        dragDistanceUnitY_ = dfY->lastRect().height;
+        dragStartFractionY_ = dfY->getFraction();
     }
-
-    dragFrame_ = neighbour->getParent();
-    auto df = dragFrame_.lock();
-
-    if (df == nullptr) {
-        // We need this check because otherwise, -Wnull-dereference complains
-        // that a nullptr might be dereferenced:
-        throw DragNotPossible("Neighbouring frame has no parent. This should never happen, please report a bug to the developers.");
-    }
-
-    dragDistanceUnit_ =
-            (df->getAlign() == SplitAlign::vertical)
-            ? df->lastRect().height
-            : df->lastRect().width;
-    dragStartFraction_ = df->getFraction();
 }
 
 void MouseResizeFrame::finalize()
@@ -299,30 +248,51 @@ void MouseResizeFrame::finalize()
 void MouseResizeFrame::handle_motion_event(Point2D newCursorPos)
 {
     assertDraggingStillSafe();
-    auto df = dragFrame_.lock();
-
-    if (df == nullptr) {
-        // This check suppresses a false-positive for -Wnull-dereference
-        return;
-    }
+    auto dfX = dragFrameX_.lock();
+    auto dfY = dragFrameY_.lock();
 
     auto deltaVec = newCursorPos - buttonDragStart_;
-    int delta;
-    if (df->getAlign() == SplitAlign::vertical) {
-        delta = deltaVec.y;
-    } else {
-        delta = deltaVec.x;
+    // translate deltaVec from 'pixels' to 'FRACTION_UNIT'
+    if (dfX) {
+        int delta = (deltaVec.x * dragStartFractionX_.unit_) / dragDistanceUnitX_;
+        dfX->setFraction(dragStartFractionX_ + FixPrecDec::raw(delta));
     }
-    // translate delta from 'pixels' to 'FRACTION_UNIT'
-    delta = (delta * dragStartFraction_.unit_) / dragDistanceUnit_;
-    df->setFraction(dragStartFraction_ + FixPrecDec::raw(delta));
+    if (dfY) {
+        int delta = (deltaVec.y * dragStartFractionY_.unit_) / dragDistanceUnitY_;
+        dfY->setFraction(dragStartFractionY_ + FixPrecDec::raw(delta));
+    }
     dragMonitor_->applyLayout();
 }
 
-MouseDragHandler::Constructor MouseResizeFrame::construct(shared_ptr<FrameLeaf> frame)
+MouseDragHandler::Constructor MouseResizeFrame::construct(shared_ptr<FrameLeaf> frame, const ResizeAction& resize)
 {
-    return [frame](MonitorManager* monitors, Client*) {
-        return make_shared<MouseResizeFrame>(monitors, frame);
+    // a helper function to find a split in a certain direction.
+    // for simpler compilation, frame is passed as an argument
+    // and not as a closure / variable capture.
+    auto splitInDirection =
+    [](shared_ptr<FrameLeaf>& frameStart, Direction dir) -> shared_ptr<FrameSplit> {
+        shared_ptr<Frame> neighbour = frameStart->neighbour(dir);
+        if (neighbour) {
+            return neighbour->getParent();
+        }
+        return {};
+    };
+    shared_ptr<FrameSplit> horizontalSplit = {};
+    shared_ptr<FrameSplit> verticalSplit = {};
+    if (resize.left) {
+        horizontalSplit = splitInDirection(frame, Direction::Left);
+    }
+    if (resize.right) {
+        horizontalSplit = splitInDirection(frame, Direction::Right);
+    }
+    if (resize.top) {
+        verticalSplit = splitInDirection(frame, Direction::Up);
+    }
+    if (resize.bottom) {
+        verticalSplit = splitInDirection(frame, Direction::Down);
+    }
+    return [frame, horizontalSplit, verticalSplit](MonitorManager* monitors, Client*) {
+        return make_shared<MouseResizeFrame>(monitors, frame, horizontalSplit, verticalSplit);
     };
 }
 
@@ -333,7 +303,7 @@ void MouseResizeFrame::assertDraggingStillSafe()
             && dragMonitorIndex_ < monitors_->size()
             && monitors_->byIdx(dragMonitorIndex_) == dragMonitor_
             && dragTag_ == dragMonitor_->tag
-            && !dragFrame_.expired();
+            && (!dragFrameX_.expired() || !dragFrameY_.expired());
     if (!allFine) {
         throw DragNotPossible("Monitor, tag or frame disappeared");
     }

--- a/src/mousedraghandler.cpp
+++ b/src/mousedraghandler.cpp
@@ -237,6 +237,9 @@ MouseResizeFrame::MouseResizeFrame(MonitorManager *monitors, shared_ptr<FrameLea
         dragDistanceUnitY_ = dfY->lastRect().height;
         dragStartFractionY_ = dfY->getFraction();
     }
+    if (!dfX && !dfY) {
+        throw DragNotPossible("No neighbour frame");
+    }
 }
 
 void MouseResizeFrame::finalize()

--- a/src/mousedraghandler.h
+++ b/src/mousedraghandler.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <memory>
 
+#include "decoration.h"
 #include "fixprecdec.h"
 #include "rectangle.h"
 
@@ -12,6 +13,7 @@ class FrameSplit;
 class HSTag;
 class Monitor;
 class MonitorManager;
+class ResizeAction;
 
 /**
  * @brief The abstract class MouseDragHandler encapsulates what drag handling
@@ -40,6 +42,9 @@ public:
     //! a MouseDragHandler::Constructor creates a MouseDragHandler object, given the
     //! MonitorManager (as a dependency) and the actual client to drag.
     typedef std::function<std::shared_ptr<MouseDragHandler>(MonitorManager*, Client*)> Constructor;
+
+    //! the way in which the current drag handler affects the window dimensions
+    ResizeAction resizeAction_;
 protected:
     MouseDragHandler() {};
 };
@@ -82,19 +87,25 @@ private:
  */
 class MouseResizeFrame : public MouseDragHandler {
 public:
-    MouseResizeFrame(MonitorManager* monitors, std::shared_ptr<FrameLeaf> frame);
+    MouseResizeFrame(MonitorManager* monitors,
+                     std::shared_ptr<FrameLeaf> frame,
+                     std::weak_ptr<FrameSplit> splitX,
+                     std::weak_ptr<FrameSplit> splitY);
     virtual ~MouseResizeFrame() {};
     virtual void finalize();
     virtual void handle_motion_event(Point2D newCursorPos);
-    static Constructor construct(std::shared_ptr<FrameLeaf> frame);
+    static Constructor construct(std::shared_ptr<FrameLeaf> frame, const ResizeAction& direction);
 private:
     void assertDraggingStillSafe();
 
     MonitorManager*  monitors_;
     Point2D          buttonDragStart_ = {};
-    std::weak_ptr<FrameSplit> dragFrame_; //! the frame whose split is adjusted
-    FixPrecDec       dragStartFraction_ = FixPrecDec::fromInteger(0); //! initial fraction
-    int              dragDistanceUnit_; //! 100% split ratio in pixels
+    std::weak_ptr<FrameSplit> dragFrameX_; //! the frame whose split is adjusted in x direction
+    FixPrecDec       dragStartFractionX_ = FixPrecDec::fromInteger(0); //! initial fraction
+    int              dragDistanceUnitX_ = 1; //! 100% split ratio in pixels
+    std::weak_ptr<FrameSplit> dragFrameY_; //! the frame whose split is adjusted in y direction
+    FixPrecDec       dragStartFractionY_ = FixPrecDec::fromInteger(0); //! initial fraction
+    int              dragDistanceUnitY_ = 1; //! 100% split ratio in pixels
     HSTag*           dragTag_; //! the tag containing the dragFrame
     Monitor*         dragMonitor_ = nullptr; //! the monitor with the dragFrame
     unsigned long    dragMonitorIndex_ = 0;

--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -255,7 +255,7 @@ string MouseManager::mouse_initiate_drag(Client *client, const MouseDragHandler:
 {
     try {
         dragHandler_ = createHandler(monitors_, client);
-        dragHandler_->resizeAction_ = resize;
+        dragHandler_->resizeAction_ = resize * client->possibleResizeActions();
         // only grab pointer if dragHandler_ could be started
         clients_->setDragged(client);
     }  catch (const MouseDragHandler::DragNotPossible& e) {

--- a/src/mousemanager.h
+++ b/src/mousemanager.h
@@ -44,6 +44,7 @@ public:
     std::string mouse_initiate_resize(Client* client, const std::vector<std::string> &cmd);
     std::string mouse_initiate_resize(Client* client, const ResizeAction& resize);
     std::string mouse_call_command(Client* client, const std::vector<std::string> &cmd);
+    ResizeAction resizeAction();
 
 private:
     //! start dragging for the specified client (possibly up to some arguments), and return a error message
@@ -67,7 +68,7 @@ private:
     //! manually (forward-)declare MouseDragHandler::Constructor as MDC here:
     typedef std::function<std::shared_ptr<MouseDragHandler>(MonitorManager*, Client*)> MDC;
     //! start a the drag, and if it does not work out, return an error message
-    std::string mouse_initiate_drag(Client* client, const MDC& createHandler);
+    std::string mouse_initiate_drag(Client* client, const MDC& createHandler, ResizeAction resize);
 
     std::map<std::string, MouseFunction> mouseFunctions_;
     std::shared_ptr<MouseDragHandler> dragHandler_;

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -1,5 +1,6 @@
 #include "xmainloop.h"
 
+#include <X11/cursorfont.h>
 #include <X11/X.h>
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
@@ -632,10 +633,13 @@ IpcServer::CallResult XMainLoop::callCommand(const vector<string>& call)
 void XMainLoop::draggedClientChanges(Client* draggedClient)
 {
     if (draggedClient) {
+        ResizeAction ra = root_->mouse->resizeAction();
+        auto maybeCursor = ra.toCursorShape();
+        Cursor cursorShape = XCreateFontCursor(X_.display(), maybeCursor.value_or(XC_fleur));
         // listen for mouse motion events:
         XGrabPointer(X_.display(), draggedClient->x11Window(), True,
             PointerMotionMask|ButtonReleaseMask, GrabModeAsync,
-                GrabModeAsync, None, None, CurrentTime);
+                GrabModeAsync, None, cursorShape, CurrentTime);
     } else { // no client is dragged -> ungrab and clear the queue
         XUngrabPointer(X_.display(), CurrentTime);
         // remove all enternotify-events from the event queue that were

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -1,9 +1,9 @@
 #include "xmainloop.h"
 
-#include <X11/cursorfont.h>
 #include <X11/X.h>
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
+#include <X11/cursorfont.h>
 #include <sys/wait.h>
 #include <iostream>
 #include <memory>


### PR DESCRIPTION
This implements a feature which was already indicated by the cursor shape:
resizing frames in both x and y direction. For this, it was necessary to
entirely change the drag handler for resizing frames.

As a little bonus, the special cursor shape persists during the drag.

The new test case essentially checks that resizing in both dimensions
works as expected. The existing testcase for 1-dimensional resize
could be simplified a lot using new attributes and the convenience
functions in the python bindings.
