### PR TITLE
Update mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,24 +1,33 @@
+queue_rules:
+  - name: default
+    conditions:
+      # Conditions to get out of the queue (= merged)
+      - check-success=Build and test on current ubuntu
+      - check-success=Build with Clang, run linters and static analyzers
+      - check-success=Build for 32bit with ancient GCC on Ubuntu 14.04
+
 pull_request_rules:
     - name: automatic merge on CI success and review
       conditions:
           - base=master
-          - status-success=Build and test on current ubuntu
-          - status-success=Build with Clang, run linters and static analyzers
-          - status-success=Build for 32bit with ancient GCC on Ubuntu 14.04
+          - check-success=Build and test on current ubuntu
+          - check-success=Build with Clang, run linters and static analyzers
+          - check-success=Build for 32bit with ancient GCC on Ubuntu 14.04
           - "#approved-reviews-by>=1"
-          - label≠wip
+          - "#changes-requested-reviews-by=0"
+          - label!=wip
       actions:
-          merge:
+          queue:
+              name: default
               method: squash
-              strict: smart
               commit_message: title+body
     - name: Implicitly allow t-wissmann to approve own pull requests
       conditions:
           - author=t-wissmann
-          - status-success=Build and test on current ubuntu
-          - status-success=Build with Clang, run linters and static analyzers
-          - status-success=Build for 32bit with ancient GCC on Ubuntu 14.04
-          - label≠wip
+          - check-success=Build and test on current ubuntu
+          - check-success=Build with Clang, run linters and static analyzers
+          - check-success=Build for 32bit with ancient GCC on Ubuntu 14.04
+          - label!=wip
           - label=self-approved
       actions:
           review:


### PR DESCRIPTION
This now uses the merge queue of mergify. Unfortunately,
the mergify documtation also will remove the `commit_message` option
from the queue action. It is unclear to me how we can keep the current
behaviour of squashing the entire PR into a single commit with the
commit message coming from the PR title and description.

The mergify config checker tells:

> The configuration uses the deprecated commit_message mode of the queue
> action. A brownout is planned for the whole March 21th, 2022 day. This
> option will be removed on April 25th, 2022. For more information:
> https://docs.mergify.com/actions/queue/