### PR TITLE
Premultiply colors with alpha if compositing

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,9 @@ Current git version
   * Frames can be simultaneously resized in x and y direction with the mouse.
   * Bug fixes:
     - Update floating geometry if a client's size hints change
+    - Correct alpha value handling: if compositor is detected, premultiply
+      rgb values with the alpha value
+  * New dependency: xfixes
 
 Release 0.9.3 on 2021-05-15
 ---------------------------

--- a/ci/Dockerfile.ci-focal
+++ b/ci/Dockerfile.ci-focal
@@ -28,7 +28,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     xterm \
     xvfb \
     xserver-xephyr \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb
 
 # Doc deps would be:
 # (not installed for now because they're huge):

--- a/ci/Dockerfile.ci-focal
+++ b/ci/Dockerfile.ci-focal
@@ -17,6 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfreetype-dev \
     libxinerama-dev \
     libxrandr-dev \
+    libxfixes-dev \
     ninja-build \
     pkg-config \
     python3.8 \

--- a/ci/Dockerfile.ci-trusty
+++ b/ci/Dockerfile.ci-trusty
@@ -21,4 +21,4 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     pkg-config:i386 \
     xterm \
     xvfb \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb

--- a/ci/Dockerfile.ci-trusty
+++ b/ci/Dockerfile.ci-trusty
@@ -16,6 +16,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libxinerama-dev:i386 \
     libxml2-utils \
     libxrandr-dev:i386 \
+    libxfixes-dev:i386 \
     ninja-build \
     pkg-config:i386 \
     xterm \

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -6,6 +6,7 @@ pkg_check_modules(X11 REQUIRED x11)
 pkg_check_modules(XRANDR REQUIRED xrandr)
 pkg_check_modules(XINERAMA xinerama)
 pkg_check_modules(XEXT REQUIRED xext)
