### PR TITLE
Increase font in test

### DIFF
--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -6,7 +6,7 @@ import pytest
 
 font_pool = [
     '-*-fixed-medium-r-*-*-13-*-*-*-*-*-*-*',
-    'Dejavu Sans:pixelsize=12:bold'
+    'Dejavu Sans:pixelsize=14:bold'
 ]
 
 


### PR DESCRIPTION
This makes the test a bit more robust. For small fonts sizes, font
hinting affects more pixels and so counting pixels with the 'main' color
leads to more imprecise results.