### PR TITLE
Add attributes 'title_when' and 'title_depth'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,9 @@ Current git version
 
   * Tabbed window titles in the 'max' layout algorithm (controllable via the
     'tabbed_max' setting)
+  * New decoration setting 'title_when' to control, when window titles and tabs
+    are shown.
+  * New decoration setting 'title_depth'.
   * New autostart object with attributes 'path', 'running', 'pid', 'last_status'
   * New decoration attribute 'title_align'
   * New client attribute 'floating_effectively' and associated X11 properties

--- a/share/autostart
+++ b/share/autostart
@@ -124,9 +124,10 @@ hc set frame_transparent_width 5
 hc set frame_gap 4
 
 hc attr theme.title_height 15
+hc attr theme.title_when always
 hc attr theme.title_font 'Dejavu Sans:pixelsize=12'  # example using Xft
 # hc attr theme.title_font '-*-fixed-medium-r-*-*-13-*-*-*-*-*-*-*'
-hc attr theme.padding_top 3  # space below the title's baseline (i.e. text depth)
+hc attr theme.title_depth 3  # space below the title's baseline
 hc attr theme.active.color '#345F0Cef'
 hc attr theme.title_color '#ffffff'
 hc attr theme.normal.color '#323232dd'

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -376,7 +376,7 @@ void Client::resize_tiling(Rectangle rect, bool isFocused, bool minimalDecoratio
     if (this->pseudotile_) {
         Rectangle inner = this->float_size_;
         applysizehints(&inner.width, &inner.height);
-        auto outline = scheme.inner_rect_to_outline(inner);
+        auto outline = scheme.inner_rect_to_outline(inner, tabs.size());
         rect.x += std::max(0, (rect.width - outline.width)/2);
         rect.y += std::max(0, (rect.height - outline.height)/2);
         rect.width = std::min(outline.width, rect.width);
@@ -803,13 +803,14 @@ void Client::fuzzy_fix_initial_position() {
     int extreme_y = float_size_->y;
     const auto& t = theme[Theme::Type::Floating];
     mostRecentThemeType = Theme::Type::Floating;
-    auto r = t.active.inner_rect_to_outline(float_size_);
+    size_t tabCount = 0;
+    auto r = t.active.inner_rect_to_outline(float_size_, tabCount);
     extreme_x = std::min(extreme_x, r.x);
     extreme_y = std::min(extreme_y, r.y);
-    r = t.normal.inner_rect_to_outline(float_size_);
+    r = t.normal.inner_rect_to_outline(float_size_, tabCount);
     extreme_x = std::min(extreme_x, r.x);
     extreme_y = std::min(extreme_y, r.y);
-    r = t.urgent.inner_rect_to_outline(float_size_);
+    r = t.urgent.inner_rect_to_outline(float_size_, tabCount);
     extreme_x = std::min(extreme_x, r.x);
     extreme_y = std::min(extreme_y, r.y);
     // if top left corner might be outside of the monitor, move it accordingly

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -161,23 +161,11 @@ Client* Decoration::toClient(Window decoration_window)
     }
 }
 
-Rectangle DecorationScheme::outline_to_inner_rect(Rectangle rect) const {
-    return rect.adjusted(-*border_width, -*border_width)
-            .adjusted(-*padding_left, -*padding_top - *title_height,
-                      -*padding_right, -*padding_bottom);
-}
-
-Rectangle DecorationScheme::inner_rect_to_outline(Rectangle rect) const {
-    return rect.adjusted(*border_width, *border_width)
-            .adjusted(*padding_left, *padding_top + *title_height,
-                      *padding_right, *padding_bottom);
-}
-
 void Decoration::resize_inner(Rectangle inner, const DecorationScheme& scheme) {
     // if the client is undecorated, the outline is identical to the inner geometry
     // otherwise, we convert the geometry using the theme
     auto outline = (client_->decorated_())
-                   ? scheme.inner_rect_to_outline(inner)
+                   ? scheme.inner_rect_to_outline(inner, tabs_.size())
                    : inner;
     resize_outline(outline, scheme, {});
     last_rect_inner = true;
@@ -189,9 +177,9 @@ Rectangle Decoration::inner_to_outer(Rectangle rect) {
         // Since the 'inner' rect is usually a floating geometry,
         // take a scheme from there.
         const DecorationScheme& fallback =  client_->theme.floating.normal;
-        return fallback.inner_rect_to_outline(rect);
+        return fallback.inner_rect_to_outline(rect, tabs_.size());
     }
-    return last_scheme->inner_rect_to_outline(rect);
+    return last_scheme->inner_rect_to_outline(rect, tabs_.size());
 }
 
 void Decoration::updateResizeAreaCursors()
@@ -291,7 +279,7 @@ ResizeAction Decoration::resizeFromRoughCursorPosition(Point2D cursor)
 void Decoration::resize_outline(Rectangle outline, const DecorationScheme& scheme, vector<Client*> tabs)
 {
     bool decorated = client_->decorated_();
-    auto inner = scheme.outline_to_inner_rect(outline);
+    auto inner = scheme.outline_to_inner_rect(outline, tabs.size());
     if (!decorated) {
         inner = outline;
     }
@@ -318,7 +306,7 @@ void Decoration::resize_outline(Rectangle outline, const DecorationScheme& schem
         // updating the outline only has an affect for tiled clients
         // because for floating clients, this has been done already
         // right when the window size changed.
-        outline = scheme.inner_rect_to_outline(inner);
+        outline = scheme.inner_rect_to_outline(inner, tabs.size());
     }
     last_inner_rect = inner;
     if (decorated) {
@@ -534,7 +522,7 @@ void Decoration::redrawPixmap() {
                        inner.width,
                        inner.height - dec->last_actual_rect.height);
     }
-    if (s.title_height() > 0) {
+    if (s.showTitle(tabs_.size())) {
         Point2D titlepos = {
             static_cast<int>(s.padding_left() + s.border_width()),
             static_cast<int>(s.title_height())
@@ -559,7 +547,7 @@ void Decoration::redrawPixmap() {
                     tabIndex * tabWidth,
                     0,
                     tabWidth + int(isLast ? (outer.width % tabs_.size()) : 0),
-                    int(s.title_height() + s.padding_top()), // tab height
+                    int(s.title_height() + s.title_depth()), // tab height
                 };
                 if (tabClient != client_) {
                     // only add clickable buttons for the other clients

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -125,13 +125,16 @@ Rectangle DecorationScheme::outline_to_inner_rect(Rectangle rect, size_t tabCoun
  */
 bool DecorationScheme::showTitle(size_t tabCount) const
 {
+    if (title_height() == 0) {
+        return false;
+    }
     switch (title_when()) {
-        case TitleWhen::always: return True;
-        case TitleWhen::never: return False;
+        case TitleWhen::always: return true;
+        case TitleWhen::never: return false;
         case TitleWhen::one_tab: return tabCount >= 1;
         case TitleWhen::multiple_tabs: return tabCount >= 2;
     }
-    return True; // Dead code. But otherwise, gcc complains
+    return true; // Dead code. But otherwise, gcc complains
 }
 
 Rectangle DecorationScheme::inner_rect_to_outline(Rectangle rect, size_t tabCount) const {

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -3,6 +3,15 @@
 using std::vector;
 using std::string;
 
+template<>
+Finite<TitleWhen>::ValueList Finite<TitleWhen>::values = ValueListPlain {
+    { TitleWhen::always, "always" },
+    { TitleWhen::never, "never" },
+    { TitleWhen::one_tab, "one_tab" },
+    { TitleWhen::multiple_tabs, "multiple_tabs" },
+};
+
+
 Theme::Theme()
     : fullscreen(*this, "fullscreen")
     , tiling(*this, "tiling")
@@ -26,7 +35,7 @@ Theme::Theme()
           "          │                  ╻\n"
           "          │                  │\n"
           "    ┌────╴│╶─────────────────┷─────┐ ⎫ border_width\n"
-          "    │     │      color             │ ⎬ + title_height\n"
+          "    │     │      color             │ ⎬ + title_height + title_depth\n"
           "    │  ┌──┷─────────────────────┐  │ ⎭ + padding_top\n"
           "    │  │====================....│  │\n"
           "    │  │== window content ==....│  │\n"
@@ -55,6 +64,8 @@ DecorationScheme::DecorationScheme()
     , proxyAttributes_ ({
         &border_width,
         &title_height,
+        &title_depth,
+        &title_when,
         &title_font,
         &title_align,
         &title_color,
@@ -91,10 +102,45 @@ DecorationScheme::DecorationScheme()
                             "the window decoration or only the window "
                             "contents of tiled clients (requires enabled "
                             "sizehints_tiling)");
+    title_depth.setDoc("the space below the baseline of the window title");
+    title_when.setDoc("when to show the window title: always, never, "
+                      "if the the client is in a tabbed scenario like a max frame (+one_tab+), "
+                      "if there are +multiple_tabs+ to be shown.");
     title_align.setDoc("the horizontal alignment of the title within the tab "
                        "or title bar. The value is one of: left, center, right");
     reset.setDoc("writing this resets all attributes to a default value");
 }
+
+Rectangle DecorationScheme::outline_to_inner_rect(Rectangle rect, size_t tabCount) const {
+    return rect.adjusted(-*border_width, -*border_width)
+            .adjusted(-*padding_left,
+                      -*padding_top - (showTitle(tabCount) ? (*title_height + *title_depth) : 0),
+                      -*padding_right, -*padding_bottom);
+}
+
+/**
+ * @brief whether to show the window titles
+ * @param the number of tabs
+ * @return
+ */
+bool DecorationScheme::showTitle(size_t tabCount) const
+{
+    switch (title_when()) {
+        case TitleWhen::always: return True;
+        case TitleWhen::never: return False;
+        case TitleWhen::one_tab: return tabCount >= 1;
+        case TitleWhen::multiple_tabs: return tabCount >= 2;
+    }
+    return True; // Dead code. But otherwise, gcc complains
+}
+
+Rectangle DecorationScheme::inner_rect_to_outline(Rectangle rect, size_t tabCount) const {
+    return rect.adjusted(*border_width, *border_width)
+            .adjusted(*padding_left,
+                      *padding_top + (showTitle(tabCount) ? (*title_height + *title_depth) : 0),
+                      *padding_right, *padding_bottom);
+}
+
 
 DecTriple::DecTriple()
    : normal(*this, "normal")

--- a/src/theme.h
+++ b/src/theme.h
@@ -5,9 +5,27 @@
 
 #include "attribute_.h"
 #include "child.h"
+#include "finite.h"
 #include "font.h"
 #include "object.h"
 #include "rectangle.h"
+
+
+/**
+ * @brief Criteria when to show the window title
+ */
+enum class TitleWhen {
+    never,
+    always,
+    one_tab,
+    multiple_tabs,
+};
+
+template <>
+struct is_finite<TitleWhen> : std::true_type {};
+template<> Finite<TitleWhen>::ValueList Finite<TitleWhen>::values;
+template<> inline Type Attribute_<TitleWhen>::staticType() { return Type::NAMES; }
+
 
 /** The proxy interface
  */
@@ -79,6 +97,8 @@ public:
     DynAttribute_<std::string> reset;
     AttributeProxy_<unsigned long>     border_width = {"border_width", 0};
     AttributeProxy_<unsigned long>     title_height = {"title_height", 0};
+    AttributeProxy_<int>           title_depth = {"title_depth", 0};
+    AttributeProxy_<TitleWhen>     title_when = {"title_when", TitleWhen::always};
     AttributeProxy_<Color>   border_color = {"color", {"black"}};
     AttributeProxy_<bool>    tight_decoration = {"tight_decoration", false}; // if set, there is no space between the
                               // decoration and the window content
@@ -97,8 +117,9 @@ public:
 
     Signal scheme_changed_; //! whenever one of the attributes changes.
 
-    Rectangle inner_rect_to_outline(Rectangle rect) const;
-    Rectangle outline_to_inner_rect(Rectangle rect) const;
+    Rectangle inner_rect_to_outline(Rectangle rect, size_t tabCount) const;
+    Rectangle outline_to_inner_rect(Rectangle rect, size_t tabCount) const;
+    bool showTitle(size_t tabCount) const;
 
     // after having called this with some vector 'decs', then if an attribute
     // is changed here, then the attribute with the same name is changed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -710,10 +710,13 @@ class X11:
     def winid_str(self, window_handle):
         return hex(window_handle.id)
 
-    def make_window_urgent(self, window):
+    def make_window_urgent(self, window, sync_hlwm=True):
         """make window urgent"""
         window.set_wm_hints(flags=Xutil.UrgencyHint)
         self.display.sync()
+        if sync_hlwm:
+            # wait for hlwm to fully recognize it as a client
+            self.sync_with_hlwm()
 
     def is_window_urgent(self, window):
         """check urgency of a given window handle"""

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -113,6 +113,7 @@ def types_and_shorthands():
         'SplitAlign': 'n',
         'LayoutAlgorithm': 'n',
         'TextAlign': 'n',
+        'TitleWhen': 'n',
         'font': 'f',
         'Rectangle': 'R',
         'WindowID': 'w',

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -186,7 +186,7 @@ def test_title_when_behaviour(hlwm):
 def test_title_when_for_absence_of_tabs(hlwm, floating):
     """
     for floating clients or frames with an algorithm other than 'max',
-    there should no be tabs at all and thus the titlebar is
+    there should be no tabs at all and thus the titlebar is
     only shown if 'title_when' is 'always'.
     """
     hlwm.attr.theme.title_height = 10

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,6 +1,8 @@
 import pytest
 from herbstluftwm.types import Point
 
+TITLE_WHEN_VALUES = ['always', 'never', 'one_tab', 'multiple_tabs']
+
 
 def read_values(hlwm, attributes):
     """return a dict with the given attributes"""
@@ -134,3 +136,79 @@ def test_decoration_geometry_vs_x11_data(hlwm, x11, floating):
     geoAttr = hlwm.attr.clients[winid].decoration_geometry()
 
     assert geoAttr == geoX11
+
+
+def test_title_when_parsing(hlwm):
+    assert sorted(TITLE_WHEN_VALUES) == sorted(hlwm.complete(['attr', 'theme.title_when']))
+
+    for v in TITLE_WHEN_VALUES:
+        hlwm.attr.theme.title_when = v
+        assert hlwm.attr.theme.title_when() == v
+
+    hlwm.call_xfail('attr theme.title_when foobar') \
+        .expect_stderr('Expecting one of:.*always')
+
+
+def test_title_when_behaviour(hlwm):
+    hlwm.attr.theme.title_height = 10
+    hlwm.attr.theme.title_depth = 5
+    expected_title_size = 10 + 5
+    hlwm.attr.theme.padding_top = 4
+    bw = 3
+    hlwm.attr.theme.border_width = bw
+    hlwm.attr.tags.focus.tiling.focused_frame.algorithm = 'max'
+
+    for client_count in range(1, 4):
+        hlwm.create_client()
+
+        for title_when in TITLE_WHEN_VALUES:
+            hlwm.attr.theme.title_when = title_when
+
+            content_geo = hlwm.attr.clients.focus.content_geometry()
+            decoration_geo = hlwm.attr.clients.focus.decoration_geometry()
+
+            assert content_geo.bottomright() + Point(bw, bw) == decoration_geo.bottomright()
+            assert decoration_geo.x + bw == content_geo.x
+            title_size = content_geo.y - decoration_geo.y - bw - hlwm.attr.theme.padding_top()
+
+            title_expected = title_when == 'always' \
+                or (title_when == 'one_tab' and client_count >= 1) \
+                or (title_when == 'multiple_tabs' and client_count >= 2)
+
+            if title_expected:
+                assert expected_title_size > 0
+                assert title_size == expected_title_size
+            else:
+                assert title_size == 0
+
+
+@pytest.mark.parametrize("floating", [True, False])
+def test_title_when_for_absence_of_tabs(hlwm, floating):
+    """
+    for floating clients or frames with an algorithm other than 'max',
+    there should no be tabs at all and thus the titlebar is
+    only shown if 'title_when' is 'always'.
+    """
+    hlwm.attr.theme.title_height = 10
+    hlwm.attr.theme.title_depth = 5
+    expected_title_size = 10 + 5
+    hlwm.attr.theme.padding_top = 4
+    bw = 3
+    hlwm.attr.theme.border_width = bw
+    hlwm.attr.tags.focus.floating = floating
+    hlwm.attr.tags.focus.tiling.focused_frame.algorithm = 'vertical'
+    for client_count in range(1, 4):
+        hlwm.create_client()
+
+        for title_when in TITLE_WHEN_VALUES:
+            hlwm.attr.theme.title_when = title_when
+            content_geo = hlwm.attr.clients.focus.content_geometry()
+            decoration_geo = hlwm.attr.clients.focus.decoration_geometry()
+
+            assert content_geo.bottomright() + Point(bw, bw) == decoration_geo.bottomright()
+            assert decoration_geo.x + bw == content_geo.x
+            title_size = content_geo.y - decoration_geo.y - bw - hlwm.attr.theme.padding_top()
+            if title_when == 'always':
+                assert title_size == expected_title_size
+            else:
+                assert title_size == 0


### PR DESCRIPTION
This makes it configurable when to show the title bar. So far, there are
four options that essentially depend on the number of tabs.
So far, I've used padding_top to add space for characters in the title
that reach below the baseline. Since the space below the baseline should
be present only when the title is shown, I've added a new setting
title_depth.

This new feature was requested multiple times on the IRC and in the
discussion of #1097 and #1388.