### PR TITLE
Handle mouse clicks in correct order

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1077,7 +1077,7 @@ def mouse(hlwm_process, hlwm):
                 hlwm.call('true')
 
         def move_relative(self, delta_x, delta_y, wait=True):
-            self.call_cmd(f'xdotool mousemove_relative --sync {delta_x} {delta_y}', shell=True)
+            self.call_cmd(f'xdotool mousemove_relative --sync -- {delta_x} {delta_y}', shell=True)
             if wait:
                 # wait until all the mouse move events that were put in the
                 # queue by the above xdotool invokation are fully processed.

--- a/tests/test_basic_events.py
+++ b/tests/test_basic_events.py
@@ -87,7 +87,7 @@ def test_focus_frame_by_mouse(hlwm, mouse, click, focus_follows_mouse):
 def test_focus_client_by_decoration(hlwm, mouse, x11, click, focus_follows_mouse):
     hlwm.attr.theme.border_width = 1
     for side in ['top', 'bottom', 'left', 'right']:
-        hlwm.attr.themes[f'padding_{side}'] = 49
+        hlwm.attr.theme[f'padding_{side}'] = 49
     hlwm.attr.theme.active.color = 'red'
     hlwm.attr.theme.normal.color = 'blue'
     hlwm.call('set_layout vertical')

--- a/tests/test_basic_events.py
+++ b/tests/test_basic_events.py
@@ -85,9 +85,11 @@ def test_focus_frame_by_mouse(hlwm, mouse, click, focus_follows_mouse):
 @pytest.mark.parametrize("click", [True, False])
 @pytest.mark.parametrize("focus_follows_mouse", [True, False])
 def test_focus_client_by_decoration(hlwm, mouse, x11, click, focus_follows_mouse):
-    hlwm.call('attr theme.border_width 50')
-    hlwm.call('attr theme.active.color red')
-    hlwm.call('attr theme.normal.color blue')
+    hlwm.attr.theme.border_width = 1
+    for side in ['top', 'bottom', 'left', 'right']:
+        hlwm.attr.themes[f'padding_{side}'] = 49
+    hlwm.attr.theme.active.color = 'red'
+    hlwm.attr.theme.normal.color = 'blue'
     hlwm.call('set_layout vertical')
     hlwm.call(['set', 'focus_follows_mouse', hlwm.bool(focus_follows_mouse)])
     winids = hlwm.create_clients(2)


### PR DESCRIPTION
This implements the following fixes:

  1. an unfocused window can now be mouse-resized without getting
     focused.
  2. mouse-resizing a tiled window with tabs now works also at the
     decoration edge at unfocused tabs (i.e. if the second tab is
     focused, then one can resize the window by dragging the top left
     corner and without activating the first tab).

There are now test cases that verify both these fixes.