### PR TITLE
Drag floating clients between monitors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,7 @@ Current git version
   * New attribute 'decorated' to disable window decorations
   * The cursor shape now indicates resize options.
   * New setting 'ellipsis'
+  * Floating clients can now be dragged between monitors via the mouse
   * Frames can be simultaneously resized in x and y direction with the mouse.
   * Bug fixes:
     - Update floating geometry if a client's size hints change

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -31,9 +31,6 @@ using std::shared_ptr;
 using std::string;
 using std::stringstream;
 
-static int g_monitor_float_treshold = 24;
-
-
 Client::Client(Window window, bool visible_already, ClientManager& cm)
     : window_(window)
     , dec(make_unique<Decoration>(this, *cm.settings))
@@ -516,21 +513,11 @@ void Client::resize_floating(Monitor* m, bool isFocused) {
     if (!m) {
         return;
     }
-    Rectangle rect = this->float_size_;
+    Rectangle rect = m->clampRelativeGeometry(float_size_);
     rect.x += m->rect->x;
     rect.y += m->rect->y;
     rect.x += m->pad_left();
     rect.y += m->pad_up();
-    // ensure position is on monitor
-    int space = g_monitor_float_treshold;
-    rect.x =
-        CLAMP(rect.x,
-              m->rect->x + m->pad_left() - rect.width + space,
-              m->rect->x + m->rect->width - m->pad_left() - m->pad_right() - space);
-    rect.y =
-        CLAMP(rect.y,
-              m->rect->y + m->pad_up() - rect.height + space,
-              m->rect->y + m->rect->height - m->pad_up() - m->pad_down() - space);
     dec->resize_inner(rect, theme[ThemeType::Floating](isFocused,urgent_()));
     mostRecentThemeType = ThemeType::Floating;
 }

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -30,6 +30,8 @@ using std::string;
 using std::stringstream;
 using std::vector;
 
+static int g_monitor_float_treshold = 24;
+
 extern MonitorManager* g_monitors;
 
 Monitor::Monitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, HSTag* tag_)
