### PR TITLE
Add content_geometry attribute to monitors and frames

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,8 @@ Current git version
     following new values: 'off', 'hide_all', and 'hide_gaps'. Setting it to
     'hide_gaps' will only hide frame gaps when applicable, 'hide_all' and 'off'
     mirror the old behaviour with regards to 'true' and 'false'.
+  * New frame attribute 'content_geometry'
+  * New monitor attribute 'content_geometry'
 
 Release 0.9.4 on 2022-03-16
 ---------------------------

--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -98,7 +98,7 @@ void FrameDecoration::render(const FrameDecorationData& data, bool isFocused) {
         && !data.hasParent) {
         bw = 0;
     }
-    Rectangle rect = data.geometry;
+    Rectangle rect = data.contentGeometry;
     XSetWindowBorderWidth(xcon.display(), window, bw);
     XMoveResizeWindow(xcon.display(), window,
                       rect.x - bw,
@@ -124,8 +124,8 @@ void FrameDecoration::render(const FrameDecorationData& data, bool isFocused) {
         }
         for (Client* client : frame_.clients) {
             Rectangle geom = client->dec->last_outer();
-            geom.x -= data.geometry.x;
-            geom.y -= data.geometry.y;
+            geom.x -= data.contentGeometry.x;
+            geom.y -= data.contentGeometry.y;
             holes.push_back(geom);
         }
         window_cut_rect_holes(xcon, window, rect.width, rect.height, holes);

--- a/src/framedecoration.h
+++ b/src/framedecoration.h
@@ -18,7 +18,7 @@ public:
     bool visible = false;
     bool hasClients = false; // whether this frame holds clients at the moment
     bool hasParent = false;
-    Rectangle geometry;
+    Rectangle contentGeometry; //! geometry of the frame's content
 };
 
 class FrameDecoration {

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -325,7 +325,7 @@ shared_ptr<FrameLeaf> FrameTree::findEmptyFrameNearFocusGeometrically(shared_ptr
             [tileres] (shared_ptr<FrameLeaf> frame) -> Rectangle {
         for (auto& framedata : tileres.frames) {
             if (framedata.first == frame->decoration) {
-                return framedata.second.geometry;
+                return framedata.second.contentGeometry;
             }
         }
         // if not found, return an invalid rectangle;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -36,7 +36,16 @@ Frame::Frame(HSTag* tag, Settings* settings, weak_ptr<FrameSplit> parent)
     , tag_(tag)
     , settings_(settings)
     , parent_(parent)
-{}
+    , contentGeometry_(this, "content_geometry", {})
+{
+    contentGeometry_.setDoc("the geometry of the frame\'s contents, i.e. "
+                            "of the area filled by child frames or client windows.");
+    frameIndexAttr_.setDoc("A string containing only \'0\' and \'1\' that describes the "
+                           "position of the frame in the tree. The empty string "
+                           "denotes the root frame. Appending \'0\' (respectively "
+                           "\'1\') to a frame index yields the frame index of the first "
+                           "(respectively second) subtree.");
+}
 Frame::~Frame() = default;
 
 FrameLeaf::FrameLeaf(HSTag* tag, Settings* settings, weak_ptr<FrameSplit> parent)
@@ -337,11 +346,12 @@ TilingResult FrameLeaf::computeLayout(Rectangle rect) {
 
     rect.width = std::max(WINDOW_MIN_WIDTH, rect.width);
     rect.height = std::max(WINDOW_MIN_HEIGHT, rect.height);
+    contentGeometry_ = rect;
 
     // move windows
     TilingResult res;
     FrameDecorationData frame_data;
-    frame_data.geometry = rect;
+    frame_data.contentGeometry = rect;
     frame_data.visible = true;
     frame_data.hasClients = !clients.empty();
     frame_data.hasParent = (bool)parent_.lock();
@@ -411,6 +421,7 @@ TilingResult FrameLeaf::computeLayout(Rectangle rect) {
 
 TilingResult FrameSplit::computeLayout(Rectangle rect) {
     last_rect = rect;
+    contentGeometry_ = rect;
     auto first = rect;
     auto second = rect;
     if (align_ == SplitAlign::vertical) {

--- a/src/layout.h
+++ b/src/layout.h
@@ -91,6 +91,11 @@ protected:
     std::weak_ptr<FrameSplit> parent_;
     Rectangle  last_rect; // last rectangle when being drawn
                           // this is only used for 'split explode'
+    /** each time, last_rect is updated, contentGeometry_ must be
+        updated, too! For FrameLeaf, the geometry is slightly different
+        because last_rect is the "outer" geometry.
+       */
+    Attribute_<Rectangle> contentGeometry_;
 };
 
 class FrameLeaf : public Frame, public FrameDataLeaf {

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -51,6 +51,7 @@ Monitor::Monitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, 
     , lock_frames(false)
     , mouse { 0, 0 }
     , rect(this, "geometry", rect_, &Monitor::atLeastMinWindowSize)
+    , contentGeometry(this, "content_geometry", &Monitor::getFloatingArea)
     , settings(settings_)
     , monman(monman_)
 {
@@ -66,6 +67,9 @@ Monitor::Monitor(Settings* settings_, MonitorManager* monman_, Rectangle rect_, 
     rect.changedByUser().connect(this, &Monitor::applyLayout);
 
     rect.setDoc("the outer geometry of the monitor");
+    contentGeometry.setDoc("the inner geometry of the monitor, i.e. the geometry with "
+                           "the pads deducted from all sides. This is the area floating "
+                           "and tiled client windows are placed.");
 
     stacking_window = XCreateSimpleWindow(g_display, g_root,
                                              42, 42, 42, 42, 1, 0, 0);

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -41,6 +41,7 @@ public:
         int y;
     } mouse;
     Attribute_<Rectangle>   rect;   // area for this monitor
+    DynAttribute_<Rectangle> contentGeometry;
     Window      stacking_window;   // window used for making stacking easy
     Signal monitorMoved;
     Rectangle clampRelativeGeometry(Rectangle relativeGeo) const;

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1916,3 +1916,29 @@ def test_frame_leaf_algorithm_change(hlwm, x11):
     assert geom1_before.height < geom1_now.height
     assert geom1_now.width == geom2_now.width
     assert geom1_now.height == geom2_now.height
+
+
+def test_frame_content_geometry_attribute(hlwm):
+    hlwm.attr.settings.smart_frame_surroundings = 'off'
+    hlwm.attr.settings.frame_gap = 0
+    hlwm.attr.settings.frame_border_width = 1
+    bw = 1
+    winid, _ = hlwm.create_client()
+    mon_rect = hlwm.attr.monitors.focus.content_geometry()
+    mon_rect_minus_frame_border = mon_rect.adjusted(dx=bw, dy=bw, dw=bw * -2, dh=bw * -2)
+
+    for split_count in range(0, 4):
+        # the content of the root frame should match the monitor.
+        # the frame border is only applied if the root frame is a
+        # frame leaf (with decoration), i.e. if split_count == 0
+        assert hlwm.attr.tags.focus.tiling.root.content_geometry() \
+            == (mon_rect_minus_frame_border if split_count == 0 else mon_rect)
+
+        # the content of the leaf frame should match the decoration of the client:
+        assert hlwm.attr.clients[winid].decoration_geometry() \
+            == hlwm.attr.tags.focus.tiling.focused_frame.content_geometry()
+
+        # split again:
+        hlwm.call('split explode')
+
+

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1940,5 +1940,3 @@ def test_frame_content_geometry_attribute(hlwm):
 
         # split again:
         hlwm.call('split explode')
-
-

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -618,24 +618,35 @@ def test_monitor_rect_command(hlwm):
     hlwm.call('add othertag')
     # two monitors with unique coordinates and pads
     hlwm.call('set_monitors 300x400+1+2 500x600+300+4')
+    assert hlwm.attr.monitors[0].geometry() \
+        == hlwm.attr.monitors[0].content_geometry()
+    assert hlwm.attr.monitors[1].geometry() \
+        == hlwm.attr.monitors[1].content_geometry()
+
     hlwm.attr.monitors[0].pad_left = 10
     hlwm.attr.monitors[0].pad_right = 20
     hlwm.attr.monitors[0].pad_up = 30
     hlwm.attr.monitors[0].pad_down = 40
+    mon_0_content_geo = [11, 32, 270, 330]
+    assert hlwm.attr.monitors[0].content_geometry() \
+        == Rectangle(*mon_0_content_geo)
 
     hlwm.attr.monitors[1].pad_left = 11
     hlwm.attr.monitors[1].pad_right = 21
     hlwm.attr.monitors[1].pad_up = 31
     hlwm.attr.monitors[1].pad_down = 41
+    mon_1_content_geo = [311, 35, 468, 528]
+    assert hlwm.attr.monitors[1].content_geometry() \
+        == Rectangle(*mon_1_content_geo)
 
     def monitor_rect(args):
-        return hlwm.call(['monitor_rect'] + args).stdout.strip()
+        return [int(v) for v in hlwm.call(['monitor_rect'] + args).stdout.strip().split(' ')]
 
-    assert monitor_rect([]) == '1 2 300 400'
+    assert monitor_rect([]) == [1, 2, 300, 400]
     assert monitor_rect(['0']) == monitor_rect([])
-    assert monitor_rect(['-p', '']) == '11 32 270 330'
-    assert monitor_rect(['1']) == '300 4 500 600'
-    assert monitor_rect(['-p', '1']) == '311 35 468 528'
+    assert monitor_rect(['-p', '']) == mon_0_content_geo
+    assert monitor_rect(['1']) == [300, 4, 500, 600]
+    assert monitor_rect(['-p', '1']) == mon_1_content_geo
     assert monitor_rect(['-p', '1']) == monitor_rect(['1', '-p'])
 
 


### PR DESCRIPTION
This adds new read-only attributes for accessing the content geometry of
frames (splits and leaves) and monitors.

There is not much to test here, so I've used both attributes in other
test cases.

While at it, I've also added documentation for the `index` attribute.

This closes #1462.