### PR TITLE
Extend foreach command by --unique and --recursive

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,7 +12,7 @@ Current git version
   * New autostart object with attributes 'path', 'running', 'pid', 'last_status'
   * New client attribute 'floating_effectively' and associated X11 properties
     'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'
-  * New 'foreach' command line flag: '--filter-name='
+  * New 'foreach' command line flags: '--filter-name=', '--recursive', '--unique'
   * The 'spawn' command now prints an error message on exec failure
   * New read-only client attribute 'decoration_geometry'.
   * New attribute 'decorated' to disable window decorations

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -921,11 +921,21 @@ sprintf 'IDENTIFIER' 'FORMAT' ['FORMATARG' ...] 'COMMAND' ['CMDARGS' ...]::
           +
           (Note how the +%c+ changes to +%s+)
 
-foreach 'IDENTIFIER' 'OBJECT' [*--filter-name=*'REGEX'] 'COMMAND' ['ARGS' ...]::
+foreach 'IDENTIFIER' 'OBJECT' [*--recursive*] [*--unique*] [*--filter-name=*'REGEX'] 'COMMAND' ['ARGS' ...]::
     For each child of the given 'OBJECT' the 'COMMAND' is called with its
-    'ARGS', where the 'IDENTIFIER' is replaced by the path of the child. If
-    *--filter-name=*'REGEX' is passed, then only children are considered whose
-    name match the specified 'REGEX'. The exit code is the exit code of the
+    'ARGS', where the 'IDENTIFIER' is replaced by the path of the child. The
+    options are:
+
+      - *--filter-name=*'REGEX' consider children whose name match the specified 'REGEX'.
+
+      - *--unique* do not print duplicates (some objects can be reached via
+        multiple paths, such as +clients.focus+)
+
+      - *--recursive* print 'OBJECT' and all its children of arbitrary depth in
+        breadth-first search order. This implicitly activates *--unique*.
+
+ ::
+    The exit code is the exit code of the
     command executed last. Examples:
 
         * +foreach T tags.by-name. echo T+ +
@@ -944,6 +954,9 @@ foreach 'IDENTIFIER' 'OBJECT' [*--filter-name=*'REGEX'] 'COMMAND' ['ARGS' ...]::
         * +foreach C clients. echo C+ prints the object paths of all clients,
           but the focused client twice, because it is mentioned in +clients.+
           twice: by window id and as +clients.focus+.
+
+        * +foreach F tags.focus.tiling.root. --recursive echo F+
+          prints the object paths of all frames on the focused tag.
 
 mktemp [*bool*|*int*|*string*|*uint*] 'IDENTIFIER' 'COMMAND' ['ARGS' ...]::
     Creates a temporary attribute with the given type and replaces all

--- a/src/metacommands.h
+++ b/src/metacommands.h
@@ -50,8 +50,10 @@ public:
     void substitute_complete(Completion& complete);
     void foreachCommand(CallOrComplete invoc);
     int foreachChild(std::string ident,
-                     Object* object,
+                     Object* parent,
                      std::string pathString,
+                     bool unique,
+                     bool recursive,
                      const RegexStr& filterName, Input nestedCommand, Output output);
     int sprintf_cmd(Input input, Output output);
     void sprintf_complete(Completion& complete);

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -239,8 +239,9 @@ def test_metacommand(hlwm, command_prefix):
     command as the parameter
     """
     cmdlist = hlwm.call('list_commands').stdout.splitlines()
-    assert hlwm.complete(command_prefix) \
-        == sorted(['ARG'] + cmdlist)
+    # filter all flags out of the completions:
+    completions = [cmd for cmd in hlwm.complete(command_prefix) if cmd[0] != '-']
+    assert completions == sorted(['ARG'] + cmdlist)
 
 
 def test_posix_escape_via_use(hlwm):

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -779,7 +779,7 @@ def test_foreach_recursive_breadth_first(hlwm):
 
     without_client = object_paths()
 
-    # and put the a client in the frame leaf:
+    # and put the client in the frame leaf:
     winid, _ = hlwm.create_client()
 
     with_client = object_paths()
@@ -796,7 +796,7 @@ def test_foreach_recursive_breadth_first(hlwm):
             found_in_without_client = True
 
     assert found_in_without_client, \
-        "The frame must be listed under tags. before client creation"
+        "The frame must be listed under 'tags' before client creation"
 
     # the frame object must have been traversed when visiting
     # the client:


### PR DESCRIPTION
This adds two flags to foreach: --unique removes duplicates (or more
precisely, aliases) of objects and --recursive recurses into subobjects.
To ensure termination --recursive implicitly also uses --unique. The
recursion is done in a breadth-first way such that deeply nested objects
are visited later.

The main application for --unique is to avoid the duplicate
clients.focus and the main application of --recursive is to traverse all
frames in the tree layout.