### PR TITLE
Add theme options for unselected tabs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,9 +11,10 @@ Current git version
     'tabbed_max' setting)
   * New decoration setting 'title_when' to control, when window titles and tabs
     are shown.
-  * New decoration setting 'title_depth'.
+  * New decoration settings 'title_depth' and 'title_align'.
+  * New decoration settings for configuring unselected tabs: 'tab_color',
+    'tab_outer_width', 'tab_outer_color', 'tab_title_color'
   * New autostart object with attributes 'path', 'running', 'pid', 'last_status'
-  * New decoration attribute 'title_align'
   * New client attribute 'floating_effectively' and associated X11 properties
     'HLWM_FLOATING_WINDOW' and 'HLWM_TILING_WINDOW'
   * New 'foreach' command line flags: '--filter-name=', '--recursive', '--unique'

--- a/share/autostart
+++ b/share/autostart
@@ -132,6 +132,10 @@ hc attr theme.active.color '#345F0Cef'
 hc attr theme.title_color '#ffffff'
 hc attr theme.normal.color '#323232dd'
 hc attr theme.urgent.color '#7811A1dd'
+hc attr theme.tab_color '#1F1F1Fdd'
+hc attr theme.active.tab_color '#2B4F0Add'
+hc attr theme.active.tab_outer_color '#6C8257dd'
+hc attr theme.active.tab_title_color '#ababab'
 hc attr theme.normal.title_color '#898989'
 hc attr theme.inner_width 1
 hc attr theme.inner_color black

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -544,6 +544,18 @@ void Decoration::redrawPixmap() {
                 const DecorationScheme& tabScheme =
                         (tabClient == client_)
                         ? s : tabClient->getDecorationScheme(false);
+                Color tabColor = tabScheme.border_color();
+                Color tabBorderColor = tabScheme.outer_color();
+                unsigned long tabBorderWidth = tabScheme.outer_width();
+                Color tabTitleColor = tabScheme.title_color();
+                if (tabClient != client_ && !tabClient->urgent_()) {
+                    // for tabs referring to non-urgent clients, try
+                    // to use the tab_* attributes of the DecorationScheme s:
+                    tabColor = s.tab_color->rightOr(tabScheme.border_color());
+                    tabBorderColor = s.tab_outer_color->rightOr(tabScheme.outer_color());
+                    tabBorderWidth = s.tab_outer_width->rightOr(tabScheme.outer_width());
+                    tabTitleColor = s.tab_title_color->rightOr(tabScheme.title_color());
+                }
                 Rectangle tabGeo {
                     tabIndex * tabWidth,
                     0,
@@ -566,24 +578,24 @@ void Decoration::redrawPixmap() {
                     { (short)tabGeo.x, (short)tabGeo.y,
                       (unsigned short)tabGeo.width, (unsigned short)tabGeo.height },
                 };
-                XSetForeground(display, gc, get_client_color(tabScheme.border_color));
+                XSetForeground(display, gc, get_client_color(tabColor));
                 XFillRectangles(display, pix, gc, &fillRects.front(), fillRects.size());
                 vector<XRectangle> borderRects = {
                     // top edge
                     { (short)tabGeo.x, (short)tabGeo.y,
-                      (unsigned short)tabGeo.width, (unsigned short)tabScheme.outer_width },
+                      (unsigned short)tabGeo.width, (unsigned short)tabBorderWidth },
                 };
                 if (isFirst) {
                     // edge on the left
                     borderRects.push_back(
                     { (short)tabGeo.x, (short)tabGeo.y,
-                      (unsigned short)tabScheme.outer_width, (unsigned short)tabGeo.height }
+                      (unsigned short)tabBorderWidth, (unsigned short)tabGeo.height }
                     );
                 } else if (client_ == tabClient) {
                     // shorter edge on the left
                     borderRects.push_back(
                     { (short)tabGeo.x, (short)tabGeo.y,
-                      (unsigned short)tabScheme.outer_width,
+                      (unsigned short)tabBorderWidth,
                       (unsigned short)(tabGeo.height - (s.border_width() - s.outer_width() - s.inner_width())) }
                     );
                 }
@@ -591,20 +603,20 @@ void Decoration::redrawPixmap() {
                     // edge on the right
                     borderRects.push_back(
                     { (short)(tabGeo.x + tabGeo.width - tabScheme.outer_width), (short)tabGeo.y,
-                      (unsigned short)tabScheme.outer_width,
+                      (unsigned short)tabBorderWidth,
                       (unsigned short)tabGeo.height }
                     );
                 } else if (client_ == tabClient) {
                     // shorter edge on the right
                     borderRects.push_back(
                     { (short)(tabGeo.x + tabGeo.width - tabScheme.outer_width), (short)tabGeo.y,
-                      (unsigned short)tabScheme.outer_width,
+                      (unsigned short)tabBorderWidth,
                       (unsigned short)(tabGeo.height - (s.border_width() - s.outer_width() - s.inner_width())) }
                     );
                 }