+pkg_check_modules(XFIXES REQUIRED xfixes)
 
 # for transparency support
 pkg_check_modules(XRENDER REQUIRED xrender)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ target_include_directories(herbstluftwm SYSTEM PUBLIC
     ${XINERAMA_INCLUDE_DIRS}
     ${XRANDR_INCLUDE_DIRS}
     ${XRENDER_INCLUDE_DIRS}
+    ${XFIXES_INCLUDE_DIRS}
     )
 target_link_libraries(herbstluftwm PUBLIC
     ${FREETYPE_LIBRARIES}
@@ -112,6 +113,7 @@ target_link_libraries(herbstluftwm PUBLIC
     ${XINERAMA_LIBRARIES}
     ${XRANDR_LIBRARIES}
     ${XRENDER_LIBRARIES}
+    ${XFIXES_LIBRARIES}
     )
 
 ## export variables to the code

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -73,7 +73,6 @@ private:
     static XConnection& xconnection();
     void redrawPixmap();
     void updateFrameExtends();
-    unsigned long get_client_color(Color color);
 
     void drawText(Pixmap& pix, GC& gc, const FontData& fontData,
                   const Color& color, Point2D position, const std::string& text,

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -211,6 +211,18 @@ Atom Ewmh::windowManagerSelection()
     return XInternAtom(X_.display(), atomName.c_str(), False);
 }
 
+Atom Ewmh::compositingManagerSelection()
+{
+    // see https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html#idm45381391209264
+    string atomName = "_NET_WM_CM_S" + to_string(X_.screen());
+    return XInternAtom(X_.display(), atomName.c_str(), False);
+}
+
+bool Ewmh::detectCompositingManager()
+{
+    return XGetSelectionOwner(X_.display(), compositingManagerSelection()) != None;
+}
+
 void Ewmh::InitialState::print(FILE *file)
 {
     fprintf(file, "EWMH: %zu desktops:", numberOfDesktops);

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -125,6 +125,8 @@ public:
      */
     bool acquireScreenSelection(bool replaceExistingWm);
     Atom windowManagerSelection();
+    Atom compositingManagerSelection();
+    bool detectCompositingManager();
     Window windowManagerWindow() { return windowManagerWindow_; }
     enum class WM { Name, Protocols, Delete, State, ChangeState, TakeFocus, Last };
 

--- a/src/x11-types.cpp
+++ b/src/x11-types.cpp
@@ -28,7 +28,7 @@ Color::Color()
 
 Color::Color(XColor xcol, unsigned short alpha)
     : red_(xcol.red), green_(xcol.green), blue_(xcol.blue), alpha_(alpha),
-      x11pixelValue_(x11PixelPlusAlpha(xcol.pixel, alpha))
+      x11pixelValue_(xcol.pixel | (0xffu << 24))  // alpha channel set to non-transparent
 {
     // TODO: special interpretation of red, green, blue when
     // xcol.flags lacks one of DoRed, DoGreen, DoBlue?

--- a/src/x11-types.h
+++ b/src/x11-types.h
@@ -24,11 +24,6 @@ public:
 
     // return an XColor as obtained form XQueryColor
     XColor toXColor() const;
-    unsigned long toX11Pixel() const { return x11pixelValue_; }
-
-    static unsigned long x11PixelPlusAlpha(unsigned long x11pixel, unsigned short alpha) {
-        return (x11pixel & 0xffffffu) | (alpha << 24);
-    }
 
     bool operator==(const Color& other) const {
         return red_ == other.red_

--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -65,7 +65,7 @@ XConnection* XConnection::connect(string display_name) {
 
 /**
  * @brief convert the given color via the given color map
- * or via the default colormap is none is given
+ * or via the default colormap if none is given
  * @param maybeColormap is a colormap or 0
  * @param color
  * @return
@@ -219,7 +219,7 @@ void XConnection::tryInitTransparency()
 
 /**
  * @brief tell xconnection whether a compositor (aka compositing manager)
- * is running at the momenet. this affects the color computation.
+ * is running at the moment. this affects the color computation.
  * @param running
  */
 void XConnection::setCompositorRunning(bool running)

--- a/src/xconnection.h
+++ b/src/xconnection.h
@@ -8,6 +8,8 @@
 #include "optional.h"
 #include "rectangle.h"
 
+class Color;
+
 class XConnection {
 private:
     XConnection(Display* disp);
@@ -26,9 +28,12 @@ public:
     int depth() { return depth_; }
     Visual* visual() { return visual_; }
 
+    unsigned long allocColor(Colormap maybeColormap, const Color& color);
+
     bool otherWmListensRoot(); // return whether another WM is running
     void tryInitTransparency();
     bool usesTransparency() { return usesTransparency_; }
+    void setCompositorRunning(bool running);
 
     // utility functions
     static const char* requestCodeToString(int requestCode);
@@ -71,6 +76,7 @@ private:
     Visual* visual_;
     Colormap colormap_;
     bool usesTransparency_ = false;
+    bool compositorRunning_ = false;
     static bool     exitOnError_; //! exit on any xlib error
     static XConnection* s_connection;
 };

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -2,6 +2,7 @@
 
 #include <X11/X.h>
 #include <X11/Xlib.h>
+#include <X11/extensions/Xfixes.h>
 #include <unistd.h> // for pid_t
 
 #include "ipc-server.h"
@@ -30,6 +31,8 @@ private:
     Root* root_;
     bool aboutToQuit_;
     EventHandler handlerTable_[LASTEvent];
+    int xfixesEventBase_ = LASTEvent;
+    int xfixesErrorBase_ = 0;
 
     void collectZombies();
     // event handlers
@@ -49,6 +52,7 @@ private:
     void mapnotify(XMapEvent* event);
     void maprequest(XMapRequestEvent* mapreq);
     void selectionclear(XSelectionClearEvent* event);
+    void selectionnotify(XFixesSelectionNotifyEvent* event);
     void propertynotify(XPropertyEvent* event);
     void unmapnotify(XUnmapEvent* event);
 

--- a/tests/test_x11.py
+++ b/tests/test_x11.py
@@ -1,5 +1,7 @@
 import pytest
 from Xlib import X
+import os
+import conftest
 
 
 @pytest.mark.parametrize("running_clients_num", [0, 1, 2])
@@ -62,3 +64,95 @@ def test_focus_steal_via_xsetinputfocus(hlwm, x11):
     x11.display.sync()
 
     assert hlwm.attr.clients.focus.winid() == new_id
+
+
+class FakeCompositor:
+    """
+    This is not a compositing manager at all, but it claims to by
+    taking the ownership of the corresponding x11 selection.
+    """
+
+    def __init__(self, x11):
+        self.x11 = x11
+        self.window = None
+
+    def is_active(self):
+        return self.window is not None
+
+    @staticmethod
+    def rgb_premultiply_alpha(rgb_tuple, alpha):
+        return tuple([int((v * alpha) / 256) for v in rgb_tuple])
+
+    def set_active(self, active):
+        if self.is_active() != active:
+            if self.window is None:
+                self.window = self.x11.create_client(force_unmanage=True, sync_hlwm=False)[0]
+                # just assume we are on screen number 0:
+                screen_no = self.x11.display.get_default_screen()
+                atom = self.x11.display.intern_atom(f'_NET_WM_CM_S{screen_no}')
+                self.window.set_selection_owner(atom, X.CurrentTime)
+                self.x11.display.sync()
+            else:
+                self.window.destroy()
+                self.window = None
+                self.x11.display.sync()
+
+
+@pytest.mark.parametrize("with_compositor", [True, False])
+def test_compositing_manager_detection_on_startup(hlwm_spawner, x11, xvfb, with_compositor):
+    compositor = FakeCompositor(x11)
+    if with_compositor:
+        compositor.set_active(True)
+    else:
+        # start and shut down again
+        compositor.set_active(True)
+        compositor.set_active(False)
+
+    hlwm_proc = hlwm_spawner()
+    hlwm = conftest.HlwmBridge(os.environ['DISPLAY'], hlwm_proc)
+
+    hlwm.attr.tags.focus.floating = True
+    handle, _ = x11.create_client()
+
+    hlwm.attr.theme.color = '#84cc4019'
+    color_plain = (0x84, 0xcc, 0x40)
+    color_premultiplied = FakeCompositor.rgb_premultiply_alpha(color_plain, 0x19)
+    hlwm.attr.theme.border_width = 10
+    hlwm.attr.theme.outer_width = 0
+
+    img = x11.decoration_screenshot(handle)
+    # just pick any pixel from the decoration, it shouldn't matter which:
+    for x in range(0, 8):
+        for y in range(0, 8):
+            assert img.pixel(0, 0) == img.pixel(x, y)
+
+    if with_compositor:
+        assert img.pixel(0, 0) == color_premultiplied
+    else:
+        assert img.pixel(0, 0) == color_plain
+
+
+def test_compositing_manager_detection_at_runtime(hlwm, x11):
+    hlwm.attr.tags.focus.floating = True
+    handle, _ = x11.create_client()
+
+    hlwm.attr.theme.color = '#84cc4019'
+    color_plain = (0x84, 0xcc, 0x40)
+    color_premultiplied = FakeCompositor.rgb_premultiply_alpha(color_plain, 0x19)
+    hlwm.attr.theme.border_width = 10
+    hlwm.attr.theme.outer_width = 0
+
+    compositor = FakeCompositor(x11)
+
+    for active in [True, False, True, False]:
+        compositor.set_active(active)
+        x11.sync_with_hlwm()
+        img = x11.decoration_screenshot(handle)
+        # just pick any pixel from the decoration, it shouldn't matter which:
+        for x in range(0, 8):
+            for y in range(0, 8):
+                assert img.pixel(0, 0) == img.pixel(x, y)
+        if active:
+            assert img.pixel(0, 0) == color_premultiplied
+        else:
+            assert img.pixel(0, 0) == color_plain


### PR DESCRIPTION
This fixes the color handling of rgba colors. The compositing of X11
expects the true transparency colors to be 'premultiplied' with the
alpha value. That is, a color r=g=b=80 with 50% alpha should have
r=g=b=40 (see also [1,2]).

This bug was still present in colors for both frame decorations and
normal decorations.

Due to this premultiplication, colors would appear darker if the
premultiplication was applied also in absence of a compositing manager
(aka compositor). Thus, this change also includes new code that detects
the presence and absence of a compositing manager at run time, using the
xfixes X11 extension library (which should be available on all systems
that have X11).

The new test cases essentially check that hlwm toggles this
premultiplication depending on whether a compositor claims to exist.

On the implementation side, this color conversion was moved to
XConnection, and so a few Color member functions are not needed anymore.

This fixes #1382.

[1] https://stackoverflow.com/q/39505100/4400896
[2] https://stackoverflow.com/a/39927205/4400896