### PR TITLE
Check early on click if client resize is possible

### DIFF
--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -246,6 +246,9 @@ void XMainLoop::buttonpress(XButtonEvent* be) {
             bool decorationClicked = be->window == client->decorationWindow();
             if (decorationClicked) {
                 resize = client->dec->positionTriggersResize({be->x, be->y});
+                if (resize) {
+                    resize = resize * client->possibleResizeActions();
+                }
             }
             if (resize) {
                 mm->mouse_initiate_resize(client, resize);


### PR DESCRIPTION
When clicking a client's border, check it early whether the client can
be resized at all. If it can not be resized, then focus the client
instead, because this is what the (normal) cursor shape indicates.

This closes #1407, a bug introduced by PR #1404.