### PR TITLE
Allow binding to key release events

### DIFF
--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -150,6 +150,12 @@ KeyCombo KeyCombo::fromString(const string& str) {
     return combo;
 }
 
+bool KeyCombo::match(const KeyCombo& other) const {
+    bool sameMods = modifiers_ & ReleaseMask || modifiers_ == other.modifiers_;
+    bool sameKeySym = keysym == other.keysym;
+    return sameMods && sameKeySym;
+}
+
 bool KeyCombo::operator==(const KeyCombo& other) const {
     bool sameMods = modifiers_ == other.modifiers_;
     bool sameKeySym = keysym == other.keysym;

--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -24,6 +24,7 @@ const vector<KeyCombo::ModifierNameAndMask> ModifierCombo::modifierMasks = {
     { "Shift",      ShiftMask },
     { "Control",    ControlMask },
     { "Ctrl",       ControlMask },
+    { "Release",    ReleaseMask },
 };
 
 ModifiersWithString::ModifiersWithString()

--- a/src/keycombo.h
+++ b/src/keycombo.h
@@ -15,6 +15,8 @@
  * Handles the parsing and creation of string representations of itself.
  */
 
+#define ReleaseMask		((unsigned int)1<<31)
+
 class ModifierCombo {
 public:
     unsigned int modifiers_ = 0;

--- a/src/keycombo.h
+++ b/src/keycombo.h
@@ -69,6 +69,7 @@ public:
     KeyCombo() = default;
 
     std::string str() const;
+    bool match(const KeyCombo& other) const;
     bool operator==(const KeyCombo& other) const;
     static KeySym keySymFromString(const std::string& str);
     static KeyCombo fromString(const std::string& str);

--- a/src/keymanager.cpp
+++ b/src/keymanager.cpp
@@ -133,7 +133,7 @@ void KeyManager::handleKeyPress(XKeyEvent* ev) const {
 
     auto found = std::find_if(binds.begin(), binds.end(),
             [=](const unique_ptr<KeyBinding> &other) {
-                return pressed == other->keyCombo;
+                return other->keyCombo.match(pressed);
             });
     if (found != binds.end()) {
         // execute the bound command

--- a/src/xkeygrabber.cpp
+++ b/src/xkeygrabber.cpp
@@ -70,7 +70,8 @@ void XKeyGrabber::ungrabAll() {
 void XKeyGrabber::changeGrabbedState(const KeyCombo& keyCombo, bool grabbed) {
     // List of ignored modifiers (key combo will be grabbed for each of them):
     const unsigned int ignModifiers[] = { 0, LockMask, numlockMask_, numlockMask_ | LockMask };
-    const unsigned int modifiers = keyCombo.modifiers_ & ~ReleaseMask;
+
+    if (keyCombo.modifiers_ & ReleaseMask) return;
 
     KeyCode keycode = XKeysymToKeycode(g_display, keyCombo.keysym);
     if (!keycode) {
@@ -81,10 +82,10 @@ void XKeyGrabber::changeGrabbedState(const KeyCombo& keyCombo, bool grabbed) {
     // Grab/ungrab key for each modifier that is ignored (capslock, numlock)
     for (auto& ignModifier : ignModifiers) {
         if (grabbed) {
-            XGrabKey(g_display, keycode, ignModifier | modifiers, g_root,
+            XGrabKey(g_display, keycode, ignModifier | keyCombo.modifiers_, g_root,
                     True, GrabModeAsync, GrabModeAsync);
         } else {
-            XUngrabKey(g_display, keycode, ignModifier | modifiers, g_root);
+            XUngrabKey(g_display, keycode, ignModifier | keyCombo.modifiers_, g_root);
         }
     }
 }

--- a/src/xkeygrabber.cpp
+++ b/src/xkeygrabber.cpp
@@ -43,6 +43,9 @@ KeyCombo XKeyGrabber::xEventToKeyCombo(XKeyEvent* ev) const {
     combo.modifiers_ = ev->state;
 
     // Normalize
+    if (ev->type == KeyRelease) {
+	combo.modifiers_ |= ReleaseMask;
+    }
     combo.modifiers_ &= ~(numlockMask_ | LockMask);
 
     return combo;
@@ -67,6 +70,7 @@ void XKeyGrabber::ungrabAll() {
 void XKeyGrabber::changeGrabbedState(const KeyCombo& keyCombo, bool grabbed) {
     // List of ignored modifiers (key combo will be grabbed for each of them):
     const unsigned int ignModifiers[] = { 0, LockMask, numlockMask_, numlockMask_ | LockMask };
+    const unsigned int modifiers = keyCombo.modifiers_ & ~ReleaseMask;
 
     KeyCode keycode = XKeysymToKeycode(g_display, keyCombo.keysym);
     if (!keycode) {
@@ -77,10 +81,10 @@ void XKeyGrabber::changeGrabbedState(const KeyCombo& keyCombo, bool grabbed) {
     // Grab/ungrab key for each modifier that is ignored (capslock, numlock)
     for (auto& ignModifier : ignModifiers) {
         if (grabbed) {
-            XGrabKey(g_display, keycode, ignModifier | keyCombo.modifiers_, g_root,
+            XGrabKey(g_display, keycode, ignModifier | modifiers, g_root,
                     True, GrabModeAsync, GrabModeAsync);
         } else {
-            XUngrabKey(g_display, keycode, ignModifier | keyCombo.modifiers_, g_root);
+            XUngrabKey(g_display, keycode, ignModifier | modifiers, g_root);
         }
     }
 }

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -68,7 +68,8 @@ XMainLoop::XMainLoop(XConnection& X, Root* root)
     handlerTable_[ EnterNotify       ] = EH(&XMainLoop::enternotify);
     handlerTable_[ Expose            ] = EH(&XMainLoop::expose);
     handlerTable_[ FocusIn           ] = EH(&XMainLoop::focusin);
-    handlerTable_[ KeyPress          ] = EH(&XMainLoop::keypress);
+    handlerTable_[ KeyPress          ] = EH(&XMainLoop::key);
+    handlerTable_[ KeyRelease        ] = EH(&XMainLoop::key);
     handlerTable_[ MapNotify         ] = EH(&XMainLoop::mapnotify);
     handlerTable_[ MapRequest        ] = EH(&XMainLoop::maprequest);
     handlerTable_[ MappingNotify     ] = EH(&XMainLoop::mappingnotify);
@@ -532,7 +533,7 @@ void XMainLoop::focusin(XFocusChangeEvent* event) {
     duringFocusIn_ = false;
 }
 
-void XMainLoop::keypress(XKeyEvent* event) {
+void XMainLoop::key(XKeyEvent* event) {
     //HSDebug("name is: KeyPress\n");
     root_->keys()->handleKeyPress(event);
 }

--- a/src/xmainloop.h
+++ b/src/xmainloop.h
@@ -46,7 +46,7 @@ private:
     void enternotify(XCrossingEvent* ce);
     void expose(XEvent* event);
     void focusin(XFocusChangeEvent* event);
-    void keypress(XKeyEvent* event);
+    void key(XKeyEvent* event);
     void mappingnotify(XMappingEvent* event);
     void motionnotify(XMotionEvent* event);
     void mapnotify(XMapEvent* event);


### PR DESCRIPTION
This is supposed to work like xbindkeys.
A virtual modifier "Release" will indicate key release instead of key press.

showing the panel only when the modifier is pressed can be done like this:
```
herbstclient keybind Super_L emit_hook togglehidepanel
herbstclient keybind Mod4+Release+Super_L emit_hook togglehidepanel
```