### PR TITLE
Do not silence error channel of panel.sh main loop

### DIFF
--- a/share/panel.sh
+++ b/share/panel.sh
@@ -191,6 +191,6 @@ hc pad $monitor $panel_height
     # After the data is gathered and processed, the output of the previous block
     # gets piped to dzen2.
 
-} 2> /dev/null | dzen2 -w $panel_width -x $x -y $y -fn "$font" -h $panel_height \
+} | dzen2 -w $panel_width -x $x -y $y -fn "$font" -h $panel_height \
     -e "button3=;button4=exec:$hc_quoted use_index -1;button5=exec:$hc_quoted use_index +1" \
     -ta l -bg "$bgcolor" -fg '#efefef'


### PR DESCRIPTION
I can't remember why I activated the silencing of stderr in
dd6436ad451ba351 but now it is causing trouble because it hides the
error message of the textwidth utility.