### PR TITLE
tests: Register herbstluftwm module for assertion rewriting

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,11 @@ import sys
 import textwrap
 import time
 import types
-import herbstluftwm
 
 import pytest
+
+pytest.register_assert_rewrite("herbstluftwm")
+import herbstluftwm  # noqa: E402
 
 
 BINDIR = os.path.join(os.path.abspath(os.environ['PWD']))


### PR DESCRIPTION
By default, pytest has its assertion rewriting disabled for code outside of the
tests and conftest modules, to avoid testing different code than what runs in
production.

However, we have assertions in the herbstluftwm module, so it would be good to
benefit from rewriting there, too.

Docs: https://docs.pytest.org/en/latest/how-to/writing_plugins.html#assertion-rewriting

For a test such as:

    def test_failing(hlwm):
        hlwm.call("false")

This turns the output:

    >       assert proc.returncode == 0
    E       AssertionError

into output with additional assertion information:

    >       assert proc.returncode == 0
    E       AssertionError: assert 1 == 0
    E        +  where 1 = CompletedProcess(args=['.../build/herbstclient', '-n', 'false'], returncode=1, stdout='', stderr='').returncode

Which will hopefully help making diagnosing issues such as #1414 easier.