### PR TITLE
Draw tabs in max layout

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ older versions.
 Current git version
 -------------------
 
+  * Tabbed window titles in the 'max' layout algorithm (controllable via the
+    'tabbed_max' setting)
   * New autostart object with attributes 'path', 'running', 'pid', 'last_status'
   * New client attribute 'floating_effectively' and associated X11 properties
     'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1077,6 +1077,10 @@ raise_on_click (Boolean)::
     If set, a window is raised if it is clicked. The value of this setting is
     only noticed in floating mode.
 
+tabbed_max (Boolean)::
+    If set, multiple windows in a frame with the 'max'
+    layout algorithm are drawn as tabs.
+
 window_border_width (Integer)::
     Border width of a window.
     *Warning:* This only exists for compatibility reasons; it is only an alias for

--- a/share/autostart
+++ b/share/autostart
@@ -126,7 +126,7 @@ hc set frame_gap 4
 hc attr theme.title_height 15
 hc attr theme.title_font 'Dejavu Sans:pixelsize=12'  # example using Xft
 # hc attr theme.title_font '-*-fixed-medium-r-*-*-13-*-*-*-*-*-*-*'
-hc attr theme.padding_top 2  # space below the title's baseline (i.e. text depth)
+hc attr theme.padding_top 3  # space below the title's baseline (i.e. text depth)
 hc attr theme.active.color '#345F0Cef'
 hc attr theme.title_color '#ffffff'
 hc attr theme.normal.color '#323232dd'
@@ -146,7 +146,7 @@ for state in active urgent normal ; do
     hc substitute C theme.${state}.inner_color \
         attr theme.${state}.outer_color C
 done
-hc attr theme.active.outer_width 1
+hc attr theme.tiling.outer_width 1
 hc attr theme.background_color '#141414'
 
 hc set window_gap 0

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -336,7 +336,7 @@ void Client::redrawRelevantTabBars()
         // if this client is mentioned in another client's tab bar,
         // then update also that
         FrameLeaf* parent = parentFrame();
