### PR TITLE
Added hlwm-save-tree to the contributions website

### DIFF
--- a/www/contrib.txt
+++ b/www/contrib.txt
@@ -4,6 +4,7 @@ Users contributions
 * tag_spaces by AnomalousBit: groups of tags similar to KDE Plasma activities. Get it from https://github.com/AnomalousBit/tag_spaces[github!]
 * Automatically disable focus_follows_mouse for floating windows by u/pmade. Get it from https://github.com/pjones/hlwmrc/blob/9f38a3023660c8c1b617be7689823f09115ecf75/bin/hlwm-ffm-skip-floats.sh[github!]
 * Layout save and recall function by u/ToPow1. Get it from https://www.reddit.com/r/herbstluftwm/comments/o13vny/layout_save_and_recall_function_for_herbstluftwm[this post on reddit!]
+* hlwm-save-tree by juacq97. Save and restore splits and windows locations using dmenu. The windows are swallowed if they're not opened when the layout is loaded. Get it from https://github.com/juacq97/hlwm-save-tree[github!]
 
 How to contribute?
 ------------------


### PR DESCRIPTION
Hi!, finally I added my own contribution to the webpage,
hlwm-save-tree is a script that load and restore layouts, but this
script also saves the location of the windows, similar to i3's
i3-save-tree feature. It uses dmenu to save and list the layouts.