### PR TITLE
Attribute to disable window decorations

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ Current git version
     'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'
   * The 'spawn' command now prints an error message on exec failure
   * New read-only client attribute 'decoration_geometry'.
+  * New attribute 'decorated' to disable window decorations
   * The cursor shape now indicates resize options.
   * Frames can be simultaneously resized in x and y direction with the mouse.
   * Bug fixes:

--- a/share/autostart
+++ b/share/autostart
@@ -85,6 +85,7 @@ hc keybind $Mod-r remove
 hc keybind $Mod-s floating toggle
 hc keybind $Mod-f fullscreen toggle
 hc keybind $Mod-Shift-f set_attr clients.focus.floating toggle
+hc keybind $Mod-Shift-d set_attr clients.focus.decorated toggle
 hc keybind $Mod-Shift-m set_attr clients.focus.minimized true
 hc keybind $Mod-Control-m jumpto last-minimized
 hc keybind $Mod-p pseudotile toggle

--- a/src/client.h
+++ b/src/client.h
@@ -39,6 +39,7 @@ public:
     Slice* slice = {};
     bool        ewmhfullscreen_ = false; // ewmh fullscreen state
     bool        neverfocus_ = false; // do not give the focus via XSetInputFocus
+    Attribute_<bool> decorated_;
     Attribute_<bool> visible_;
     bool        dragged_ = false;  // if this client is dragged currently
     int         ignore_unmaps_ = 0;  // Ignore one unmap for each reparenting
@@ -136,6 +137,7 @@ public:
     void updateEwmhState();
 private:
     void floatingGeometryChanged();