-        if (parent->getLayout() == LayoutAlgorithm::max) {
+        if (parent && parent->getLayout() == LayoutAlgorithm::max) {
             parent->foreachClient([&](Client* otherClient) {
                 if (otherClient != this) {
                     otherClient->dec->redraw();
@@ -780,6 +780,11 @@ FrameLeaf* Client::parentFrame()
     if (is_client_floated()) {
         return nullptr;
     } else {
+        if (!tag_) {
+            // a fallback if this is called in the early
+            // phase of a client object
+            return nullptr;
+        }
         return tag_->frame->findFrameWithClient(this).get();
     }
 }

--- a/src/client.h
+++ b/src/client.h
@@ -111,7 +111,7 @@ public:
     Rectangle outer_floating_rect();
 
     void setup_border(bool focused);
-    void resize_tiling(Rectangle rect, bool isFocused, bool minimalDecoration);
+    void resize_tiling(Rectangle rect, bool isFocused, bool minimalDecoration, std::vector<Client*> tabs);
     void resize_floating(Monitor* m, bool isFocused);
     void resize_fullscreen(Rectangle m, bool isFocused);
     bool is_client_floated();
@@ -138,6 +138,8 @@ public:
 private:
     void floatingGeometryChanged();
     void fixParentWindow(bool decorated);
+    void redraw();
+    void redrawRelevantTabBars();
     Rectangle decorationGeometry();
     std::string getWindowClass();
     std::string getWindowInstance();
@@ -152,6 +154,7 @@ private:
     XConnection& X_;
     std::string tagName();
     const DecTriple& getDecTriple();
+    const DecorationScheme& getDecorationScheme(bool focused);
     Theme::Type mostRecentThemeType;
 };
 

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -210,6 +210,17 @@ void Decoration::updateResizeAreaCursors()
     }
 }
 
+std::experimental::optional<Decoration::ClickArea>
+Decoration::positionHasButton(Point2D p)
+{
+    for (auto& button : buttons_) {
+        if (button.area_.contains(p)) {
+            return button;
+        }
+    }
+    return {};
+}
+
 /**
  * @brief Tell whether clicking on the decoration at the specified location
  * should result in resizing or moving the client
@@ -467,6 +478,7 @@ void Decoration::redrawPixmap() {
         }
         dec->pixmap = XCreatePixmap(display, decwin, outer.width, outer.height, depth);
     }
+    buttons_.clear();
     Pixmap pix = dec->pixmap;
     GC gc = XCreateGC(display, pix, 0, nullptr);
 
@@ -549,6 +561,13 @@ void Decoration::redrawPixmap() {
                     tabWidth + int(isLast ? (outer.width % tabs_.size()) : 0),
                     int(s.title_height() + s.padding_top()), // tab height
                 };
+                if (tabClient != client_) {
+                    // only add clickable buttons for the other clients
+                    ClickArea tabButton;
+                    tabButton.area_ = tabGeo;
+                    tabButton.tabClient_ = tabClient;
+                    buttons_.push_back(tabButton);
+                }
                 int titleWidth = tabGeo.width;
                 if (tabClient == client_) {
                     tabGeo.height += s.border_width() - s.inner_width();

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -37,6 +37,12 @@ public:
 
 class Decoration {
 public:
+    class ClickArea {
+    public:
+        Rectangle area_ = {}; //! where to click
+        Client* tabClient_ = {}; //! the client that will get activated
+    };
+
     Decoration(Client* client_, Settings& settings_);
     void createWindow();
     virtual ~Decoration();
@@ -57,6 +63,7 @@ public:
 
     void updateResizeAreaCursors();
 
+    std::experimental::optional<ClickArea> positionHasButton(Point2D p);
     ResizeAction positionTriggersResize(Point2D p);
     ResizeAction resizeFromRoughCursorPosition(Point2D cursor);
 
@@ -78,6 +85,7 @@ private:
     Rectangle   last_outer_rect = {0, 0, 0, 0}; // only valid if width >= 0
     Rectangle   last_actual_rect = {0, 0, 0, 0}; // last actual client rect, relative to decoration
     std::vector<Client*>    tabs_ = {}; //! the tabs shown in the decoration
+    std::vector<ClickArea>  buttons_ = {};
     /* X specific things */
     Visual*                 visual = nullptr;
     Colormap                colormap = 0;

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -41,7 +41,7 @@ public:
     void createWindow();
     virtual ~Decoration();
     // resize such that the decorated outline of the window fits into rect
-    void resize_outline(Rectangle outline, const DecorationScheme& scheme);
+    void resize_outline(Rectangle outline, const DecorationScheme& scheme, std::vector<Client*> tabs);
 
     // resize such that the window content fits into rect
     void resize_inner(Rectangle inner, const DecorationScheme& scheme);
@@ -77,6 +77,7 @@ private:
     Rectangle   last_inner_rect = {0, 0, 0, 0}; // only valid if width >= 0
     Rectangle   last_outer_rect = {0, 0, 0, 0}; // only valid if width >= 0
     Rectangle   last_actual_rect = {0, 0, 0, 0}; // last actual client rect, relative to decoration
+    std::vector<Client*>    tabs_ = {}; //! the tabs shown in the decoration
     /* X specific things */
     Visual*                 visual = nullptr;
     Colormap                colormap = 0;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -255,7 +255,9 @@ TilingResult FrameLeaf::layoutMax(Rectangle rect) {
         if (client == clients[selection]) {
             step.needsRaise = true;
         }
-        step.tabs = clients;
+        if (settings_->tabbed_max()) {
+            step.tabs = clients;
+        }
         res.add(client, step);
     }
     return res;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -255,6 +255,7 @@ TilingResult FrameLeaf::layoutMax(Rectangle rect) {
         if (client == clients[selection]) {
             step.needsRaise = true;
         }
+        step.tabs = clients;
         res.add(client, step);
     }
     return res;

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -243,7 +243,7 @@ void Monitor::applyLayout() {
             c->resize_floating(this, clientFocused);
         } else {
             bool minDec = p.second.minimalDecoration;
-            c->resize_tiling(p.second.geometry, clientFocused, minDec);
+            c->resize_tiling(p.second.geometry, clientFocused, minDec, p.second.tabs);
         }
     }
     for (auto& c : tag->floating_clients_) {

--- a/src/rectangle.h
+++ b/src/rectangle.h
@@ -42,6 +42,10 @@ struct Rectangle {
 
     Rectangle intersectionWith(const Rectangle& other) const;
     int manhattanDistanceTo(Rectangle& other) const;
+    bool contains(Point2D p) const {
+        return x <= p.x && p.x < x + width
+                && y <= p.y && p.y < y + height;
+    };
 
     int x;
     int y;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -136,7 +136,7 @@ Settings::Settings()
     );
     tabbed_max.setDoc(
         "if activated, multiple windows in a frame with the \'max\' "
-        "algorithm are drawn as tabs."
+        "layout algorithm are drawn as tabs."
     );
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -70,6 +70,7 @@ Settings::Settings()
         &raise_on_focus_temporarily,
         &raise_on_click,
         &gapless_grid,
+        &tabbed_max,
         &hide_covered_windows,
         &smart_frame_surroundings,
         &smart_window_surroundings,
@@ -111,6 +112,7 @@ Settings::Settings()
     frame_bg_transparent.setWritable();
     for (auto i : {&always_show_frame,
          &gapless_grid,
+         &tabbed_max,
          &smart_frame_surroundings,
          &smart_window_surroundings,
          &raise_on_focus_temporarily}) {
@@ -131,6 +133,10 @@ Settings::Settings()
     setDoc(
         "This has an attribute for each setting. Many settings are "
         "wrappers around attributes and only exist for compatibility."
+    );
+    tabbed_max.setDoc(
+        "if activated, multiple windows in a frame with the \'max\' "
+        "algorithm are drawn as tabs."
     );
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -56,6 +56,7 @@ public:
     Attribute_<bool>          raise_on_focus_temporarily = {"raise_on_focus_temporarily", false};
     Attribute_<bool>          raise_on_click = {"raise_on_click", true};
     Attribute_<bool>          gapless_grid = {"gapless_grid", true};
+    Attribute_<bool>          tabbed_max = {"tabbed_max", true};
     Attribute_<bool>          hide_covered_windows = {"hide_covered_windows", false};
     Attribute_<bool>          smart_frame_surroundings = {"smart_frame_surroundings", false};
     Attribute_<bool>          smart_window_surroundings = {"smart_window_surroundings", false};

--- a/src/tilingresult.h
+++ b/src/tilingresult.h
@@ -20,6 +20,7 @@ public:
                          //! by another window (e.g. in max layout)
     bool minimalDecoration = false; //! minimal window decration, e.g. when
                                     //! smart_window_surroundings is active
+    std::vector<Client*> tabs = {}; //! tabs, including the client itself
 };
 
 // a tiling result contains the movement commands etc. for all clients

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -239,7 +239,6 @@ void XMainLoop::buttonpress(XButtonEvent* be) {
         if (!client) {
             client = Decoration::toClient(be->window);
         }
-        if (client && client->dec)
         if (client) {
             Client* tabClient = {};
             if (client->dec->decorationWindow() && be->button == Button1) {

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -241,7 +241,9 @@ void XMainLoop::buttonpress(XButtonEvent* be) {
         }
         if (client) {
             Client* tabClient = {};
-            if (client->dec->decorationWindow() && be->button == Button1) {
+            if (be->window == client->dec->decorationWindow()
+                && be->button == Button1)
+            {
                 auto maybeClick = client->dec->positionHasButton({be->x, be->y});
                 if (maybeClick.has_value()) {
                     tabClient = maybeClick.value().tabClient_;

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -239,15 +239,27 @@ void XMainLoop::buttonpress(XButtonEvent* be) {
         if (!client) {
             client = Decoration::toClient(be->window);
         }
+        if (client && client->dec)
         if (client) {
+            Client* tabClient = {};
+            if (client->dec->decorationWindow() && be->button == Button1) {
+                auto maybeClick = client->dec->positionHasButton({be->x, be->y});
+                if (maybeClick.has_value()) {
+                    tabClient = maybeClick.value().tabClient_;
+                }
+            }
             bool raise = root_->settings->raise_on_click();
-            focus_client(client, false, true, raise);
-            if (be->window == client->decorationWindow()) {
-                ResizeAction resize = client->dec->positionTriggersResize({be->x, be->y});
-                if (resize) {
-                    mm->mouse_initiate_resize(client, resize);
-                } else {
-                    mm->mouse_initiate_move(client, {});
+            if (tabClient) {
+                focus_client(tabClient, false, true, raise);
+            } else {
+                focus_client(client, false, true, raise);
+                if (be->window == client->decorationWindow()) {
+                    ResizeAction resize = client->dec->positionTriggersResize({be->x, be->y});
+                    if (resize) {
+                        mm->mouse_initiate_resize(client, resize);
+                    } else {
+                        mm->mouse_initiate_move(client, {});
+                    }
                 }
             }
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -681,6 +681,13 @@ class RawImage:
                 count += 1
         return count
 
+    def color_count_dict(self):
+        """return a dictionary telling how often each color occurs"""
+        result = {}
+        for pix in self.data:
+            result[pix] = result.get(pix, 0) + 1
+        return result
+
     @staticmethod
     def rgb2string(rgb_triple):
         return '#%02x%02x%02x' % rgb_triple
@@ -850,6 +857,10 @@ class X11:
     def decoration_screenshot(self, win_handle):
         decoration = self.get_decoration_window(win_handle)
         return self.screenshot(decoration)
+
+    def set_window_title(self, win_handle, title):
+        self.set_property_textlist('_NET_WM_NAME', [title], window=win_handle)
+        self.sync_with_hlwm()
 
     def sync_with_hlwm(self):
         self.display.sync()

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -254,3 +254,27 @@ def test_frame_holes_for_pseudotiled_client(hlwm, x11, frame_bg_transparent):
     img.pixel(0, h // 2) == black
     img.pixel(w - 1, h // 2) == black
     img.pixel(w // 2, h // 2) == black
+
+
+def test_decoration_click_into_window_does_not_change_tab(hlwm, mouse):
+    wins = hlwm.create_clients(2)
+    hlwm.call(['load', '(clients max:1 {})'.format(' '.join(wins))])
+    hlwm.attr.settings.tabbed_max = True
+    hlwm.attr.theme.title_height = 10
+
+    assert hlwm.attr.clients.focus.winid() == wins[1]
+
+    # move into the window and click:
+    mouse.move_into(wins[0], x=4, y=4)
+    mouse.click('1')
+
+    # this does not change the focus:
+    assert hlwm.attr.clients.focus.winid() == wins[1]
+
+    # to double check:
+    # if the cursor was 8px further up, the click
+    # however would change the tab
+    mouse.move_relative(0, -8)
+    mouse.click('1')
+
+    assert hlwm.attr.clients.focus.winid() == wins[0]

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -363,7 +363,6 @@ def test_decoration_click_changes_tab(hlwm, mouse, running_clients, running_clie
         # and the bottom right corner of the title bar:
         # the extra 0.5 makes that we click in the middle of the tab
         ratio = (idx + 0.5) / running_clients_num
-        print(f'ratio = {ratio}')
         cursor = tabbar_top_left * (1 - ratio) + tabbar_bottom_right * ratio
         mouse.move_to(cursor.x, cursor.y)
         mouse.click('1')

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -349,7 +349,6 @@ def test_decoration_tab_title_update(hlwm, x11):
     assert x11.decoration_screenshot(win_handles[0]).color_count(text_color) > 5
 
 
-
 @pytest.mark.parametrize("running_clients_num", [4])
 def test_decoration_click_changes_tab(hlwm, mouse, running_clients, running_clients_num):
     hlwm.call(['load', '(clients max:0 {})'.format(' '.join(running_clients))])

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -309,7 +309,7 @@ def test_decoration_tab_urgent(hlwm, x11, running_clients, running_clients_num):
     color_count = img.color_count_dict()
     assert urgent_color not in color_count
 
-    # make one of the unfocsed tabs urgent
+    # make one of the unfocused tabs urgent
     x11.make_window_urgent(x11.window(running_clients[2]))
     img = x11.decoration_screenshot(winhandle)
     new_color_count = img.color_count_dict()
@@ -358,8 +358,6 @@ def test_decoration_click_changes_tab(hlwm, mouse, running_clients, running_clie
     geo = hlwm.attr.clients.focus.decoration_geometry()
     tabbar_top_left = geo.topleft()
     tabbar_bottom_right = geo.topleft() + Point(geo.width, hlwm.attr.theme.title_height())
-    print(f"tl {tabbar_top_left}")
-    print(f"br {tabbar_bottom_right}")
     for idx in reversed(range(0, running_clients_num)):
         # pick a point between top left corner of the title bar
         # and the bottom right corner of the title bar:

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -1,3 +1,4 @@
+from herbstluftwm.types import Point
 from conftest import RawImage
 from conftest import HlwmBridge
 import pytest
@@ -70,8 +71,7 @@ def screenshot_with_title(x11, win_handle, title):
     """ set the win_handle's window title and then
     take a screenshot
     """
-    x11.set_property_textlist('_NET_WM_NAME', [title], window=win_handle)
-    x11.sync_with_hlwm()
+    x11.set_window_title(win_handle, title)
     # double check that hlwm has updated the client's title:
     winid = x11.winid_str(win_handle)
     hlwm = HlwmBridge.INSTANCE
@@ -254,6 +254,124 @@ def test_frame_holes_for_pseudotiled_client(hlwm, x11, frame_bg_transparent):
     img.pixel(0, h // 2) == black
     img.pixel(w - 1, h // 2) == black
     img.pixel(w // 2, h // 2) == black
+
+
+@pytest.mark.parametrize("running_clients_num", [3])
+def test_decoration_tab_colors(hlwm, x11, running_clients, running_clients_num):
+    active_color = (200, 23, 0)  # something unique
+    normal_color = (23, 200, 0)  # something unique
+    hlwm.attr.theme.active.color = RawImage.rgb2string(active_color)
+    hlwm.attr.theme.active.title_color = RawImage.rgb2string(active_color)
+    hlwm.attr.theme.normal.color = RawImage.rgb2string(normal_color)
+    hlwm.attr.theme.normal.title_color = RawImage.rgb2string(normal_color)
+
+    hlwm.attr.theme.title_height = 20
+    hlwm.call(['set_layout', 'max'])
+    # split twice to make tab area smaller and screenshots faster :-)
+    hlwm.call(['split', 'bottom'])
+    hlwm.call(['split', 'bottom'])
+
+    winhandle = x11.window(hlwm.attr.clients.focus.winid())
+    img = x11.decoration_screenshot(winhandle)
+    color_count = img.color_count_dict()
+    # we have three tabs, and one of them should have the active color:
+    assert color_count[active_color] * (running_clients_num - 1) == color_count[normal_color]
+
+    # if we disable tabs, then the 'normal_color' should disappear:
+    hlwm.attr.settings.tabbed_max = False
+    winhandle = x11.window(hlwm.attr.clients.focus.winid())
+    img = x11.decoration_screenshot(winhandle)
+    new_color_count = img.color_count_dict()
+    assert normal_color not in new_color_count
+    assert new_color_count[active_color] == running_clients_num * color_count[active_color]
+
+
+@pytest.mark.parametrize("running_clients_num", [3])
+def test_decoration_tab_urgent(hlwm, x11, running_clients, running_clients_num):
+    active_color = (200, 23, 0)  # something unique
+    normal_color = (23, 200, 0)  # something unique
+    urgent_color = (17, 2, 189)  # something unique
+    hlwm.attr.theme.active.color = RawImage.rgb2string(active_color)
+    hlwm.attr.theme.active.title_color = RawImage.rgb2string(active_color)
+    hlwm.attr.theme.normal.color = RawImage.rgb2string(normal_color)
+    hlwm.attr.theme.normal.title_color = RawImage.rgb2string(normal_color)
+    hlwm.attr.theme.urgent.color = RawImage.rgb2string(urgent_color)
+    hlwm.attr.theme.urgent.title_color = RawImage.rgb2string(urgent_color)
+
+    hlwm.attr.theme.title_height = 20
+    hlwm.call(['load', '(clients max:0 {})'.format(' '.join(running_clients))])
+    # split twice to make tab area smaller and screenshots faster :-)
+    hlwm.call(['split', 'bottom'])
+    hlwm.call(['split', 'bottom'])
+
+    winhandle = x11.window(running_clients[0])
+    img = x11.decoration_screenshot(winhandle)
+    color_count = img.color_count_dict()
+    assert urgent_color not in color_count
+
+    # make one of the unfocsed tabs urgent
+    x11.make_window_urgent(x11.window(running_clients[2]))
+    img = x11.decoration_screenshot(winhandle)
+    new_color_count = img.color_count_dict()
+    assert urgent_color in new_color_count
+    # there is one 'normal' and one 'urgent' tab, so the colors should
+    # appear similarly often:
+    assert new_color_count[urgent_color] == new_color_count[normal_color]
+    assert new_color_count[normal_color] == color_count[normal_color] / 2
+
+
+def test_decoration_tab_title_update(hlwm, x11):
+    text_color = (212, 189, 140)
+    hlwm.attr.theme.title_color = RawImage.rgb2string(text_color)
+    hlwm.attr.theme.title_height = 20
+    hlwm.call(['set_layout', 'max'])
+    # split twice to make tab area smaller and screenshots faster :-)
+    hlwm.call(['split', 'bottom'])
+    hlwm.call(['split', 'bottom'])
+
+    count = 5
+    win_handles = [x11.create_client()[0] for _ in range(0, count)]
+
+    # empty all window titles:
+    for wh in win_handles:
+        x11.set_window_title(wh, '')
+
+    # focus handle 0:
+    hlwm.call(['jumpto', x11.winid_str(win_handles[0])])
+
+    # take a screenshot, it should not contain the text_color:
+    assert x11.decoration_screenshot(win_handles[0]).color_count(text_color) == 0
+
+    # change the title of an unfocused window:
+    x11.set_window_title(win_handles[2], 'SOMETHING')
+    # this change should now be visible in the tab bar, at least 5 pixels
+    # should have this color now:
+    assert x11.decoration_screenshot(win_handles[0]).color_count(text_color) > 5
+
+
+
+@pytest.mark.parametrize("running_clients_num", [4])
+def test_decoration_click_changes_tab(hlwm, mouse, running_clients, running_clients_num):
+    hlwm.call(['load', '(clients max:0 {})'.format(' '.join(running_clients))])
+    hlwm.attr.settings.tabbed_max = True
+    hlwm.attr.theme.title_height = 10
+
+    geo = hlwm.attr.clients.focus.decoration_geometry()
+    tabbar_top_left = geo.topleft()
+    tabbar_bottom_right = geo.topleft() + Point(geo.width, hlwm.attr.theme.title_height())
+    print(f"tl {tabbar_top_left}")
+    print(f"br {tabbar_bottom_right}")
+    for idx in reversed(range(0, running_clients_num)):
+        # pick a point between top left corner of the title bar
+        # and the bottom right corner of the title bar:
+        # the extra 0.5 makes that we click in the middle of the tab
+        ratio = (idx + 0.5) / running_clients_num
+        print(f'ratio = {ratio}')
+        cursor = tabbar_top_left * (1 - ratio) + tabbar_bottom_right * ratio
+        mouse.move_to(cursor.x, cursor.y)
+        mouse.click('1')
+
+        assert hlwm.attr.clients.focus.winid() == running_clients[idx]
 
 
 def test_decoration_click_into_window_does_not_change_tab(hlwm, mouse):


### PR DESCRIPTION
This draws the hidden windows in max layout as tabs if the setting
tabbed_max is set (which is the default).

This directly closes #1299 and also implements a suggestion mentioned in
#1097 and in various other places throughout the years.
