### PR TITLE
Add 'fixedsize' rule condition

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,7 @@ Current git version
   * New 'foreach' command line flags: '--filter-name=', '--recursive', '--unique'
   * The 'spawn' command now prints an error message on exec failure
   * New read-only client attribute 'decoration_geometry'.
+  * New rule condition 'fixedsize'
   * New attribute 'decorated' to disable window decorations
   * The cursor shape now indicates resize options.
   * New setting 'ellipsis'

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1078,6 +1078,16 @@ Valid 'properties' are:
 +windowrole+::
     matches the WM_WINDOW_ROLE property of a window if it is set by the window.
 
+
++fixedsize+ (no parameter)::
+    matches if the window does not allow being resized (i.e. if the minimum size
+    matches the maximum size). This condition does *not* take a parameter.
+    Example: +
++
+------
+hc rule fixedsize floating=on
+------
+
 Each 'CONSEQUENCE' consists of a 'NAME'='VALUE' pair. Valid 'NAMES' are:
 
 +tag+::

--- a/share/autostart
+++ b/share/autostart
@@ -171,6 +171,7 @@ hc rule floatplacement=smart
 hc rule windowtype~'_NET_WM_WINDOW_TYPE_(DIALOG|UTILITY|SPLASH)' floating=on
 hc rule windowtype='_NET_WM_WINDOW_TYPE_DIALOG' focus=on
 hc rule windowtype~'_NET_WM_WINDOW_TYPE_(NOTIFICATION|DOCK|DESKTOP)' manage=off
+hc rule fixedsize floating=on
 
 hc set tree_style '╾│ ├└╼─┐'
 

--- a/src/client.h
+++ b/src/client.h
@@ -49,7 +49,7 @@ public:
                                 // notify event
     //! the last time when minimized_ was changed (with discrete time ticks).
     long long int minimizedLastChange_ = 0;
-    // for size hints
+    // for size hints; 0 means 'unset'
     float mina_ = 0;
     float maxa_ = 0;
     int basew_ = 0;

--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -55,6 +55,14 @@ int RuleManager::parseRule(Input input, Output output, Rule& rule, bool& prepend
             arg = *(++argIter);
         }
 
+        if (arg == "fixedsize") {
+            Condition cond;
+            cond.name = arg;
+            cond.value_type = CONDITION_VALUE_TYPE_NO_ARG;
+            cond.match_ = &Condition::matchesFixedSize;
+            rule.conditions.push_back(cond);
+        }
+
         // Tokenize arg, expect something like foo=bar or foo~bar:
         char oper;
         string lhs, rhs;
@@ -218,7 +226,7 @@ void RuleManager::unruleCompletion(Completion& complete) {
 }
 
 void RuleManager::addRuleCompletion(Completion& complete) {
-    complete.full({ "not", "!", "prepend", "once", "printlabel" });
+    complete.full({ "fixedsize", "not", "!", "prepend", "once", "printlabel" });
     complete.partial("label=");
     for (auto&& matcher : Condition::matchers) {
         auto condName = matcher.first;

--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -60,7 +60,9 @@ int RuleManager::parseRule(Input input, Output output, Rule& rule, bool& prepend
             cond.name = arg;
             cond.value_type = CONDITION_VALUE_TYPE_NO_ARG;
             cond.match_ = &Condition::matchesFixedSize;
+            cond.negated = negated;
             rule.conditions.push_back(cond);
+            continue;
         }
 
         // Tokenize arg, expect something like foo=bar or foo~bar:

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -350,8 +350,7 @@ bool Condition::matchesWindowrole(const Client* client) const {
     return matches(role.value());
 }
 
-bool Condition::matchesFixedSize(const Client* client) const
-{
+bool Condition::matchesFixedSize(const Client* client) const {
     return client->maxw_ != 0
             && client->maxh_ != 0
             && client->minh_ == client->maxh_

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -131,6 +131,7 @@ bool Rule::addCondition(const Condition::Matchers::const_iterator& it, char op, 
     }
 
     cond.name = name;
+    cond.match_ = it->second;
 
     conditions.push_back(cond);
     return true;
@@ -197,7 +198,7 @@ bool Rule::evaluate(Client* client, ClientChanges& changes, Output output)
             continue;
         }
 
-        bool matches = Condition::matchers.at(cond.name)(&cond, client);
+        bool matches = cond.match_(&cond, client);
 
         if (!matches && !cond.negated && cond.name == "maxage")
         {
@@ -347,6 +348,14 @@ bool Condition::matchesWindowrole(const Client* client) const {
     }
 
     return matches(role.value());
+}
+
+bool Condition::matchesFixedSize(const Client* client) const
+{
+    return client->maxw_ != 0
+            && client->maxh_ != 0
+            && client->minh_ == client->maxh_
+            && client->minw_ == client->maxw_;
 }
 
 /// CONSEQUENCES ///

--- a/src/rules.h
+++ b/src/rules.h
@@ -15,6 +15,7 @@ enum {
     CONDITION_VALUE_TYPE_STRING,
     CONDITION_VALUE_TYPE_REGEX,
     CONDITION_VALUE_TYPE_INTEGER,
+    CONDITION_VALUE_TYPE_NO_ARG,
 };
 
 enum {
@@ -36,6 +37,7 @@ public:
     int value_integer = 0;
     std::regex value_reg_exp;
     std::string value_reg_str;
+    Matcher match_;
 
     /*! Timestamp of when this condition (i.e. rule) was created, which is
      * needed for the maxage matcher.
@@ -46,6 +48,7 @@ public:
      */
     time_t conditionCreationTime = 0;
 
+    bool matchesFixedSize(const Client* client) const;
 private:
     bool matchesClass(const Client* client) const;
     bool matchesInstance(const Client* client) const;

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1047,7 +1047,6 @@ def test_fixedsize(hlwm, hc_idle, x11):
             'flags': Xutil.PMinSize | Xutil.PMaxSize,
         }
         w.set_wm_normal_hints(**hints)
-        pass
 
     _, win_fixed = x11.create_client(pre_map=make_fixedsize)
     _, win_nofixed = x11.create_client()


### PR DESCRIPTION
As requested in #1406, this introduces a new rule condition `fixedsize`
which checks whether minimum and maximum size of a window match.
The condition does not take a parameter, because otherwise, it looks as
if it was a rule consequence.

This closes #1406.