### PR TITLE
Raise undecorated fullscreen windows above panels

### DIFF
--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -539,7 +539,11 @@ void Monitor::restack() {
      * manually such that it is above the panel */
     Client* client = tag->focusedClient();
     if (client && client->fullscreen_) {
-        fullscreenFocus = client->decorationWindow();
+        if (client->decorated_()) {
+            fullscreenFocus = client->decorationWindow();
+        } else {
+            fullscreenFocus = client->x11Window();
+        }
         XRaiseWindow(g_display, fullscreenFocus);
     }
     // collect all other windows in a vector and pass it to XRestackWindows

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -865,6 +865,15 @@ class X11:
         else:
             return tree.parent
 
+    def get_window_under_cursor(self):
+        parent = None
+        window = self.root
+        while window is not None and window != 0:
+            parent = window
+            window = window.query_pointer().child
+            print("window under cursor: {}".format(window))
+        return parent
+
     def get_absolute_top_left(self, window):
         """return the absolute (x,y) coordinate of the given window,
         i.e. relative to the root window"""

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -363,5 +363,3 @@ def test_fullscreen_above_unmanaged(hlwm, x11, mouse, decorated):
     # double check that disabling fullscreen lowers the window again:
     hlwm.attr.clients[fs_winid].fullscreen = False
     assert x11.get_window_under_cursor() == um
-
-

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -336,3 +336,32 @@ def test_focused_on_other_monitor_above_fullscreen(hlwm, focus_other_monitor):
     # above
     assert helper_get_stack_as_list(hlwm, strip_focus_layer=False) \
         == [win_focused, win_fullscreen]
+
+
+@pytest.mark.parametrize("decorated", [True, False])
+def test_fullscreen_above_unmanaged(hlwm, x11, mouse, decorated):
+    """
+    This test verifies that normal windows are below unmanaged windows (such as
+    panels) and that focused fullscreen windows cover the unmanaged windows.
+    """
+    # create an un-managed window:
+    um, um_winid = x11.create_client(geometry=(100, 100, 100, 100), force_unmanage=True)
+
+    # create a managed window without decorations
+    fs, fs_winid = x11.create_client()
+    hlwm.attr.clients[fs_winid].decorated = decorated
+
+    # move to the middle of the unmanaged window
+    mouse.move_to(150, 150)
+    # unmanaged windows are above normal windows:
+    assert x11.get_window_under_cursor() == um
+
+    # but below fullscreen windows:
+    hlwm.attr.clients[fs_winid].fullscreen = True
+    assert x11.get_window_under_cursor() == fs
+
+    # double check that disabling fullscreen lowers the window again:
+    hlwm.attr.clients[fs_winid].fullscreen = False
+    assert x11.get_window_under_cursor() == um
+
+


### PR DESCRIPTION
Correctly raise focused fullscreen windows above unmanaged windows (such
as panels). Beside the fix, this also contains a test case.

This closes #1383.