-                XSetForeground(display, gc, get_client_color(tabScheme.outer_color));
+                XSetForeground(display, gc, get_client_color(tabBorderColor));
                 XFillRectangles(display, pix, gc, &borderRects.front(), borderRects.size());
-                drawText(pix, gc, tabScheme.title_font->data(), tabScheme.title_color(),
+                drawText(pix, gc, tabScheme.title_font->data(), tabTitleColor,
                          tabGeo.tl() + Point2D { tabPadLeft, (int)s.title_height()},
                          tabClient->title_(), titleWidth - 2 * tabPadLeft, s.title_align);
                 if (client_ != tabClient) {

--- a/src/either.h
+++ b/src/either.h
@@ -52,6 +52,28 @@ public:
     Either(const B& b)
         : data_(b), isA_(false)
     {}
+    bool operator==(const Either<A,B>& other) {
+        if (isA_ && other.isA_) {
+            return data_.a_ == other.data_.a_;
+        }
+        if (!isA_ && !other.isA_) {
+            return data_.b_ == other.data_.b_;
+        }
+        return false;
+    }
+    bool operator!=(const Either<A,B>& other) {
+        return !(*this == other);
+    }
+
+    // convert Either<A,B> to type 'B'
+    B rightOr(const B& onA) const {
+        if (isA_) {
+            return onA;
+        } else {
+            return data_.b_;
+        }
+    }
+
 private:
     Either() = delete;
     union UnionAB {

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -1,5 +1,7 @@
 #include "theme.h"
 
+#include "completion.h"
+
 using std::vector;
 using std::string;
 
@@ -46,7 +48,11 @@ Theme::Theme()
           "\n"
           "Setting an attribute of the theme object just propagates the "
           "value to the respective attribute of the +tiling+ and the +floating+ "
-          "object."
+          "object.\n"
+          "If the title area is divided into tabs, then the not selected tabs "
+          "can be styled using the +tab_...+ attributes. If these attributes are "
+          "empty, then the colors are taken from the theme of the client to which "
+          "the tab refers to."
     );
     tiling.setChildDoc(
                 "configures the decoration of tiled clients, setting one of "
@@ -75,6 +81,10 @@ DecorationScheme::DecorationScheme()
         &inner_width,
         &outer_color,
         &outer_width,
+        &tab_color,
+        &tab_outer_color,
+        &tab_outer_width,
+        &tab_title_color,
         &padding_top,
         &padding_right,
         &padding_bottom,
@@ -108,6 +118,13 @@ DecorationScheme::DecorationScheme()
                       "if there are +multiple_tabs+ to be shown.");
     title_align.setDoc("the horizontal alignment of the title within the tab "
                        "or title bar. The value is one of: left, center, right");
+    tab_color.setDoc("if non-empty, the color of non-urgent and unfocused tabs");
+    tab_outer_color.setDoc(
+                "if non-empty, the outer border color of non-urgent and "
+                "unfocused tabs; if empty, the colors are taken from the tab's"
+                "client decoration settings.");
+    tab_outer_width.setDoc("if non-empty, the outer border width of non-urgent and unfocused tabs");
+    tab_title_color.setDoc("if non-empty, the title color of non-urgent and unfocused tabs");
     reset.setDoc("writing this resets all attributes to a default value");
 }
 
@@ -186,3 +203,8 @@ void DecorationScheme::makeProxyFor(vector<DecorationScheme*> decs) {
 }
 
 
+template<>
+void Converter<Inherit>::complete(Completion& complete, const Inherit* relativeTo)
+{
+    complete.full("");
+}

--- a/src/theme.h
+++ b/src/theme.h
@@ -4,8 +4,8 @@
 #include <vector>
 
 #include "attribute_.h"
-#include "converter.h"
 #include "child.h"
+#include "converter.h"
 #include "either.h"
 #include "finite.h"
 #include "font.h"

--- a/src/theme.h
+++ b/src/theme.h
@@ -4,7 +4,9 @@
 #include <vector>
 
 #include "attribute_.h"
+#include "converter.h"
 #include "child.h"
+#include "either.h"
 #include "finite.h"
 #include "font.h"
 #include "object.h"
@@ -26,6 +28,29 @@ struct is_finite<TitleWhen> : std::true_type {};
 template<> Finite<TitleWhen>::ValueList Finite<TitleWhen>::values;
 template<> inline Type Attribute_<TitleWhen>::staticType() { return Type::NAMES; }
 
+class Inherit {
+public:
+    bool operator==(const Inherit& other) { return true; }
+};
+
+template<>
+inline std::string Converter<Inherit>::str(Inherit payload) { return ""; }
+template<>
+inline Inherit Converter<Inherit>::parse(const std::string &payload) {
+    if (payload.empty()) {
+        return {};
+    }
+    throw std::invalid_argument("Use an empty string for inheriting the value.");
+}
+template<> void Converter<Inherit>::complete(Completion& complete, Inherit const* relativeTo);
+
+
+typedef Either<Inherit,Color> MaybeColor;
+typedef Either<Inherit,unsigned long> MaybeULong;
+template<>
+inline Type Attribute_<MaybeColor>::staticType() { return Type::STRING; }
+template<>
+inline Type Attribute_<MaybeULong>::staticType() { return Type::STRING; }
 
 /** The proxy interface
  */
@@ -114,6 +139,10 @@ public:
     AttributeProxy_<unsigned long>     padding_bottom = {"padding_bottom", 0}; // additional window border
     AttributeProxy_<unsigned long>     padding_left = {"padding_left", 0};   // additional window border
     AttributeProxy_<Color>   background_color = {"background_color", {"black"}}; // color behind client contents
+    AttributeProxy_<MaybeColor>   tab_color = {"tab_color", {Inherit()}};
+    AttributeProxy_<MaybeColor>   tab_outer_color = {"tab_outer_color", {Inherit()}};
+    AttributeProxy_<MaybeULong>   tab_outer_width = {"tab_outer_width", {Inherit()}};
+    AttributeProxy_<MaybeColor>   tab_title_color = {"tab_title_color", {Inherit()}};
 
     Signal scheme_changed_; //! whenever one of the attributes changes.
 

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -293,14 +293,21 @@ def test_frame_holes_for_pseudotiled_client(hlwm, x11, frame_bg_transparent):
     img.pixel(w // 2, h // 2) == black
 
 
+@pytest.mark.parametrize("method", ['tab_*-attributes', 'other scheme'])
 @pytest.mark.parametrize("running_clients_num", [3])
-def test_decoration_tab_colors(hlwm, x11, running_clients, running_clients_num):
+def test_decoration_tab_colors(hlwm, x11, method, running_clients, running_clients_num):
     active_color = (200, 23, 0)  # something unique
     normal_color = (23, 200, 0)  # something unique
     hlwm.attr.theme.active.color = RawImage.rgb2string(active_color)
     hlwm.attr.theme.active.title_color = RawImage.rgb2string(active_color)
-    hlwm.attr.theme.normal.color = RawImage.rgb2string(normal_color)
-    hlwm.attr.theme.normal.title_color = RawImage.rgb2string(normal_color)
+    if method == 'tab_*-attributes':
+        hlwm.attr.theme.active.tab_color = RawImage.rgb2string(normal_color)
+        hlwm.attr.theme.active.tab_title_color = RawImage.rgb2string(normal_color)
+        hlwm.attr.theme.active.tab_outer_color = RawImage.rgb2string(normal_color)
+        hlwm.attr.theme.active.tab_outer_width = 1
+    if method == 'other scheme':
+        hlwm.attr.theme.normal.color = RawImage.rgb2string(normal_color)
+        hlwm.attr.theme.normal.title_color = RawImage.rgb2string(normal_color)
 
     hlwm.attr.theme.title_height = 20
     hlwm.call(['set_layout', 'max'])

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -117,6 +117,8 @@ def types_and_shorthands():
         'font': 'f',
         'Rectangle': 'R',
         'WindowID': 'w',
+        'MaybeColor': 'c',
+        'MaybeULong': 'u',
     }
 
 

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -117,8 +117,8 @@ def types_and_shorthands():
         'font': 'f',
         'Rectangle': 'R',
         'WindowID': 'w',
-        'MaybeColor': 'c',
-        'MaybeULong': 'u',
+        'MaybeColor': 's',
+        'MaybeULong': 's',
     }
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -62,6 +62,20 @@ def test_color_names(hlwm):
         assert hlwm.attr.theme.color() == rgb
 
 
+def test_maybe_color(hlwm):
+    for value in ['#ff0000', '']:
+        hlwm.attr.theme.tab_color = value
+        assert hlwm.attr.theme.tab_color() == value
+    assert '' in hlwm.complete('set_attr theme.tab_outer_width', evaluate_escapes=True)
+
+
+def test_maybe_ulong(hlwm):
+    for value in ['5', '']:
+        hlwm.attr.theme.tab_outer_width = value
+        assert hlwm.attr.theme.tab_outer_width() == value
+    assert '' in hlwm.complete('set_attr theme.tab_outer_width', evaluate_escapes=True)
+
+
 def test_int_uint_unparsable_suffix(hlwm):
     for attrtype in ['int', 'uint']:
         attr = 'my_' + attrtype


### PR DESCRIPTION
In order to distinguish unselected from selected tabs, this adds new
attributes for controlling tab appearance. Those attributes can also be
empty, which will cause the normal attributes to be used (as before);
this makes the change 100% backwards compatible.

This implements what has been requested during the discussion of #1388
and closes #1389.