### PR TITLE
React to focus stealing via XSetInputFocus

### DIFF
--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -622,3 +622,29 @@ const char* XConnection::requestCodeToString(int requestCode)
     }
     return nullptr;
 }
+
+#define DetailCodeAndString(C)  { C, #C }
+/**
+ * @brief print the name of the 'detail' of a XFocusedChangedEvent
+ * @param the 'detail' of a XFocusedChangedEvent
+ * @return
+ */
+const char* XConnection::focusChangedDetailToString(int focusedChangedEventDetail)
+{
+    vector<pair<int, const char*>> table = {
+        DetailCodeAndString(NotifyAncestor),
+        DetailCodeAndString(NotifyVirtual),
+        DetailCodeAndString(NotifyInferior),
+        DetailCodeAndString(NotifyNonlinear),
+        DetailCodeAndString(NotifyNonlinearVirtual),
+        DetailCodeAndString(NotifyPointer),
+        DetailCodeAndString(NotifyPointerRoot),
+        DetailCodeAndString(NotifyDetailNone),
+    };
+    for (auto& e : table) {
+        if (e.first == focusedChangedEventDetail) {
+            return e.second;
+        }
+    }
+    return nullptr;
+}

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -32,6 +32,7 @@ public:
 
     // utility functions
     static const char* requestCodeToString(int requestCode);
+    static const char* focusChangedDetailToString(int focusedChangedEventDetail);
     Rectangle windowSize(Window window);
     int windowPid(Window window);
     int windowPgid(Window window);

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -447,8 +447,40 @@ void XMainLoop::expose(XEvent* event) {
     //HSDebug("name is: Expose for window %lx\n", ewin);
 }
 
-void XMainLoop::focusin(XEvent* event) {
-    //HSDebug("name is: FocusIn\n");
+void XMainLoop::focusin(XFocusChangeEvent* event) {
+    // get the newest FocusIn event, otherwise we could trigger
+    // an endless loop of FocusIn events
+    while (XCheckMaskEvent(X_.display(), FocusChangeMask, (XEvent *)event)) {
+        ;
+    }
+    HSDebug("FocusIn for 0x%lx (%s)\n",
+            event->window,
+            XConnection::focusChangedDetailToString(event->detail));
+    if (event->type == FocusIn
+        && (event->detail == NotifyNonlinear
+            || event->detail == NotifyNonlinearVirtual))
+    {
+        // an event if an application steals input focus
+        // directly via XSetInputFocus, e.g. via `xdotool windowfocus`.
+        // also other applications do this, e.g. `emacsclient -n FILENAME`
+        // when an emacs window exist. There are still subtle differences between
+        // xdotool and emacsclient: xdotool generates detail=NotifyNonlinear
+        // whereas emacsclient only detail=NotifyNonlinearVirtual.
+        // I don't know how to prevent the keyboard input steal, so all we can
+        // do is to update clients.focus accordingly.
+        Window currentFocus = 0;
+        if (root_->clients->focus()) {
+            currentFocus = root_->clients->focus()->x11Window();
+        }
+        if (event->window != currentFocus) {
+            HSDebug("Window 0x%lx steals the focus\n", event->window);
+            Client* target = root_->clients->client(event->window);
+            // Warning: focus_client() itself calls XSetInputFocus() which might
+            // cause an endless loop if we didn't correctly cleared the
+            // event queue with XCheckMaskEvent() above!
+            focus_client(target, false, true, false);
+        }
+    }
 }
 
 void XMainLoop::keypress(XKeyEvent* event) {

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -42,7 +42,7 @@ private:
     void destroynotify(XUnmapEvent* event);
     void enternotify(XCrossingEvent* ce);
     void expose(XEvent* event);
-    void focusin(XEvent* event);
+    void focusin(XFocusChangeEvent* event);
     void keypress(XKeyEvent* event);
     void mappingnotify(XMappingEvent* event);
     void motionnotify(XMotionEvent* event);

--- a/tests/test_x11.py
+++ b/tests/test_x11.py
@@ -1,4 +1,5 @@
 import pytest
+from Xlib import X
 
 
 @pytest.mark.parametrize("running_clients_num", [0, 1, 2])
@@ -47,3 +48,17 @@ def test_client_moveresizes_itself(hlwm, x11):
     assert (win_geo.width, win_geo.height) == (300, 200)
     x, y = x11.get_absolute_top_left(w)
     assert (x, y) == (60, 70)
+
+
+def test_focus_steal_via_xsetinputfocus(hlwm, x11):
+    oldfocus, old_id = x11.create_client()
+    newfocus, new_id = x11.create_client()
+
+    hlwm.call(['jumpto', old_id])
+    assert hlwm.attr.clients.focus.winid() == old_id
+
+    # steal the focus like XSetInputFocus in `xdotool windowfocus` would do it:
+    x11.display.set_input_focus(newfocus, X.RevertToParent, X.CurrentTime)
+    x11.display.sync()
+
+    assert hlwm.attr.clients.focus.winid() == new_id


### PR DESCRIPTION
Usually, clients should request a focus change via an EWMH request,
which the WM can then respect or ignore. Some clients however just
change the input focus themselves (i.e. they change the window where
keyboard events are sent to), e.g. via XSetInputFocus().
Examples are `xdotool windowfocus` or `emacsclient -n $filename`.

The only way to handle these input focus changes is to update hlwm's
state to match the new focus. I am not entirely confident in the code
handling it, but it seems to update the clients.focus object accordingly
(see the new test case) and it does not trigger any endless loop (which
would happen without the XCheckMaskEvent()).

I assume that this fixes the issue #33.