### PR TITLE
Fix doc for member-initialized attributes

### DIFF
--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -456,11 +456,12 @@ class ObjectInformation:
     def process_member_init(self):
         """try to pass collected member initializations and docs to members"""
         for (clsname, attrs), attr in self.member2info.items():
-            if attr.constructor_args is not None:
-                continue
-            init_list = self.member2init.get((clsname, attr.cpp_name), None)
-            if init_list is not None:
-                attr.add_constructor_args(init_list)
+            if attr.constructor_args is None:
+                # if the attribute wasn't initialized directly during declaration,
+                # then try to find it from the initalizer lists:
+                init_list = self.member2init.get((clsname, attr.cpp_name), None)
+                if init_list is not None:
+                    attr.add_constructor_args(init_list)
             doc = self.member2doc.get((clsname, attr.cpp_name), None)
             if doc is not None:
                 attr.doc = doc

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -211,3 +211,22 @@ def test_help_on_children_vs_json(hlwm, clsname, object_path, json_doc):
             # then there should be one in the cpp source
             # and thus also not in the help output:
             assert f"Entry '{name}'" not in help_txt
+
+
+@pytest.mark.parametrize('clsname,object_path', classname2examplepath)
+def test_attribute_doc_in_json(hlwm, clsname, object_path, json_doc):
+    """
+    Verify that if an attribute has a doc string (according to the 'help' command)
+    then the doc string is also present in the json.
+    """
+    path = object_path(hlwm)
+
+    for _, attribute in json_doc['objects'][clsname]['attributes'].items():
+        name = attribute['name']
+        help_txt = hlwm.call(['help', f'{path}.{name}'.lstrip('.')]).stdout
+        # the doc is the last line of the help text
+        doc_in_help = help_txt.strip().splitlines()[-1]
+        if not doc_in_help.startswith('Current value:'):
+            # if there is a doc printed by 'help', then it
+            # should also be present in the json:
+            assert doc_in_help == attribute['doc']


### PR DESCRIPTION
This fixes a wrongly nested if-statement in gendoc.py which caused the
doc string of Attributes to be hidden if they were member-initialized
(during the class definition). This affects the doc string of all theme
attributes.

The new test case checks that (and failed before the present change to
gendoc.py).