+    void fixParentWindow(bool decorated);
     Rectangle decorationGeometry();
     std::string getWindowClass();
     std::string getWindowInstance();

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -274,7 +274,11 @@ ResizeAction Decoration::resizeFromRoughCursorPosition(Point2D cursor)
 
 void Decoration::resize_outline(Rectangle outline, const DecorationScheme& scheme)
 {
+    bool decorated = client_->decorated_();
     auto inner = scheme.outline_to_inner_rect(outline);
+    if (!decorated) {
+        inner = outline;
+    }
     Window win = client_->window_;
 
     auto tile = inner;
@@ -294,15 +298,19 @@ void Decoration::resize_outline(Rectangle outline, const DecorationScheme& schem
     //    return;
     //}
 
-    if (scheme.tight_decoration()) {
+    if (decorated && scheme.tight_decoration()) {
         // updating the outline only has an affect for tiled clients
         // because for floating clients, this has been done already
         // right when the window size changed.
         outline = scheme.inner_rect_to_outline(inner);
     }
     last_inner_rect = inner;
-    inner.x -= outline.x;
-    inner.y -= outline.y;
+    if (decorated) {
+        // if the window is decorated, then x/y are relative
+        // to the decoration window's top left
+        inner.x -= outline.x;
+        inner.y -= outline.y;
+    }
     XWindowChanges changes;
     changes.x = inner.x;
     changes.y = inner.y;
@@ -337,33 +345,40 @@ void Decoration::resize_outline(Rectangle outline, const DecorationScheme& schem
         last_actual_rect.width = changes.width;
         last_actual_rect.height = changes.height;
     }
-    redrawPixmap();
     XConnection& xcon = xconnection();
-    XSetWindowBackgroundPixmap(xcon.display(), decwin, pixmap);
-    if (!size_changed) {
-        // if size changes, then the window is cleared automatically
-        XClearWindow(xcon.display(), decwin);
-    }
-    if (!client_->dragged_ || settings_.update_dragged_clients()) {
+    if (decorated) {
+        redrawPixmap();
+        XSetWindowBackgroundPixmap(xcon.display(), decwin, pixmap);
+        if (!size_changed) {
+            // if size changes, then the window is cleared automatically
+            XClearWindow(xcon.display(), decwin);
+        }
+        if (!client_->dragged_ || settings_.update_dragged_clients()) {
+            XConfigureWindow(xcon.display(), win, mask, &changes);
+            XMoveResizeWindow(xcon.display(), bgwin,
+                              changes.x, changes.y,
+                              changes.width, changes.height);
+        }
+    } else {
+        // resize the client window
         XConfigureWindow(xcon.display(), win, mask, &changes);
-        XMoveResizeWindow(xcon.display(), bgwin,
-                          changes.x, changes.y,
-                          changes.width, changes.height);
     }
     // update geometry of resizeArea window
-    int bw = 0;
-    if (last_scheme) {
-        bw = last_scheme->border_width();
+    if (decorated) {
+        int bw = 0;
+        if (last_scheme) {
+            bw = last_scheme->border_width();
+        }
+        Rectangle areaGeo;
+        for (size_t i = 0; i < resizeAreaSize; i++) {
+            areaGeo = resizeAreaGeometry(i, bw, outline.width, outline.height);
+            XMoveResizeWindow(xcon.display(), resizeArea[i],
+                              areaGeo.x, areaGeo.y,
+                              areaGeo.width, areaGeo.height);
+        }
+        XMoveResizeWindow(xcon.display(), decwin,
+                          outline.x, outline.y, outline.width, outline.height);
     }
-    Rectangle areaGeo;
-    for (size_t i = 0; i < resizeAreaSize; i++) {
-        areaGeo = resizeAreaGeometry(i, bw, outline.width, outline.height);
-        XMoveResizeWindow(xcon.display(), resizeArea[i],
-                          areaGeo.x, areaGeo.y,
-                          areaGeo.width, areaGeo.height);
-    }
-    XMoveResizeWindow(xcon.display(), decwin,
-                      outline.x, outline.y, outline.width, outline.height);
     updateFrameExtends();
     if (!client_->dragged_ || settings_.update_dragged_clients()) {
         client_->send_configure(false);
@@ -376,6 +391,12 @@ void Decoration::updateFrameExtends() {
     int top  = last_inner_rect.y - last_outer_rect.y;
     int right = last_outer_rect.width - last_inner_rect.width - left;
     int bottom = last_outer_rect.height - last_inner_rect.height - top;
+    if (!client_->decorated_()) {
+        left = 0;
+        top = 0;
+        right = 0;
+        bottom = 0;
+    }
     client_->ewmh.updateFrameExtents(client_->window_, left,right, top,bottom);
 }
 
@@ -398,8 +419,10 @@ void Decoration::change_scheme(const DecorationScheme& scheme) {
 
 void Decoration::redraw()
 {
-    if (last_scheme) {
-        change_scheme(*last_scheme);
+    if (client_->decorated_()) {
+        if (last_scheme) {
+            change_scheme(*last_scheme);
+        }
     }
 }
 

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -174,7 +174,12 @@ Rectangle DecorationScheme::inner_rect_to_outline(Rectangle rect) const {
 }
 
 void Decoration::resize_inner(Rectangle inner, const DecorationScheme& scheme) {
-    resize_outline(scheme.inner_rect_to_outline(inner), scheme);
+    // if the client is undecorated, the outline is identical to the inner geometry
+    // otherwise, we convert the geometry using the theme
+    auto outline = (client_->decorated_())
+                   ? scheme.inner_rect_to_outline(inner)
+                   : inner;
+    resize_outline(outline, scheme);
     last_rect_inner = true;
 }
 

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -113,7 +113,11 @@ void Slice::extractWindowsFromSlice(bool real_clients, HSLayer layer,
             if (real_clients) {
                 yield(data.client->x11Window());
             } else {
-                yield(data.client->decorationWindow());
+                if (data.client->decorated_()) {
+                    yield(data.client->decorationWindow());
+                } else {
+                    yield(data.client->x11Window());
+                }
             }
             break;
         case Type::WindowSlice:

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -486,6 +486,7 @@ void XMainLoop::mapnotify(XMapEvent* event) {
         // also update the window title - just to be sure
         c->update_title();
     } else if (!root_->ewmh_.isOwnWindow(event->window)
+               && !Decoration::toClient(event->window)
                && !is_herbstluft_window(X_.display(), event->window)) {
         // the window is not managed.
         HSDebug("MapNotify: briefly managing 0x%lx to apply rules\n", event->window);
@@ -590,8 +591,12 @@ void XMainLoop::propertynotify(XPropertyEvent* ev) {
 }
 
 void XMainLoop::unmapnotify(XUnmapEvent* event) {
-    HSDebug("name is: UnmapNotify for %lx\n", event->window);
-    root_->clients()->unmap_notify(event->window);
+    HSDebug("name is: UnmapNotify for window=0x%lx and event=0x%lx\n", event->window, event->event);
+    if (event->window == event->event) {
+        // reparenting the window creates multiple unmap notify events,
+        // both for the root window and the window itself.
+        root_->clients()->unmap_notify(event->window);
+    }
     if (event->send_event) {
         // if the event was synthetic, then we need to understand it as a kind request
         // by the window to be unmanaged. I don't understand fully how this is implied

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -509,3 +509,37 @@ def test_floating_effectively_x11_property(hlwm, x11):
                 assert hlwm.attr.clients[winid].floating_effectively() is False
                 assert prop_float is None
                 assert prop_tile[0] == 1
+
+
+def assert_decoration_state_correct(hlwm, x11, winid):
+    handle = x11.window(winid)
+    client_obj = hlwm.attr.clients[winid]
+    assert client_obj.content_geometry() \
+        == x11.get_absolute_geometry(handle)
+    if not client_obj.decorated():
+        assert client_obj.content_geometry() == client_obj.decoration_geometry()
+
+
+def test_decorated_off_vs_x11(hlwm, x11):
+    handle, winid = x11.create_client()
+    hlwm.attr.theme.border_width = 11
+    for floating in [True, False]:
+        hlwm.attr.clients[winid].floating = floating
+        for decorated in [True, False]:
+            hlwm.attr.clients[winid].decorated = decorated
+
+            assert_decoration_state_correct(hlwm, x11, winid)
+
+
+def test_decorated_off_floating_geometry_correct(hlwm):
+    winid, _ = hlwm.create_client()
+    hlwm.attr.theme.border_width = 8
+    client_obj = hlwm.attr.clients[winid]
+
+    client_obj.floating_geometry = Rectangle(10, 20, 200, 100)
+    client_obj.floating = True
+    client_obj.decorated = False
+
+    assert client_obj.floating_geometry() == client_obj.decoration_geometry()
+
+

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -541,5 +541,3 @@ def test_decorated_off_floating_geometry_correct(hlwm):
     client_obj.decorated = False
 
     assert client_obj.floating_geometry() == client_obj.decoration_geometry()
-
-


### PR DESCRIPTION
This adds a client attribute 'decorated' that adjusts whether a client
has a window decoration frame. Changing the option reparents the window
either to the root or to the decoration window.

This should make it easier to work with shaped windows and to solve
issues with freesync (#1347).