### PR TITLE
Add settings.ellipsis

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ Current git version
   * New read-only client attribute 'decoration_geometry'.
   * New attribute 'decorated' to disable window decorations
   * The cursor shape now indicates resize options.
+  * New setting 'ellipsis'
   * Frames can be simultaneously resized in x and y direction with the mouse.
   * Bug fixes:
     - Update floating geometry if a client's size hints change

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -14,6 +14,7 @@
 #include "fontdata.h"
 #include "settings.h"
 #include "theme.h"
+#include "utils.h"
 #include "xconnection.h"
 
 using std::string;
@@ -672,9 +673,35 @@ void Decoration::drawText(Pixmap& pix, GC& gc, const FontData& fontData, const C
     // shorten the text first:
     size_t textLen = text.size();
     int textwidth = fontData.textwidth(text, textLen);
-    while (textLen > 0 && textwidth > width) {
-        textLen--;
-        textwidth = fontData.textwidth(text, textLen);
+    string with_ellipsis; // declaration here for sufficently long lifetime
+    const char* final_c_str = nullptr;
+    if (textwidth <= width) {
+        final_c_str = text.c_str();
+    } else {
+        // shorten title:
+        with_ellipsis = text + settings_.ellipsis();
+        // temporarily, textLen is the length of the text surviving from the
+        // original window title
+        while (textLen > 0 && textwidth > width) {
+            textLen--;
+            // remove the (multibyte-)character that ends at with_ellipsis[textLen]
+            size_t character_width = 1;
+            while (textLen > 0 && utf8_is_continuation_byte(with_ellipsis[textLen])) {
+                textLen--;
+                character_width++;
+            }
+            // now, textLen points to the first byte of the (multibyte-)character
+            with_ellipsis.erase(textLen, character_width);
+            textwidth = fontData.textwidth(with_ellipsis, with_ellipsis.size());
+        }
+        // make textLen refer to the actual string and shorten further if it
+        // is still too wide:
+        textLen = with_ellipsis.size();
+        while (textLen > 0 && textwidth > width) {
+            textLen--;
+            textwidth = fontData.textwidth(with_ellipsis, textLen);
+        }
+        final_c_str = with_ellipsis.c_str();
     }
     switch (align) {
     case TextAlign::left: break;
@@ -696,19 +723,19 @@ void Decoration::drawText(Pixmap& pix, GC& gc, const FontData& fontData, const C
         XftColorAllocValue(display, xftvisual, xftcmap, &xrendercol, &xftcol);
         XftDrawStringUtf8(xftd, &xftcol, fontData.xftFont_,
                        position.x, position.y,
-                       (const XftChar8*)text.c_str(), textLen);
+                       (const XftChar8*)final_c_str, textLen);
         XftDrawDestroy(xftd);
         XftColorFree(display, xftvisual, xftcmap, &xftcol);
     } else if (fontData.xFontSet_) {
         XSetForeground(display, gc, get_client_color(color));
         XmbDrawString(display, pix, fontData.xFontSet_, gc, position.x, position.y,
-                text.c_str(), textLen);
+                final_c_str, textLen);
     } else if (fontData.xFontStruct_) {
         XSetForeground(display, gc, get_client_color(color));
         XFontStruct* font = fontData.xFontStruct_;
         XSetFont(display, gc, font->fid);
         XDrawString(display, pix, gc, position.x, position.y,
-                text.c_str(), textLen);
+                final_c_str, textLen);
     }
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -79,6 +79,7 @@ Settings::Settings()
         &auto_detect_panels,
         &pseudotile_center_threshold,
         &update_dragged_clients,
+        &ellipsis,
         &tree_style,
         &wmname,
 
@@ -92,6 +93,7 @@ Settings::Settings()
     for (auto i : {&frame_gap, &frame_padding, &window_gap}) {
         i->changed().connect([] { all_monitors_apply_layout(); });
     }
+    ellipsis.changed().connect([] { all_monitors_apply_layout(); });
     hide_covered_windows.changed().connect([] { all_monitors_apply_layout(); });
     for (auto i : {
          &frame_border_active_color,
@@ -137,6 +139,10 @@ Settings::Settings()
     tabbed_max.setDoc(
         "if activated, multiple windows in a frame with the \'max\' "
         "layout algorithm are drawn as tabs."
+    );
+    ellipsis.setDoc(
+        "string to append when window or tab titles are shortened "
+        "to fit in the available space."
     );
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -65,6 +65,7 @@ public:
     Attribute_<bool>          auto_detect_panels = {"auto_detect_panels", true};
     Attribute_<int>           pseudotile_center_threshold = {"pseudotile_center_threshold", 10};
     Attribute_<bool>          update_dragged_clients = {"update_dragged_clients", false};
+    Attribute_<string>        ellipsis = {"ellipsis", "..."};
     Attribute_<string>        tree_style = {"tree_style", "*| +`--."};
     Attribute_<string>        wmname = {"wmname", WINDOW_MANAGER_NAME};
     // for compatibility

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -94,7 +94,8 @@ size_t utf8_string_length(const string& str) {
    // http://stackoverflow.com/questions/5117393/utf-8-strings-length-in-linux-c
    size_t i = 0, j = 0;
    while (str[i]) {
-       if ((str[i] & 0xc0) != 0x80) {
+       // count all the non-continuation bytes
+       if (!utf8_is_continuation_byte(str[i])) {
            j++;
        }
      i++;

--- a/src/utils.h
+++ b/src/utils.h
@@ -70,6 +70,15 @@ void set_window_double_border(Display *dpy, Window win, int ibw,
 
 size_t      utf8_string_length(const std::string& str);
 std::string utf8_string_at(const std::string& str, size_t offset);
+/**
+ * @brief in utf8, a single unicode character may be spread over
+ * multiple bytes. This function tells whether a given byte
+ * is part of such a sequence but not the first one.
+ * see also https://stackoverflow.com/a/9356203/4400896
+ * @param ch
+ * @return
+ */
+inline bool utf8_is_continuation_byte(char ch) { return (ch & 0xc0) == 0x80; }
 
 #define RECTANGLE_EQUALS(a, b) (\
         (a).x == (b).x &&   \


### PR DESCRIPTION
As requested in #1395, this adds an ellipsis, which is appended to the
window title if its too long for the available space. This requires that
we erase characters in the middle of a utf-8 string, and so we need to
take care of characters that amount to multiple bytes in the string.

This closes #1395.