### PR TITLE
Let active and inactive tabs have same text width

### DIFF
--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -568,7 +568,7 @@ void Decoration::redrawPixmap() {
                     tabButton.tabClient_ = tabClient;
                     buttons_.push_back(tabButton);
                 }
-                int titleWidth = tabGeo.width;
+                int titleWidth = tabGeo.width - tabScheme.outer_width;
                 if (tabClient == client_) {
                     tabGeo.height += s.border_width() - s.inner_width();
                 }
@@ -605,7 +605,6 @@ void Decoration::redrawPixmap() {
                       (unsigned short)tabScheme.outer_width,
                       (unsigned short)tabGeo.height }
                     );
-                    titleWidth -= tabScheme.outer_width;
                 } else if (client_ == tabClient) {
                     // shorter edge on the right
                     borderRects.push_back(
@@ -613,7 +612,6 @@ void Decoration::redrawPixmap() {
                       (unsigned short)tabScheme.outer_width,
                       (unsigned short)(tabGeo.height - (s.border_width() - s.outer_width() - s.inner_width())) }
                     );
-                    titleWidth -= tabScheme.outer_width;
                 }
                 XSetForeground(display, gc, get_client_color(tabScheme.outer_color));
                 XFillRectangles(display, pix, gc, &borderRects.front(), borderRects.size());


### PR DESCRIPTION
If the title was centered or right-aligned, the title sometimes moved
slightly. This was caused by the text area having slightly different
widths for active and inactive tabs. The present change fixes this and
adds a test case for it.

Unfortunately, the test case is quite time consuming (8 seconds here),
because it takes 3 * 2 = 6 screenshots, but I think it's worth the
effort.