### PR TITLE
CI: update pkg list before doc build

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: install asciidoc
-        run: sudo apt-get install --no-install-recommends asciidoc xsltproc docbook-xsl
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends asciidoc xsltproc docbook-xsl
       - name: restrict cmake to doc
         run: |
           cat > CMakeLists.txt <<EOF


### PR DESCRIPTION
We need to run 'update' before installing the dependencies for the
documentation build. This should fix the current CI issue.