### PR TITLE
Do not map already visible unmanaged windows

### DIFF
--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -208,7 +208,8 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
     auto stdio = OutputChannels::stdio();
     changes = Root::get()->rules()->evaluateRules(client, stdio, changes);
     if (!changes.manage || force_unmanage) {
-        // map it... just to be sure
+        // if the window becomes unmanaged and wasn't visible before,
+        // then map it.
         if (!visible_already) {
             XMapWindow(X_->display(), win);
         }

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -209,7 +209,9 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
     changes = Root::get()->rules()->evaluateRules(client, stdio, changes);
     if (!changes.manage || force_unmanage) {
         // map it... just to be sure
-        XMapWindow(X_->display(), win);
+        if (!visible_already) {
+            XMapWindow(X_->display(), win);
+        }
         delete client;
         return {};
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -767,6 +767,7 @@ class X11:
                       window_type=None,
                       transient_for=None,
                       pre_map=lambda wh: None,  # called before the window is mapped
+                      pre_sync=lambda wh: None,  # called before the display is synced
                       ):
         w = self.root.create_window(
             geometry[0],
@@ -807,6 +808,7 @@ class X11:
 
         pre_map(w)
         w.map()
+        pre_sync(w)
         self.display.sync()
         if sync_hlwm:
             # wait for hlwm to fully recognize it as a client
@@ -939,6 +941,18 @@ class X11:
             window.unmap()
             window.destroy()
         self.display.sync()
+
+    def pop_pending_events(self):
+        """extract all pending events from the event queue"""
+        events = []
+        while True:
+            self.display.sync()
+            count = self.display.pending_events()
+            if count <= 0:
+                break
+            for i in range(0, count):
+                events.append(self.display.next_event())
+        return events
 
 
 @pytest.fixture()

--- a/tests/test_basic_events.py
+++ b/tests/test_basic_events.py
@@ -1,5 +1,6 @@
 import pytest
 import test_stack
+import Xlib
 
 
 @pytest.mark.parametrize("single_floating", [True, False])
@@ -143,3 +144,31 @@ def test_enternotify_do_not_drop_events(hlwm, mouse, client_count):
 
     # finally, all enter notify events must survive
     assert hlwm.get_attr('clients.focus.winid') == winid[client_count - 1]
+
+
+def test_no_map_of_visible_unmanaged_windows(hlwm, hc_idle, x11):
+    hlwm.call(['rule', 'hook=tempmanage'])
+    x11.pop_pending_events()  # clear event queue
+
+    def pre_map(winhandle):
+        # get MapNotify events
+        winhandle.change_attributes(event_mask=Xlib.X.StructureNotifyMask)
+        x11.display.grab_server()
+
+    def pre_sync(winhandle):
+        # right after mapping, unmap the window again.
+        # Hence, we will be noticed if hlwm maps the window without permission
+        winhandle.unmap()
+        x11.display.ungrab_server()
+
+    handle, winid = x11.create_client(force_unmanage=True, pre_map=pre_map, pre_sync=pre_sync)
+    map_notify_events = []
+    events = x11.pop_pending_events()
+    for e in events:
+        if e.type == Xlib.X.MapNotify:
+            map_notify_events.append(e)
+
+    # the rules are evaluated correctly:
+    assert ['rule', 'tempmanage', winid] in hc_idle.hooks()
+    # and thlwm didn't try to call XMapWindow:
+    assert len(map_notify_events) == 1

--- a/tests/test_basic_events.py
+++ b/tests/test_basic_events.py
@@ -170,5 +170,5 @@ def test_no_map_of_visible_unmanaged_windows(hlwm, hc_idle, x11):
 
     # the rules are evaluated correctly:
     assert ['rule', 'tempmanage', winid] in hc_idle.hooks()
-    # and thlwm didn't try to call XMapWindow:
+    # and hlwm didn't try to call XMapWindow:
     assert len(map_notify_events) == 1


### PR DESCRIPTION
In the MapNotify for an unmanaged window, manage_client() is called,
which should not call XMapWindow(), because the window is already
visible. When XMapWindow() was still called, this could trigger wrong
behaviour if a x11 client quickly maps and then unmaps the window,
because hlwm would then map the window again.

Concretely, this bug triggered an endless loop when pressing Alt in
pcmanfm (one should only test this in Xephyr, otherwise the session
hangs).

The new test case quickly maps and unmaps a window, and verifies that
hlwm does not try to map the window again.