### PR TITLE
Avoid theme.h include in client.h

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -67,7 +67,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , settings(*cm.settings)
     , ewmh(*cm.ewmh)
     , X_(*cm.X_)
-    , mostRecentThemeType(Theme::Type::Tiling)
+    , mostRecentThemeType(ThemeType::Tiling)
 {
     stringstream tmp;
     window_id_str = WindowID(window).str();
@@ -289,8 +289,8 @@ void Client::redrawRelevantTabBars()
 }
 
 void Client::resize_fullscreen(Rectangle monitor_rect, bool isFocused) {
-    dec->resize_outline(monitor_rect, theme[Theme::Type::Fullscreen](isFocused,urgent_()), {});
-    mostRecentThemeType = Theme::Type::Fullscreen;
+    dec->resize_outline(monitor_rect, theme[ThemeType::Fullscreen](isFocused,urgent_()), {});
+    mostRecentThemeType = ThemeType::Fullscreen;
 }
 
 void Client::raise() {
@@ -312,7 +312,7 @@ void Client::lower()
 void Client::resize_tiling(Rectangle rect, bool isFocused, bool minimalDecoration, vector<Client*> tabs) {
     // only apply minimal decoration if the window is not pseudotiled
     auto themetype = (minimalDecoration && !pseudotile_())
-            ? Theme::Type::Minimal : Theme::Type::Tiling;
+            ? ThemeType::Minimal : ThemeType::Tiling;
     mostRecentThemeType = themetype;
     auto& scheme = theme[themetype](isFocused, urgent_());
     if (this->pseudotile_) {
@@ -528,8 +528,8 @@ void Client::resize_floating(Monitor* m, bool isFocused) {
         CLAMP(rect.y,
               m->rect->y + m->pad_up() - rect.height + space,
               m->rect->y + m->rect->height - m->pad_up() - m->pad_down() - space);
-    dec->resize_inner(rect, theme[Theme::Type::Floating](isFocused,urgent_()));
-    mostRecentThemeType = Theme::Type::Floating;
+    dec->resize_inner(rect, theme[ThemeType::Floating](isFocused,urgent_()));
+    mostRecentThemeType = ThemeType::Floating;
 }
 
 Rectangle Client::outer_floating_rect() {
@@ -725,8 +725,8 @@ void Client::fuzzy_fix_initial_position() {
     // considering the current settings of possible floating decorations
     int extreme_x = float_size_->x;
     int extreme_y = float_size_->y;
-    const auto& t = theme[Theme::Type::Floating];
-    mostRecentThemeType = Theme::Type::Floating;
+    const auto& t = theme[ThemeType::Floating];
+    mostRecentThemeType = ThemeType::Floating;
     size_t tabCount = 0;
     auto r = t.active.inner_rect_to_outline(float_size_, tabCount);
     extreme_x = std::min(extreme_x, r.x);

--- a/src/client.h
+++ b/src/client.h
@@ -11,7 +11,6 @@
 #include "object.h"
 #include "rectangle.h"
 #include "regexstr.h"
-#include "theme.h"
 #include "x11-types.h"
 
 class Decoration;
@@ -24,7 +23,10 @@ class HSTag;
 class Monitor;
 class Settings;
 class ClientManager;
+class Theme;
+class DecorationScheme;
 class XConnection;
+enum class ThemeType;
 
 class Client : public Object {
 public:
@@ -151,7 +153,7 @@ private:
     std::string tagName();
     const DecTriple& getDecTriple();
     const DecorationScheme& getDecorationScheme(bool focused);
-    Theme::Type mostRecentThemeType;
+    ThemeType mostRecentThemeType;
 };
 
 

--- a/src/theme.h
+++ b/src/theme.h
@@ -152,15 +152,21 @@ public:
     }
 };
 
+/**
+ * @brief the members of the 'theme' object. It is a separate
+ * enum class (and not nested in Theme) because this makes
+ * forward declaration possible.
+ */
+enum class ThemeType {
+    Fullscreen,
+    Tiling,
+    Floating,
+    Minimal,
+};
+
 class Theme : public DecTriple {
 public:
-    enum class Type {
-        Fullscreen,
-        Tiling,
-        Floating,
-        Minimal,
-    };
-    const DecTriple& operator[](Type t) const {
+    const DecTriple& operator[](ThemeType t) const {
         return *decTriples[static_cast<int>(t)];
     };
     Theme();


### PR DESCRIPTION
By making Theme::Type a separate enum class ThemeType, we can use
forward declaration and avoid, that theme.h is included in client.h.