### PR TITLE
eliminate autostart bashism, tag reconfiguration

### DIFF
--- a/share/autostart
+++ b/share/autostart
@@ -63,18 +63,31 @@ hc keybind $Mod-Control-Up      resize up +$resizestep
 hc keybind $Mod-Control-Right   resize right +$resizestep
 
 # tags
-tag_names=( {1..9} )
-tag_keys=( {1..9} 0 )
-
-hc rename default "${tag_names[0]}" || true
-for i in "${!tag_names[@]}" ; do
-    hc add "${tag_names[$i]}"
-    key="${tag_keys[$i]}"
+i=0
+while read name key ; do
+    [ -n "$name" ] || continue
+    if [ $i -eq 0 ] ; then
+        [ -n "$name" ] && hc rename default "$name"
+    else
+        [ -n "$name" ] && hc add "$name"
+    fi
     if [ -n "$key" ] ; then
         hc keybind "$Mod-$key" use_index "$i"
         hc keybind "$Mod-Shift-$key" move_index "$i"
     fi
-done
+    i=$((i+1))
+done <<END
+1              1
+2              2
+3              3
+4              4
+5              5
+6              6
+7              7
+8              8
+9              9
+10             0
+END
 
 # cycle through tags
 hc keybind $Mod-period use_index +1 --skip-visible

--- a/share/autostart
+++ b/share/autostart
@@ -72,8 +72,8 @@ while read name key ; do
         [ -n "$name" ] && hc add "$name"
     fi
     if [ -n "$key" ] ; then
-        hc keybind "$Mod-$key" use_index "$i"
-        hc keybind "$Mod-Shift-$key" move_index "$i"
+        hc keybind "$Mod-$key" use "$name"
+        hc keybind "$Mod-Shift-$key" move "$name"
     fi
     i=$((i+1))
 done <<END


### PR DESCRIPTION
Actually two changes:
- I just don't like depending on bash when plain borne shell suffices. Also I believe the code is more readable without array index acrobatics, but instead using the `read` ideom.
- the tag index is impossible to guess when tags are _renamed_ during autostart reload, because the old names are not removed. (The old names cannot be guessed either). Therefore use `use` and `move` instead of `use_index` and `move_index`.
