### PR TITLE
Fix input focus for preexisting clients

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -204,6 +204,9 @@ void Client::make_full_client() {
         // point, we did not call XSelectInput() yet, so the above
         // XReparentWindow does not trigger an event for the window.
         visible_ = false;
+        // we also unmap the window such that the decoration window is
+        // in 'mapped' state f and only if the window itself is so.
+        XUnmapWindow(X_.display(), window_);
     }
     // get events from window
     XSelectInput(X_.display(), dec->decorationWindow(), (EnterWindowMask | LeaveWindowMask |

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -205,7 +205,7 @@ void Client::make_full_client() {
         // XReparentWindow does not trigger an event for the window.
         visible_ = false;
         // we also unmap the window such that the decoration window is
-        // in 'mapped' state f and only if the window itself is so.
+        // in 'mapped' state if and only if the window itself is so.
         XUnmapWindow(X_.display(), window_);
     }
     // get events from window

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -152,6 +152,7 @@ def test_tags_restored_after_wmexec(hlwm, hlwm_process):
     (2, [0, 1]),
     (2, [None, 1]),  # client without index set
     (2, [2, 1, 8, 0]),  # clients exceeding the index range
+    (3, [1, 2]),  # no client on the focused tag
     (5, [1, 1, 0, 4, 4, 4]),
 ])
 def test_client_initially_on_desktop(hlwm_spawner, x11, desktops, client2desktop):
@@ -176,6 +177,18 @@ def test_client_initially_on_desktop(hlwm_spawner, x11, desktops, client2desktop
         else:
             assert hlwm.get_attr(f'clients.{winid}.tag') \
                 == desktop_names[0]
+
+    # check that clients.focus matches the X11 input focus on all tags:
+    for i in range(0, desktops):
+        assert i == hlwm.attr.tags.focus.index()
+        input_focus = x11.display.get_input_focus().focus
+        if 'focus' in hlwm.list_children('clients'):
+            # if a client is focused according to hlwm, it has the input focus:
+            assert x11.winid_str(input_focus) == hlwm.attr.clients.focus.winid()
+        else:
+            # otherwise, the invisible hlwm dummy window is focused:
+            assert input_focus.id == x11.get_property('_NET_SUPPORTING_WM_CHECK')[0]
+        hlwm.call('use_index +1')
 
     hlwm_proc.shutdown()
 


### PR DESCRIPTION
This correctly puts the input focus to clients that exist before hlwm.
This is a bug that was brought to the surface by PR #1403, because now,
hlwm only calls XSetInputFocus() if the focus actually changes.

The solution now is: the decoration window is 'unmapped' if and only if
the client window itself is 'unmapped'. This is true already for all
clients that show up during the hlwm execution, but wasn't true for
clients existing before. With this property, making the client visible
(in Client::set_visible()) will actually set the client to the 'mapped'
state, triggering a MapNotify event, whose handler then calls
XSetInputFocus() if necessary.