### PR TITLE
Make title alignment configurable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ Current git version
   * Tabbed window titles in the 'max' layout algorithm (controllable via the
     'tabbed_max' setting)
   * New autostart object with attributes 'path', 'running', 'pid', 'last_status'
+  * New decoration attribute 'title_align'
   * New client attribute 'floating_effectively' and associated X11 properties
     'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'
   * New 'foreach' command line flag: '--filter-name='

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -409,7 +409,8 @@ class ObjectInformation:
                 # assume that the next token in the list 'cpp_token' is a
                 # token group
                 cpp_token = cpp_token[4].enclosed_tokens[0]
-            if cpp_token[0:3] == ['LayoutAlgorithm', ':', ':']:
+            if len(cpp_token) == 4 and cpp_token[1:3] == [':', ':']:
+                # if the token is: EnumClass::value
                 cpp_token = cpp_token[3]
             if cpp_token == 'WINDOW_MANAGER_NAME':
                 cpp_token = 'herbstluftwm'

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -619,7 +619,7 @@ void Decoration::redrawPixmap() {
                 XFillRectangles(display, pix, gc, &borderRects.front(), borderRects.size());
                 drawText(pix, gc, tabScheme.title_font->data(), tabScheme.title_color(),
                          tabGeo.tl() + Point2D { tabPadLeft, (int)s.title_height()},
-                         tabClient->title_(), titleWidth - tabPadLeft, s.title_align);
+                         tabClient->title_(), titleWidth - 2 * tabPadLeft, s.title_align);
                 if (client_ != tabClient) {
                     // horizontal border connecting the focused tab with the outer border
                     Point2D westEnd = tabGeo.bl();

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -541,7 +541,7 @@ void Decoration::redrawPixmap() {
         };
         if (tabs_.size() <= 1) {
             drawText(pix, gc, s.title_font->data(), s.title_color(),
-                     titlepos, client_->title_(), inner.width);
+                     titlepos, client_->title_(), inner.width, s.title_align);
         } else {
             int tabWidth = outer.width / tabs_.size();
             int tabIndex = 0;
@@ -643,7 +643,7 @@ void Decoration::redrawPixmap() {
                 }
                 drawText(pix, gc, tabScheme.title_font->data(), tabScheme.title_color(),
                          tabGeo.tl() + Point2D { tabPadLeft, (int)s.title_height()},
-                         tabClient->title_(), titleWidth - tabPadLeft);
+                         tabClient->title_(), titleWidth - tabPadLeft, s.title_align);
                 tabIndex++;
             }
         }
@@ -660,17 +660,26 @@ void Decoration::redrawPixmap() {
  * @param color
  * @param position The position of the left end of the baseline
  * @param width The maximum width of the string (in pixels)
+ * @param the horizontal alignment within this maximum width
  * @param text
  */
 void Decoration::drawText(Pixmap& pix, GC& gc, const FontData& fontData, const Color& color,
-                          Point2D position, const string& text, int width)
+                          Point2D position, const string& text, int width,
+                          const TextAlign& align)
 {
     XConnection& xcon = xconnection();
     Display* display = xcon.display();
     // shorten the text first:
     size_t textLen = text.size();
-    while (textLen > 0 && fontData.textwidth(text, textLen) > width) {
+    int textwidth = fontData.textwidth(text, textLen);
+    while (textLen > 0 && textwidth > width) {
         textLen--;
+        textwidth = fontData.textwidth(text, textLen);
+    }
+    switch (align) {
+    case TextAlign::left: break;
+    case TextAlign::center: position.x += (width - textwidth) / 2; break;
+    case TextAlign::right: position.x += width - textwidth; break;
     }
     if (fontData.xftFont_) {
         Visual* xftvisual = visual ? visual : xcon.visual();

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -10,6 +10,7 @@
 
 class Client;
 class FontData;
+enum class TextAlign;
 class Settings;
 class DecorationScheme;
 class XConnection;
@@ -76,7 +77,7 @@ private:
 
     void drawText(Pixmap& pix, GC& gc, const FontData& fontData,
                   const Color& color, Point2D position, const std::string& text,
-                  int width);
+                  int width, const TextAlign& align );
 
     Window                  decwin = 0; // the decoration window
     const DecorationScheme* last_scheme = {};

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -9,6 +9,12 @@ using std::shared_ptr;
 using std::string;
 using std::weak_ptr;
 
+template<>
+Finite<TextAlign>::ValueList Finite<TextAlign>::values = ValueListPlain {
+    { TextAlign::left, "left" },
+    { TextAlign::center, "center" },
+    { TextAlign::right, "right" },
+};
 
 /**
  * @brief This map caches loaded fonts, such that whenever the same

--- a/src/font.h
+++ b/src/font.h
@@ -7,9 +7,24 @@
 #include "attribute_.h"
 #include "converter.h"
 #include "entity.h"
+#include "finite.h"
 
 class FontData;
 class XConnection;
+
+/**
+ * @brief the horizontal alignment of text
+ */
+enum class TextAlign {
+    left,
+    center,
+    right,
+};
+
+template <>
+struct is_finite<TextAlign> : std::true_type {};
+template<> Finite<TextAlign>::ValueList Finite<TextAlign>::values;
+template<> inline Type Attribute_<TextAlign>::staticType() { return Type::NAMES; };
 
 /**
  * @brief An object of this class holds a font.

--- a/src/font.h
+++ b/src/font.h
@@ -24,7 +24,7 @@ enum class TextAlign {
 template <>
 struct is_finite<TextAlign> : std::true_type {};
 template<> Finite<TextAlign>::ValueList Finite<TextAlign>::values;
-template<> inline Type Attribute_<TextAlign>::staticType() { return Type::NAMES; };
+template<> inline Type Attribute_<TextAlign>::staticType() { return Type::NAMES; }
 
 /**
  * @brief An object of this class holds a font.

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -56,6 +56,7 @@ DecorationScheme::DecorationScheme()
         &border_width,
         &title_height,
         &title_font,
+        &title_align,
         &title_color,
         &border_color,
         &tight_decoration,
@@ -90,6 +91,8 @@ DecorationScheme::DecorationScheme()
                             "the window decoration or only the window "
                             "contents of tiled clients (requires enabled "
                             "sizehints_tiling)");
+    title_align.setDoc("the horizontal alignment of the title within the tab "
+                       "or title bar. The value is one of: left, center, right");
     reset.setDoc("writing this resets all attributes to a default value");
 }
 

--- a/src/theme.h
+++ b/src/theme.h
@@ -83,6 +83,7 @@ public:
     AttributeProxy_<bool>    tight_decoration = {"tight_decoration", false}; // if set, there is no space between the
                               // decoration and the window content
     AttributeProxy_<HSFont>  title_font = {"title_font", HSFont::fromStr("fixed")};
+    AttributeProxy_<TextAlign> title_align = {"title_align", TextAlign::left};
     AttributeProxy_<Color>   title_color = {"title_color", {"black"}};
     AttributeProxy_<Color>   inner_color = {"inner_color", {"black"}};
     AttributeProxy_<unsigned long>     inner_width = {"inner_width", 0};

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -112,6 +112,7 @@ def types_and_shorthands():
         'regex': 'r',
         'SplitAlign': 'n',
         'LayoutAlgorithm': 'n',
+        'TextAlign': 'n',
         'font': 'f',
         'Rectangle': 'R',
         'WindowID': 'w',


### PR DESCRIPTION
This adds a new attribute title_align that configures the horizontal
alignment of the window title within the title bar, respectively tab.

This was requested in #1097.