### PR TITLE
Fix: Remove client from tab bars before unmanage

### DIFF
--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -289,7 +289,7 @@ void Decoration::removeFromTabBar(Client* otherClientTab)
     tabs_.erase(std::remove_if(tabs_.begin(), tabs_.end(),
                                [=](Client* c) {
         return c == otherClientTab;
-    }));
+    }), tabs_.end());
 }
 
 void Decoration::resize_outline(Rectangle outline, const DecorationScheme& scheme, vector<Client*> tabs)

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -279,6 +279,19 @@ ResizeAction Decoration::resizeFromRoughCursorPosition(Point2D cursor)
     return ra;
 }
 
+/**
+ * @brief ensure that the other mentioned client is removed
+ * from the tab bar of 'this' client.
+ * @param otherClientTab
+ */
+void Decoration::removeFromTabBar(Client* otherClientTab)
+{
+    tabs_.erase(std::remove_if(tabs_.begin(), tabs_.end(),
+                               [=](Client* c) {
+        return c == otherClientTab;
+    }));
+}
+
 void Decoration::resize_outline(Rectangle outline, const DecorationScheme& scheme, vector<Client*> tabs)
 {
     bool decorated = client_->decorated_();

--- a/src/decoration.h
+++ b/src/decoration.h
@@ -67,6 +67,7 @@ public:
     std::experimental::optional<ClickArea> positionHasButton(Point2D p);
     ResizeAction positionTriggersResize(Point2D p);
     ResizeAction resizeFromRoughCursorPosition(Point2D cursor);
+    void removeFromTabBar(Client* otherClientTab);
 
 private:
     static Visual* check_32bit_client(Client* c);

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -7,6 +7,7 @@
 #include "client.h"
 #include "clientmanager.h"
 #include "completion.h"
+#include "decoration.h"
 #include "ewmh.h"
 #include "floating.h"
 #include "frametree.h"
@@ -180,6 +181,12 @@ void HSTag::setVisible(bool newVisible)
 }
 
 bool HSTag::removeClient(Client* client) {
+    // remove 'client' from the tab bars of all other clients
+    foreachClient([client](Client* remainingClient) {
+        if (remainingClient != client) {
+            remainingClient->dec->removeFromTabBar(client);
+        }
+    });
     if (frame->root_->removeClient(client)) {
         return true;
     }


### PR DESCRIPTION
Before unmanaging and deleting a client, remove it from all tab bars of
the remaining clients. This fixes a crash triggered by the new test case
included in this change.