### PR TITLE
Simplify urgency handling by using signals

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -644,7 +644,7 @@ void Client::set_visible(bool visible) {
 void Client::urgencyAttributeChanged(bool state)
 {
     if (this == manager.focus() && state == true) {
-        // supress it if the focused client wants to be urgent
+        // suppress it if the focused client wants to be urgent
         urgent_ = false;
         return;
     }

--- a/src/client.h
+++ b/src/client.h
@@ -64,6 +64,7 @@ public:
 
     // attributes:
     Attribute_<bool> urgent_;
+    bool x11urgent_ = false;
     Attribute_<bool> floating_;
     Attribute_<bool> fullscreen_;
     Attribute_<bool> minimized_;
@@ -116,7 +117,7 @@ public:
     void resize_fullscreen(Rectangle m, bool isFocused);
     bool is_client_floated();
     void set_urgent(bool state);
-    void update_wm_hints();
+    void readWmHints(bool forceNotUrgent = false);
     void update_title();
     void raise();
     void lower();
@@ -128,7 +129,6 @@ public:
 
     void set_visible(bool visible);
 
-    void set_urgent_force(bool state);
     void requestClose(); //! ask the client to close
 
     void clear_properties();
@@ -137,6 +137,7 @@ public:
     void updateEwmhState();
 private:
     void floatingGeometryChanged();
+    void urgencyAttributeChanged(bool state);
     void fixParentWindow(bool decorated);
     void redraw();
     void redrawRelevantTabBars();

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -386,7 +386,7 @@ void Ewmh::handleClientMessage(XClientMessageEvent* me) {
                 // Focus stealing is not allowed, at least mark the client urgent
                 auto client = Root::common().client(me->window);
                 if (client) {
-                    client->set_urgent(true);
+                    client->urgent_ = true;
                 }
             }
             break;
@@ -433,7 +433,7 @@ void Ewmh::handleClientMessage(XClientMessageEvent* me) {
                 { NetWmStateFullscreen,
                     client->fullscreen_,     [](Client* c, bool state){ c->fullscreen_ = state; } },
                 { NetWmStateDemandsAttention,
-                    client->urgent_,         [](Client* c, bool state){ c->set_urgent(state); } },
+                    client->urgent_,         [](Client* c, bool state){ c->urgent_ = state; } },
             };
 
             /* me->data.l[1] and [2] describe the properties to alter */

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -648,3 +648,24 @@ const char* XConnection::focusChangedDetailToString(int focusedChangedEventDetai
     }
     return nullptr;
 }
+
+void XConnection::setWindowUrgencyHint(Window window, bool urgent)
+{
+    XWMHints* wmh;
+    if (!(wmh = XGetWMHints(m_display, window))) {
+        // just allocate new wm hints for the case the window
+        // did not have wm hints set before.
+        // here, we ignore what happens on insufficient memory
+        wmh = XAllocWMHints();
+    }
+    bool currentState = (wmh->flags & XUrgencyHint) != 0;
+    if (currentState != urgent) {
+        if (urgent) {
+            wmh->flags |= XUrgencyHint;
+        } else {
+            wmh->flags &= ~XUrgencyHint;
+        }
+        XSetWMHints(m_display, window, wmh);
+    }
+    XFree(wmh);
+}

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -33,6 +33,7 @@ public:
     // utility functions
     static const char* requestCodeToString(int requestCode);
     static const char* focusChangedDetailToString(int focusedChangedEventDetail);
+    void setWindowUrgencyHint(Window window, bool urgent);
     Rectangle windowSize(Window window);
     int windowPid(Window window);
     int windowPgid(Window window);

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -607,7 +607,8 @@ void XMainLoop::propertynotify(XPropertyEvent* ev) {
             //        ev->atom,
             //        atomname);
             if (ev->atom == XA_WM_HINTS) {
-                client->update_wm_hints();
+                bool forceNotUrgent = root_->clients->focus() == client;
+                client->readWmHints(forceNotUrgent);
             } else if (ev->atom == XA_WM_NORMAL_HINTS) {
                 client->updatesizehints();
                 Rectangle geom = client->float_size_;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -715,11 +715,12 @@ class X11:
         window.set_wm_hints(flags=Xutil.UrgencyHint)
         self.display.sync()
         if sync_hlwm:
-            # wait for hlwm to fully recognize it as a client
+            # wait for hlwm to fully recognize the new wm hint
             self.sync_with_hlwm()
 
     def is_window_urgent(self, window):
         """check urgency of a given window handle"""
+        self.display.sync()
         hints = window.get_wm_hints()
         if hints is None:
             return False


### PR DESCRIPTION
This simplifies the handling of urgency handling and as a bonus, it
makes the urgency attribute writable.

The main idea behind this change is to separate the logic from the
communication with X11. One function (readWmHints) reads the urgency
hint from X11 to the attributes, and a signal propagates changes of the
attribute's value back to X11. The entire hlwm 'logic' only operates on
the urgency attribute (and so we can also grant the user write access to
it). This is similar to the focus change handling in #1403.

Also, this avoids a few X11 errors if a new client is already urgent.
Before this change, an urgent client triggered an early relayout, which
even led to the CI failure in #1399.