### PR TITLE
tests: Fix Xvfb shutdown timeout

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -991,7 +991,11 @@ class MultiscreenDisplay:
 
     def __exit__(self, type_param, value, traceback):
         self.proc.terminate()
-        self.proc.wait(PROCESS_SHUTDOWN_TIME)
+        try:
+            self.proc.wait(PROCESS_SHUTDOWN_TIME)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait(PROCESS_SHUTDOWN_TIME)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Recently, a timeout exception in the CI was repeatedly thrown during the
shutdown of the test_ipc_reply_with_error_channel test case, causing
annoying failures of the CI. One can reliably reproduce the timeout by
increasing the repeat parameter of the test case.

The fix is to send sigkill if the process did not shut down after the
sigterm. Of course, this implicitly doubles the timeout. Anyway, this
should solve the issue for us.