### PR TITLE
Try to work around CI failure of xsltproc

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -261,7 +261,12 @@ jobs:
       - name: build doc
         run: |
           cd $BUILD
-          make all_doc 2> >(tee asciidoc-stderr.log)
+          # sometimes a2x fails because of xsltproc. so let us hope
+          # that it works within 4 attempts:
+          make -j1 all_doc 2> >(tee asciidoc-stderr.log) ||
+          make -j1 all_doc 2> >(tee asciidoc-stderr.log) ||
+          make -j1 all_doc 2> >(tee asciidoc-stderr.log) ||
+          make -j1 all_doc 2> >(tee asciidoc-stderr.log)
           echo == Checking that asciidoc built without warnings ==
           ! grep WARNING asciidoc-stderr.log # grep must not find warnings
       - name: build website


### PR DESCRIPTION
The 'build doc' regularly fails in the CI with the message:

  a2x: ERROR: "xsltproc"  --stringparam callout.graphics 0 --stringparam
  navig.graphics 0 --stringparam admon.textlabel 1 --stringparam admon.graphics 0
  "/etc/asciidoc/docbook-xsl/manpage.xsl"
  "/home/runner/work/herbstluftwm/herbstluftwm/build-1017/doc/herbstclient.xml"
  returned non-zero exit status 6

With this change, I simply make 4 attempts, since it is probably not
worth the effort to investigate the actual issue of a2x/xsltproc.