@@ -526,6 +528,33 @@ int Monitor::relativeX(int x_root) {
 
 int Monitor::relativeY(int y_root) {
     return y_root - rect->y - pad_up;
+}
+
+/**
+ * @brief Adjust the given geometry (relative to monitor contents)
+ * such that it is visible within the monitor.
+ * @param relativeGeo geometry relative to the interior area of the monitor
+ * @return the adjusted relative geometry
+ */
+Rectangle Monitor::clampRelativeGeometry(Rectangle relativeGeo) const
+{
+    // make sure, this many pixels are still visible:
+    int space = g_monitor_float_treshold;
+    // since coordinates are relative to the monitor, we ensure that
+    // relativeGeo intersects with the rectangle
+    // (0,0,monitorInteriorWidth,monitorInteriorHeight)
+    // by at least 'space' many pixels
+    int monitorInteriorWidth = rect->width - pad_left() - pad_right();
+    int monitorInteriorHeight = rect->height - pad_up() - pad_down();
+    relativeGeo.x =
+        CLAMP(relativeGeo.x,
+              space - relativeGeo.width,
+              monitorInteriorWidth - space);
+    relativeGeo.y =
+        CLAMP(relativeGeo.y,
+              space - relativeGeo.height,
+              monitorInteriorHeight - space);
+    return relativeGeo;
 }
 
 void Monitor::restack() {

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -43,6 +43,7 @@ public:
     Attribute_<Rectangle>   rect;   // area for this monitor
     Window      stacking_window;   // window used for making stacking easy
     Signal monitorMoved;
+    Rectangle clampRelativeGeometry(Rectangle relativeGeo) const;
     void setIndexAttribute(unsigned long index) override;
     int lock_tag_cmd(Input argv, Output output);
     int unlock_tag_cmd(Input argv, Output output);

--- a/src/mousedraghandler.h
+++ b/src/mousedraghandler.h
@@ -13,6 +13,7 @@ class FrameSplit;
 class HSTag;
 class Monitor;
 class MonitorManager;
+class TagManager;
 class ResizeAction;
 
 /**
@@ -41,7 +42,7 @@ public:
 
     //! a MouseDragHandler::Constructor creates a MouseDragHandler object, given the
     //! MonitorManager (as a dependency) and the actual client to drag.
-    typedef std::function<std::shared_ptr<MouseDragHandler>(MonitorManager*, Client*)> Constructor;
+    typedef std::function<std::shared_ptr<MouseDragHandler>(MonitorManager*, TagManager*, Client*)> Constructor;
 
     //! the way in which the current drag handler affects the window dimensions
     ResizeAction resizeAction_;
@@ -57,7 +58,7 @@ class MouseDragHandlerFloating : public MouseDragHandler {
 public:
     typedef void (MouseDragHandlerFloating::*DragFunction)(Point2D);
 
-    MouseDragHandlerFloating(MonitorManager* monitors_, Client* dragClient, DragFunction function);
+    MouseDragHandlerFloating(MonitorManager* monitors_, TagManager* tags, Client* dragClient, DragFunction function);
     virtual ~MouseDragHandlerFloating() {};
     virtual void finalize();
     virtual void handle_motion_event(Point2D newCursorPos);
@@ -72,6 +73,7 @@ private:
     void assertDraggingStillSafe();
 
     MonitorManager*  monitors_;
+    TagManager*  tags_;
     Point2D          buttonDragStart_ = {};
     Rectangle        winDragStart_;
     Client*        winDragClient_ = nullptr;

--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -34,6 +34,7 @@ MouseManager::MouseManager()
     : dragHandler_({})
     , clients_(nullptr)
     , monitors_(nullptr)
+    , tags_(nullptr)
 {
     /* set cursor theme */
     cursor = XCreateFontCursor(g_display, XC_left_ptr);

--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -51,10 +51,11 @@ MouseManager::~MouseManager() {
     XFreeCursor(g_display, cursor);
 }
 
-void MouseManager::injectDependencies(ClientManager* clients, MonitorManager* monitors)
+void MouseManager::injectDependencies(ClientManager* clients, TagManager* tags, MonitorManager* monitors)
 {
     clients_ = clients;
     monitors_ = monitors;
+    tags_ = tags;
 }
 
 int MouseManager::addMouseBindCommand(Input input, Output output) {
@@ -207,8 +208,8 @@ string MouseManager::mouse_initiate_resize(Client* client, const ResizeAction& r
 {
     MouseDragHandler::Constructor constructor;
     if (client->is_client_floated()) {
-        constructor = [resize](MonitorManager* monitors, Client* clientInner) -> shared_ptr<MouseDragHandler> {
-            auto mdh = make_shared<MouseDragHandlerFloating>(monitors, clientInner, &MouseDragHandlerFloating::mouse_function_resize);
+        constructor = [resize](MonitorManager* monitors, TagManager* tags, Client* clientInner) -> shared_ptr<MouseDragHandler> {
+            auto mdh = make_shared<MouseDragHandlerFloating>(monitors, tags, clientInner, &MouseDragHandlerFloating::mouse_function_resize);
             mdh->lockWidth = !resize.left && !resize.right;
             mdh->lockHeight = !resize.top && !resize.bottom;
             return mdh;
@@ -254,7 +255,7 @@ ResizeAction MouseManager::resizeAction()
 string MouseManager::mouse_initiate_drag(Client *client, const MouseDragHandler::Constructor& createHandler, ResizeAction resize)
 {
     try {
-        dragHandler_ = createHandler(monitors_, client);
+        dragHandler_ = createHandler(monitors_, tags_, client);
         dragHandler_->resizeAction_ = resize * client->possibleResizeActions();
         // only grab pointer if dragHandler_ could be started
         clients_->setDragged(client);

--- a/src/mousemanager.h
+++ b/src/mousemanager.h
@@ -14,6 +14,7 @@ class ClientManager;
 class MonitorManager;
 class MouseDragHandler;
 class ResizeAction;
+class TagManager;
 struct Point2D;
 
 class MouseManager : public Object {
@@ -21,7 +22,7 @@ public:
     MouseManager();
     ~MouseManager();
 
-    void injectDependencies(ClientManager* clients, MonitorManager* monitors);
+    void injectDependencies(ClientManager* clients, TagManager* tags, MonitorManager* monitors);
 
     int addMouseBindCommand(Input input, Output output);
 
@@ -66,7 +67,7 @@ private:
     MouseFunction string2mousefunction(const std::string& name);
 
     //! manually (forward-)declare MouseDragHandler::Constructor as MDC here:
-    typedef std::function<std::shared_ptr<MouseDragHandler>(MonitorManager*, Client*)> MDC;
+    typedef std::function<std::shared_ptr<MouseDragHandler>(MonitorManager*, TagManager*, Client*)> MDC;
     //! start a the drag, and if it does not work out, return an error message
     std::string mouse_initiate_drag(Client* client, const MDC& createHandler, ResizeAction resize);
 
@@ -75,4 +76,5 @@ private:
     Cursor cursor;
     ClientManager*  clients_;
     MonitorManager*  monitors_;
+    TagManager*  tags_;
 };

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -71,7 +71,7 @@ Root::Root(Globals g, XConnection& xconnection, Ewmh& ewmh, IpcServer& ipcServer
     clients->injectDependencies(settings(), theme(), &ewmh_);
     panels->injectDependencies(settings());
     monitors->injectDependencies(settings(), tags(), panels());
-    mouse->injectDependencies(clients(), monitors());
+    mouse->injectDependencies(clients(), tags(), monitors());
     watchers->injectDependencies(this);
 
     // set temporary globals

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -467,7 +467,7 @@ def test_can_move_client_at_monitor_edge(hlwm, mouse):
     hlwm.attr.tags.focus.floating = True
     winid, _ = hlwm.create_client()
     hlwm.call('move_monitor 0 600x400+0+0')
-    # move floating coordinates clearly off scrreen:
+    # move floating coordinates clearly off screen:
     floating_geo = Rectangle(x=2000, y=4000, width=300, height=200)
     hlwm.attr.clients[winid].sizehints_floating = False
     hlwm.attr.clients[winid].floating_geometry = floating_geo
@@ -504,7 +504,7 @@ def test_can_move_client_at_monitor_edge(hlwm, mouse):
 def test_drag_floating_to_other_monitor(hlwm, mouse, source_floating, client_floating, target_floating, client_focused):
     total_width = hlwm.attr.monitors.focus.geometry().width
     total_height = hlwm.attr.monitors.focus.geometry().height
-    # create two monitors side by side with small gaps, pads, and some odds coordinates
+    # create two monitors side by side with small gaps, pads, and some odd coordinates
     hlwm.call('add othertag')
     geo1 = Rectangle(x=10, y=20, width=total_width / 2 - 30, height=total_height)
     geo2 = Rectangle(x=total_width / 2, y=15, width=total_width / 2, height=total_height)

--- a/tests/test_mousebind.py
+++ b/tests/test_mousebind.py
@@ -1,6 +1,6 @@
 import pytest
 import math
-from herbstluftwm.types import Point
+from herbstluftwm.types import Point, Rectangle
 
 # Note: For unknown reasons, mouse buttons 4 and 5 (scroll wheel) do not work
 # in Xvfb when running tests in the CI. Therefore, we maintain two lists of
@@ -403,7 +403,7 @@ def test_resize_unfocused_client(hlwm, mouse, floating):
 
 
 @pytest.mark.parametrize('resize_possible', [True, False])
-def test_border_click_either_focuses_or_resizez(hlwm, mouse, resize_possible):
+def test_border_click_either_focuses_or_resizes(hlwm, mouse, resize_possible):
     """
     when clicking on the outer decoration of a window, then this should either
     trigger the resize or focus the client (if resizing is not possible).
@@ -461,3 +461,96 @@ def test_resize_client_via_decoration(hlwm, x11, mouse, repeat):
     assert expected_size == (size_after.width, size_after.height)
     # and also the location
     assert expected_position == x11.get_absolute_top_left(client)
+
+
+def test_can_move_client_at_monitor_edge(hlwm, mouse):
+    hlwm.attr.tags.focus.floating = True
+    winid, _ = hlwm.create_client()
+    hlwm.call('move_monitor 0 600x400+0+0')
+    # move floating coordinates clearly off scrreen:
+    floating_geo = Rectangle(x=2000, y=4000, width=300, height=200)
+    hlwm.attr.clients[winid].sizehints_floating = False
+    hlwm.attr.clients[winid].floating_geometry = floating_geo
+    # still, the window overlaps with the monitor by a few pixels
+    content_geo = hlwm.attr.clients[winid].content_geometry()
+    assert content_geo.x + 20 < 600
+    assert content_geo.y + 20 < 400
+    assert hlwm.attr.clients[winid].floating_geometry() == floating_geo
+    # so, despite the floating geo is far off,
+    # the window is shown on the monitor
+
+    # now drag the window by a few pixels back into the monitor:
+    mouse.move_into(winid)
+    hlwm.attr.settings.update_dragged_clients = True
+    hlwm.call(['drag', winid, 'move'])
+    delta = Point(-72, -93)
+    assert hlwm.get_attr('clients.dragged.winid') == winid
+    mouse.move_relative(delta.x, delta.y)
+
+    # then, we expect that the window actually moves back
+    # by precisely this distance:
+    # (in old hlwm versions, the window was glueing in the bottom right corner)
+    assert hlwm.attr.clients[winid].content_geometry() == content_geo.adjusted(dx=delta.x, dy=delta.y)
+    # but of course the floating geo changed a lot (e.g. more than 500),
+    # because the window is now within the screen again:
+    new_floating_geo = hlwm.attr.clients[winid].floating_geometry()
+    assert abs(new_floating_geo.x - floating_geo.x) > 500
+    assert abs(new_floating_geo.y - floating_geo.y) > 500
+
+
+@pytest.mark.parametrize('source_floating,client_floating', [(True, True), (True, False), (False, True)])
+@pytest.mark.parametrize('target_floating', [True, False])
+@pytest.mark.parametrize('client_focused', [True, False])
+def test_drag_floating_to_other_monitor(hlwm, mouse, source_floating, client_floating, target_floating, client_focused):
+    total_width = hlwm.attr.monitors.focus.geometry().width
+    total_height = hlwm.attr.monitors.focus.geometry().height
+    # create two monitors side by side with small gaps, pads, and some odds coordinates
+    hlwm.call('add othertag')
+    geo1 = Rectangle(x=10, y=20, width=total_width / 2 - 30, height=total_height)
+    geo2 = Rectangle(x=total_width / 2, y=15, width=total_width / 2, height=total_height)
+    hlwm.call(['set_monitors', geo1.to_user_str(), geo2.to_user_str()])
+    hlwm.call(['pad', '0', '11', '12', '13', '14'])
+    hlwm.call(['pad', '1', '15', '16', '17', '18'])
+    hlwm.attr.settings.update_dragged_clients = True
+
+    hlwm.attr.tags[0].floating = source_floating
+    hlwm.attr.tags[1].floating = target_floating
+    # another dummy client
+    otherclient, _ = hlwm.create_client()
+
+    # put client in the middle of tag 0
+    hlwm.call('rule floatplacement=center')
+    winid, _ = hlwm.create_client()
+    if client_focused:
+        focused_winid = winid
+    else:
+        focused_winid = otherclient
+    hlwm.call(['jumpto', focused_winid])
+    hlwm.attr.clients[winid].floating = client_floating
+    assert hlwm.attr.clients[winid].tag() == hlwm.attr.tags[0].name()
+    assert hlwm.attr.clients.focus.winid() == focused_winid
+
+    # start dragging
+    content_geo_before = hlwm.attr.clients[winid].content_geometry()
+    start = content_geo_before.center()
+    mouse.move_to(start.x, start.y)
+    hlwm.call(['drag', winid, 'move'])
+    end = hlwm.attr.monitors[1].geometry().center()
+    mouse.move_to(end.x, end.y)
+    content_geo_after = hlwm.attr.clients[winid].content_geometry()
+    assert end == content_geo_after.center()
+    assert hlwm.attr.clients[winid].tag() == hlwm.attr.tags[1].name()
+    assert hlwm.attr.clients[winid].floating_effectively() is True
+    # check that the focused client does not change:
+    assert hlwm.attr.clients.focus.winid() == focused_winid
+    # check that the correct monitor is focused
+    assert hlwm.attr.monitors.focus.tag() == hlwm.attr.clients.focus.tag()
+    assert hlwm.attr.monitors.focus.index() == (1 if client_focused else 0)
+    if not target_floating:
+        # if the target tag is not floating, the client must have been
+        # set to single-window floating
+        assert hlwm.attr.clients[winid].floating() is True
+    else:
+        # if the target tag is floating, then the client's floating
+        # state is unchanged
+        assert hlwm.attr.clients[winid].floating() == client_floating


### PR DESCRIPTION
This allows that floating clients can be dragged between monitors. When
moving the dragged client to another monitor, the monitors are redrawn
multiple times, and one flicker might occur, but I think one can live
with that.

While at it, I also removed another odd behaviour: if a tag with
floating windows is moved from a big to a small monitor, then the
windows do not 'glue' in the bottom right corner anymore, because the
floating position is now fixed when the drag starts.

Both new features have their test case.

This closes #1415 and #1245.