### PR TITLE
Cancel outdated workflow runs

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -1,5 +1,11 @@
 name: HLWM CI
 
+concurrency:
+  # Using concurrency to cancel any in-progress job or run
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -1,7 +1,7 @@
 name: HLWM CI
 
 concurrency:
-  # Using concurrency to cancel any in-progress job or run
+  # Using concurrency to cancel any in-progress job or run.
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
When multiple commits are pushed to the same PR, every still running
workflow of previous commits is now cancelled.