### PR TITLE
Make fixed font visible in man page

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -249,6 +249,7 @@ jobs:
           cat > CMakeLists.txt <<EOF
           project(Herbstluftwm)
           file(STRINGS VERSION VERSION) # read file 'VERSION'
+          set(CMAKE_INSTALL_SYSCONF_PREFIX /etc/)
           set(DOCDIR /tmp/)
           set(MANDIR /tmp/)
           add_subdirectory(doc)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -58,6 +58,7 @@ function(gen_manpage sourcefile man_nr)
     # additional arguments (${ARGN}) are passed as DEPENDS to the asciidoc command
     set(src "${CMAKE_CURRENT_SOURCE_DIR}/${sourcefile}.txt")
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${sourcefile}.${man_nr}")
+    set(docbookxml "${CMAKE_CURRENT_BINARY_DIR}/${sourcefile}.xml")
     STRING(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)
 
     # as a hack, every man page depends on gen_object_asciidoc, even though only
@@ -74,16 +75,34 @@ function(gen_manpage sourcefile man_nr)
             COMMENT "Using pre-built ${dst_prebuilt}"
             )
     else()
+        # if the documentation is built from scratch, add an intermediate step for
+        # the xml-based docbook format.
+        # add_dependencies("doc_man_${sourcefile}" "doc_man_${sourcefile}_xml")
+        # add_custom_target("doc_man_${sourcefile}_xml" ALL DEPENDS ${docbookxml})
         add_custom_command(
-            OUTPUT ${dst}
-            COMMAND ${ASCIIDOC_A2X}
-                    --no-xmllint
-                    -f manpage
+            OUTPUT ${dst} ${docbookxml}
+            # first create the docbook xml:
+            COMMAND ${ASCIIDOC}
+                    -o ${docbookxml}
+                    -b docbook45
                     -a \"herbstluftwmversion=herbstluftwm ${VERSION}\"
                     -a \"date=${BUILD_DATE}\"
                     -a \"builddir=${CMAKE_CURRENT_BINARY_DIR}\"
-                    --destination-dir="${CMAKE_CURRENT_BINARY_DIR}"
                     ${src}
+            # then, patch the xml:
+            COMMAND ${XSLTPROC}
+                --output ${docbookxml}
+                ${CMAKE_CURRENT_SOURCE_DIR}/literal2emph.xsl
+                ${docbookxml}
+            # and finally, create the man page from it:
+            COMMAND ${XSLTPROC}
+                --output ${dst}
+                --stringparam callout.graphics 0
+                --stringparam navig.graphics 0
+                --stringparam admon.textlabel 1
+                --stringparam admon.graphics 0
+                ${ASCIIDOC_MANPAGE_XSL}
+                ${docbookxml}
             DEPENDS ${src} ${ARGN}
             )
     endif()
@@ -132,6 +151,9 @@ if (WITH_DOCUMENTATION)
     if (NOT COPY_DOCUMENTATION)
         find_program(ASCIIDOC_A2X NAMES a2x DOC "Path to AsciiDoc a2x command")
         find_program(ASCIIDOC NAMES asciidoc DOC "Path to AsciiDoc command")
+        find_program(XSLTPROC NAMES xsltproc DOC "Path to xsltproc")
+        set(ASCIIDOC_MANPAGE_XSL ${CMAKE_INSTALL_SYSCONF_PREFIX}/asciidoc/docbook-xsl/manpage.xsl
+            CACHE PATH "The manpage.xsl provided by asciidoc to generate man pages from docbook xml")
     endif()
 
     gen_manpage(herbstclient 1)

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1364,10 +1364,11 @@ Each 'CONSEQUENCE' consists of a 'NAME'='VALUE' pair. Valid 'NAMES' are:
     consequence.
 
 +keymask+::
-    sets the keymask for a client (see <<KEYMASK, explanation in OBJECTS>>).
+    sets the keymask for a client (see the +keymask+ attribute documentation).
 
 +keys_inactive+::
-    sets a regex that determines which key bindings are inactive for a client (see <<KEYMASK, explanation in OBJECTS>>).
+    sets a regex that determines which key bindings are inactive for a client
+    (see the +keys_inactive+ attribute documentation).
 
 +floatplacement+::
     changes the floating position of a window. The 'VALUE' can be one of the

--- a/doc/literal2emph.xsl
+++ b/doc/literal2emph.xsl
@@ -1,0 +1,36 @@
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <!--
+        In the man page, one can not distinguish fixed font text from ordinary
+        text. However, we use fixed font in examples to indicate that the text
+        can be copied verbatim. In order to make this visible in the man page,
+        we replace fixed font by strong in the intermediate xml format. (I don't
+        want to use the same format in the source txt file, because in the web
+        version, one can perfectly distinguish bold and fixed font)
+    -->
+    <!-- the present xsl sheet is a modification of
+         https://stackoverflow.com/a/6113231/4400896
+    -->
+    <xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="no" indent="yes"/>
+    <!-- Do not strip spaces, preserve them per default
+    https://www.data2type.de/xml-xslt-xslfo/xslt/xslt-referenz/preserve-space
+    <xsl:strip-space elements="*"/>
+    -->
+    <xsl:preserve-space elements="*"/>
+
+
+    <!-- essentially, the following rules immitate the sed expression:
+     's,<literal>,<emphasis role=\"strong\">,g\;s,</literal>,</emphasis>,g'
+    -->
+
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="literal">
+        <emphasis role="strong"><xsl:value-of select="."/></emphasis>
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
This patches the man page creation such that text formatted in fixed
font is recognizable in the man page. This is makes examples stand out
more in the man page.

On the technical side, the cmake file now does the two steps which are
normally done by a2x: first creating a docbook xml, and then
transforming the xml to a man page. By doing these steps manually, we
can now patch the intermediate xml file to our needs.

Maybe, this also helps us to see more error messages which were formerly
buried in a2x. In fact, the present change helped to discover two
broken links within the herbstluftwm man page, which I've fixed along
the way. Strictly speaking, we don't need the a2x binary anymore, but
since it comes with asciidoc anyway, I've left it as a dependency.