### PR TITLE
Mergify: use commit_message_template

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,7 +20,11 @@ pull_request_rules:
           queue:
               name: default
               method: squash
-              commit_message: title+body
+              commit_message_template: |
+                {{ title }} (#{{ number }})
+
+                {{ body }}
+
     - name: Implicitly allow t-wissmann to approve own pull requests
       conditions:
           - author=t-wissmann


### PR DESCRIPTION
Since mergify deprecates commit_message, we can hopefully recreate the
desired behaviour with commit_message_template: the commit message
should be the text in the PR body.

It took some attempts until I made it work. For instance, it is *not
enough* to set

    commit_message_template: "{{ body }}"

I have tested the new setting in my personal fork, where the pull
request[1] had the desired message in the pr body. There are multiple
commits in this pr, but none of them show up in the message of the
squashed commit[2], as desired.

[1] https://github.com/t-wissmann/herbstluftwm/pull/10
[2] https://github.com/t-wissmann/herbstluftwm/commit/6cc99630adb61a93e941bfaced90f7311cf3653b