### PR TITLE
Use xmllint step of a2x for patching manpages

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -249,7 +249,6 @@ jobs:
           cat > CMakeLists.txt <<EOF
           project(Herbstluftwm)
           file(STRINGS VERSION VERSION) # read file 'VERSION'
-          set(CMAKE_INSTALL_SYSCONF_PREFIX /etc/)
           set(DOCDIR /tmp/)
           set(MANDIR /tmp/)
           add_subdirectory(doc)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -78,7 +78,7 @@ function(gen_manpage sourcefile man_nr)
         # our script patching the man page xml instead of running xmllint
         set(custom_asciidoc_cfg "${CMAKE_CURRENT_BINARY_DIR}/a2x-patched-dont-install.conf")
         file(WRITE ${custom_asciidoc_cfg}
-        "XMLLINT = \'${CMAKE_CURRENT_SOURCE_DIR}/patch-manpage-xml.py\'")
+        "XMLLINT = '${CMAKE_CURRENT_SOURCE_DIR}/patch-manpage-xml.py'")
         add_custom_command(
             OUTPUT ${dst}
             COMMAND ${ASCIIDOC_A2X}

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -58,7 +58,6 @@ function(gen_manpage sourcefile man_nr)
     # additional arguments (${ARGN}) are passed as DEPENDS to the asciidoc command
     set(src "${CMAKE_CURRENT_SOURCE_DIR}/${sourcefile}.txt")
     set(dst "${CMAKE_CURRENT_BINARY_DIR}/${sourcefile}.${man_nr}")
-    set(docbookxml "${CMAKE_CURRENT_BINARY_DIR}/${sourcefile}.xml")
     STRING(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)
 
     # as a hack, every man page depends on gen_object_asciidoc, even though only
@@ -75,34 +74,22 @@ function(gen_manpage sourcefile man_nr)
             COMMENT "Using pre-built ${dst_prebuilt}"
             )
     else()
-        # if the documentation is built from scratch, add an intermediate step for
-        # the xml-based docbook format.
-        # add_dependencies("doc_man_${sourcefile}" "doc_man_${sourcefile}_xml")
-        # add_custom_target("doc_man_${sourcefile}_xml" ALL DEPENDS ${docbookxml})
+        # create a config file such that we can tell a2x to call
+        # our script patching the man page xml instead of running xmllint
+        set(custom_asciidoc_cfg "${CMAKE_CURRENT_BINARY_DIR}/a2x-patched-dont-install.conf")
+        file(WRITE ${custom_asciidoc_cfg}
+        "XMLLINT = \'${CMAKE_CURRENT_SOURCE_DIR}/patch-manpage-xml.py\'")
         add_custom_command(
-            OUTPUT ${dst} ${docbookxml}
-            # first create the docbook xml:
-            COMMAND ${ASCIIDOC}
-                    -o ${docbookxml}
-                    -b docbook45
+            OUTPUT ${dst}
+            COMMAND ${ASCIIDOC_A2X}
+                    --verbose
+                    --conf-file=${custom_asciidoc_cfg}
+                    -f manpage
                     -a \"herbstluftwmversion=herbstluftwm ${VERSION}\"
                     -a \"date=${BUILD_DATE}\"
                     -a \"builddir=${CMAKE_CURRENT_BINARY_DIR}\"
+                    --destination-dir="${CMAKE_CURRENT_BINARY_DIR}"
                     ${src}
-            # then, patch the xml:
-            COMMAND ${XSLTPROC}
-                --output ${docbookxml}
-                ${CMAKE_CURRENT_SOURCE_DIR}/literal2emph.xsl
-                ${docbookxml}
-            # and finally, create the man page from it:
-            COMMAND ${XSLTPROC}
-                --output ${dst}
-                --stringparam callout.graphics 0
-                --stringparam navig.graphics 0
-                --stringparam admon.textlabel 1
-                --stringparam admon.graphics 0
-                ${ASCIIDOC_MANPAGE_XSL}
-                ${docbookxml}
             DEPENDS ${src} ${ARGN}
             )
     endif()
@@ -151,9 +138,6 @@ if (WITH_DOCUMENTATION)
     if (NOT COPY_DOCUMENTATION)
         find_program(ASCIIDOC_A2X NAMES a2x DOC "Path to AsciiDoc a2x command")
         find_program(ASCIIDOC NAMES asciidoc DOC "Path to AsciiDoc command")
-        find_program(XSLTPROC NAMES xsltproc DOC "Path to xsltproc")
-        set(ASCIIDOC_MANPAGE_XSL ${CMAKE_INSTALL_SYSCONF_PREFIX}/asciidoc/docbook-xsl/manpage.xsl
-            CACHE PATH "The manpage.xsl provided by asciidoc to generate man pages from docbook xml")
     endif()
 
     gen_manpage(herbstclient 1)

--- a/doc/patch-manpage-xml.py
+++ b/doc/patch-manpage-xml.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+"""
+Act like 'xmllint', but instead patch the given man page
+in docbook xml format using literal2emph.xsl
+"""
+
+import sys
+import subprocess
+import os
+
+# the filename of the docbook xml is probably the first
+# command line argument that is not a flag
+filename = None
+for arg in sys.argv[1:]:
+    if len(arg) > 0 and arg[0] != '-':
+        filename = arg
+        break
+
+xsltproc = 'xsltproc'
+
+doc_directory = os.path.dirname(__file__)
+
+cmd = [
+    xsltproc,
+    '--output',
+    filename,
+    os.path.join(doc_directory, 'literal2emph.xsl'),
+    filename
+]
+
+print("Running: {}".format(str(cmd)), file=sys.stderr)
+subprocess.call(cmd, stdin=subprocess.DEVNULL)


### PR DESCRIPTION
This essentially reverts the cmake changes of f61211ad0f (#1396) and
instead injects the patch-manpage-xml.py via asciidoc's xmllint step.

The positive effect of this is that we do not need to know the path used
in ASCIIDOC_MANPAGE_XSL. Recently on arch linux, it was moved from

    /etc/asciidoc/docbook-xsl/manpage.xsl

to

    /usr/lib/python3.10/site-packages/asciidoc/resources/docbook-xsl/manpage.xsl

which of course depends on a lot of parameters (python version, etc).
Since I couldn't find a way to let asciidoc tell me the path, so having
the path a cmake parameter will presumably cause a lot of packaging
headache.

Instead, I noticed, that we could abuse the 'xmllint' step of the
asciidoc compilation to inject a tool that patches the man page xml.
As a side-effect, this changes make the documentation build again
successfully out of the box on arch linux.