### PR TITLE
Prevent endless focus stealing loop

### DIFF
--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -54,8 +54,10 @@ private:
 
     void focusedClientChanges(Client* newFocus);
     Client* lastFocus_ = {}; // the old value of clients.focus
+    void setInputFocus(Client* newFocus);
 
     bool duringEnterNotify_ = false; //! whether we are in enternotify()
+    bool duringFocusIn_ = false; //! whether we are in focusin()
 
     static IpcServer::CallResult callCommand(const std::vector<std::string>& call);
 


### PR DESCRIPTION
I think that this now solves the issue of the endless FocusIn event loop
triggered by #1386. However, I still do not know how to reproduce the
endless loop. In the present solution, I avoid that the handler of
FocusIn triggers further FocusIn or similar events (via the member
duringFocusIn_).

While at it, I've moved all calls to XSetInputFocus() to a custom
setInputFocus() function that possibly falls back to the WM_TAKE_FOCUS
method if the client requests so.