### PR TITLE
Move XKeyGrabber out of KeyManager

### DIFF
--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -28,6 +28,10 @@ const vector<KeyCombo::ModifierNameAndMask> ModifierCombo::modifierMasks = {
     { "Ctrl",       ControlMask },
 };
 
+const unsigned int ModifierCombo::allModifierMasks =
+        Mod1Mask | Mod2Mask | Mod3Mask | Mod4Mask
+        | Mod5Mask | ShiftMask | ControlMask;
+
 ModifiersWithString::ModifiersWithString()
     : suffix_("")
 {

--- a/src/keycombo.h
+++ b/src/keycombo.h
@@ -38,6 +38,9 @@ public:
      * we need well-defined reverse lookups for stringification.
      */
     static const std::vector<ModifierNameAndMask> modifierMasks;
+    /*! bit-wise or of all supported modifier masks
+     */
+    static const unsigned int allModifierMasks;
     static unsigned int modifierMaskFromTokens(const std::vector<std::string>& tokens);
     static std::vector<std::string> tokensFromString(std::string keySpec);
     static std::vector<std::string> getNamesForModifierMask(unsigned int mask);

--- a/src/keymanager.h
+++ b/src/keymanager.h
@@ -9,7 +9,6 @@
 #include "keycombo.h"
 #include "object.h"
 #include "regexstr.h"
-#include "xkeygrabber.h"
 
 class Client;
 class Completion;
@@ -67,6 +66,13 @@ public:
     KeyManager() = default;
     ~KeyManager();
 
+    //! emitted whenever a keycombo changes from inactive to active
+    Signal_<KeyCombo> keyComboActive;
+    //! emitted whenever a keycombo changes from active to inactive
+    Signal_<KeyCombo> keyComboInactive;
+    //! emitted when all keycombos become inactive
+    Signal keyComboAllInactive;
+
     void keybindCommand(CallOrComplete invoc);
     int addKeybind(KeyBinding newBinding, Output output);
     int listKeybindsCommand(Output output) const;
@@ -74,26 +80,17 @@ public:
 
     void removeKeybindCompletion(Completion &complete);
 
-    void handleKeyPress(XKeyEvent* ev);
+    void handleKeyComboEvent(KeyCombo combo);
 
-    void regrabAll();
     void ensureKeyMask(const Client* client = nullptr);
     void setActiveKeyMask(const KeyMask& keyMask, const KeyMask& keysInactive);
     void clearActiveKeyMask();
-
-    // TODO: This is not supposed to exist. It only does as a workaround,
-    // because mouse.cpp still wants to know the numlock mask.
-    unsigned int getNumlockMask() const {
-        return xKeyGrabber_.getNumlockMask();
-    }
 
 private:
     bool removeKeyBinding(const KeyCombo& comboToRemove, bool* wasActive = nullptr);
 
     //! Currently defined keybindings
     std::vector<std::unique_ptr<KeyBinding>> binds;
-
-    XKeyGrabber xKeyGrabber_;
 
     // The last applies KeyMask & KeysInactive(for comparison on change)
     KeyMask currentKeyMask_;

--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -23,6 +23,7 @@
 #include "root.h"
 #include "tag.h"
 #include "x11-utils.h"
+#include "xkeygrabber.h"
 
 using std::make_shared;
 using std::vector;
@@ -317,15 +318,8 @@ MouseManager::MouseFunction MouseManager::string2mousefunction(const string& nam
 }
 
 std::experimental::optional<MouseManager::MouseBinding> MouseManager::mouse_binding_find(unsigned int modifiers, unsigned int button) {
-    unsigned int numlockMask = Root::get()->keys()->getNumlockMask();
     MouseCombo mb = {};
-    mb.modifiers_ = modifiers
-        & ~(numlockMask|LockMask) // remove numlock and capslock mask
-        & ~( Button1Mask // remove all mouse button masks
-           | Button2Mask
-           | Button3Mask
-           | Button4Mask
-           | Button5Mask );
+    mb.modifiers_ = modifiers & ModifierCombo::allModifierMasks;
     mb.button_ = button;
 
     auto found = std::find_if(binds.begin(), binds.end(),
@@ -341,7 +335,7 @@ std::experimental::optional<MouseManager::MouseBinding> MouseManager::mouse_bind
 
 void MouseManager::grab_client_buttons(Client* client, bool focused) {
     XUngrabButton(g_display, AnyButton, AnyModifier, client->x11Window());
-    unsigned int numlockMask = Root::get()->keys()->getNumlockMask();
+    unsigned int numlockMask = Root::get()->xKeyGrabber_->getNumlockMask();
     vector<unsigned int> modifiers = { 0, LockMask, numlockMask, numlockMask | LockMask };
     if (focused) {
         for (auto& bind : binds) {

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -23,6 +23,7 @@
 #include "typesdoc.h"
 #include "utils.h"
 #include "watchers.h"
+#include "xkeygrabber.h"
 
 using std::shared_ptr;
 
@@ -46,6 +47,7 @@ Root::Root(Globals g, XConnection& xconnection, Ewmh& ewmh, IpcServer& ipcServer
     , meta_commands(make_unique<MetaCommands>(*this))
     , global_commands(make_unique<GlobalCommands>(*this))
     , X(xconnection)
+    , xKeyGrabber_(make_unique<XKeyGrabber>(xconnection))
     , ipcServer_(ipcServer)
     , ewmh_(ewmh)
 {
@@ -86,6 +88,11 @@ Root::Root(Globals g, XConnection& xconnection, Ewmh& ewmh, IpcServer& ipcServer
     });
     theme->theme_changed_.connect(monitors(), &MonitorManager::relayoutAll);
     panels->panels_changed_.connect(monitors(), &MonitorManager::autoUpdatePads);
+
+    // X11 specific slots:
+    keys->keyComboActive.connect(xKeyGrabber_.get(), &XKeyGrabber::grabKeyCombo);
+    keys->keyComboInactive.connect(xKeyGrabber_.get(), &XKeyGrabber::ungrabKeyCombo);
+    keys->keyComboAllInactive.connect(xKeyGrabber_.get(), &XKeyGrabber::ungrabAll);
 }
 
 Root::~Root() {

--- a/src/root.h
+++ b/src/root.h
@@ -28,6 +28,7 @@ class Tmp; // IWYU pragma: keep
 class TypesDoc; // IWYU pragma: keep
 class Watchers;
 class XConnection;
+class XKeyGrabber;
 
 class Globals {
 public:
@@ -73,6 +74,7 @@ public:
     std::unique_ptr<MetaCommands> meta_commands; // Using "pimpl" to avoid include
     std::unique_ptr<GlobalCommands> global_commands; // Using "pimpl" to avoid include
     XConnection& X;
+    std::unique_ptr<XKeyGrabber> xKeyGrabber_;
     IpcServer& ipcServer_;
     //! Temporary member. In the long run, ewmh should get its information
     // automatically from the signals emitted by ClientManager, etc

--- a/src/xkeygrabber.cpp
+++ b/src/xkeygrabber.cpp
@@ -5,12 +5,15 @@
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
 
-#include "globals.h"
+#include "root.h"
+#include "xconnection.h"
 
 using std::vector;
 using std::string;
 
-XKeyGrabber::XKeyGrabber() {
+XKeyGrabber::XKeyGrabber(XConnection& X)
+    : X_(X)
+{
     updateNumlockMask();
 }
 
@@ -19,11 +22,11 @@ void XKeyGrabber::updateNumlockMask() {
     XModifierKeymap *modmap;
 
     numlockMask_ = 0;
-    modmap = XGetModifierMapping(g_display);
+    modmap = XGetModifierMapping(X_.display());
     for (size_t i = 0; i < 8; i++) {
         for (int j = 0; j < modmap->max_keypermod; j++) {
             if (modmap->modifiermap[i * modmap->max_keypermod + j]
-                    == XKeysymToKeycode(g_display, XK_Num_Lock)) {
+                    == XKeysymToKeycode(X_.display(), XK_Num_Lock)) {
                 numlockMask_ = (1 << i);
             }
         }
@@ -42,7 +45,7 @@ void XKeyGrabber::updateNumlockMask() {
  */
 KeyCombo XKeyGrabber::xEventToKeyCombo(XKeyEvent* ev) {
     KeyCombo combo = {};
-    combo.keysym = XkbKeycodeToKeysym(g_display, ev->keycode, 0, 0);
+    combo.keysym = XkbKeycodeToKeysym(X_.display(), ev->keycode, 0, 0);
     combo.modifiers_ =  ev->state & ~(numlockMask_ | LockMask);
     if (ev->type == KeyRelease) {
         // on key release: extract the modifier state from when
@@ -67,7 +70,7 @@ KeyCombo XKeyGrabber::xEventToKeyCombo(XKeyEvent* ev) {
 }
 
 //! Grabs the given key combo
-void XKeyGrabber::grabKeyCombo(const KeyCombo& keyCombo) {
+void XKeyGrabber::grabKeyCombo(KeyCombo keyCombo) {
     auto x11KeyCombo = keyCombo;
     x11KeyCombo.onRelease_ = false;
     int oldCount = keyComboCount(x11KeyCombo);
@@ -78,7 +81,7 @@ void XKeyGrabber::grabKeyCombo(const KeyCombo& keyCombo) {
 }
 
 //! Ungrabs the given key combo
-void XKeyGrabber::ungrabKeyCombo(const KeyCombo& keyCombo) {
+void XKeyGrabber::ungrabKeyCombo(KeyCombo keyCombo) {
     auto x11KeyCombo = keyCombo;
     x11KeyCombo.onRelease_ = false;
     int oldCount = keyComboCount(x11KeyCombo);
@@ -90,8 +93,24 @@ void XKeyGrabber::ungrabKeyCombo(const KeyCombo& keyCombo) {
 
 //! Removes all grabbed keys (without knowing them)
 void XKeyGrabber::ungrabAll() {
-    XUngrabKey(g_display, AnyKey, AnyModifier, g_root);
+    XUngrabKey(X_.display(), AnyKey, AnyModifier, X_.root());
     keycombo2bindCount_.clear();
+}
+
+void XKeyGrabber::regrabAll()
+{
+    updateNumlockMask();
+
+     // Remove all current grabs:
+    XUngrabKey(X_.display(), AnyKey, AnyModifier, X_.root());
+
+    // grab precisely those again, that have been grabbed before.
+    // here, it is important that we grab each KeyCombo only once.
+    // this works, because even if both press&release are grabbed, the
+    // map has only one combined entry for both.
+    for (auto& binding : keycombo2bindCount_) {
+        changeGrabbedState(binding.first, true);
+    }
 }
 
 //! Grabs/ungrabs a given key combo
@@ -99,7 +118,7 @@ void XKeyGrabber::changeGrabbedState(const KeyCombo& keyCombo, bool grabbed) {
     // List of ignored modifiers (key combo will be grabbed for each of them):
     const unsigned int ignModifiers[] = { 0, LockMask, numlockMask_, numlockMask_ | LockMask };
 
-    KeyCode keycode = XKeysymToKeycode(g_display, keyCombo.keysym);
+    KeyCode keycode = XKeysymToKeycode(X_.display(), keyCombo.keysym);
     if (!keycode) {
         // Ignore unknown keysym
         return;
@@ -108,10 +127,10 @@ void XKeyGrabber::changeGrabbedState(const KeyCombo& keyCombo, bool grabbed) {
     // Grab/ungrab key for each modifier that is ignored (capslock, numlock)
     for (auto& ignModifier : ignModifiers) {
         if (grabbed) {
-            XGrabKey(g_display, keycode, ignModifier | keyCombo.modifiers_, g_root,
+            XGrabKey(X_.display(), keycode, ignModifier | keyCombo.modifiers_, X_.root(),
                     True, GrabModeAsync, GrabModeAsync);
         } else {
-            XUngrabKey(g_display, keycode, ignModifier | keyCombo.modifiers_, g_root);
+            XUngrabKey(X_.display(), keycode, ignModifier | keyCombo.modifiers_, X_.root());
         }
     }
 }
@@ -138,11 +157,12 @@ void XKeyGrabber::setKeyComboCount(const KeyCombo& x11KeyCombo, int newCount)
 vector<string> XKeyGrabber::getPossibleKeySyms() {
     vector<string> ret;
     int min, max;
-    XDisplayKeycodes(g_display, &min, &max);
+    XConnection& X = Root::get()->X;
+    XDisplayKeycodes(X.display(), &min, &max);
     int kc_count = max - min + 1;
     int ks_per_kc; // count of keysysms per keycode
     KeySym* keysyms;
-    keysyms = XGetKeyboardMapping(g_display, min, kc_count, &ks_per_kc);
+    keysyms = XGetKeyboardMapping(X.display(), min, kc_count, &ks_per_kc);
     // only symbols at a position i*ks_per_kc are symbols that are recieved in
     // a keyevent, it should be the symbol for the keycode if no modifier is
     // pressed

--- a/src/xkeygrabber.h
+++ b/src/xkeygrabber.h
@@ -7,6 +7,8 @@
 
 #include "keycombo.h"
 
+class XConnection;
+
 /*!
  * Handles the actual grabbing/releasing of given key combinations, and
  * maintains knowledge of the current keyboard layout
@@ -16,15 +18,17 @@
  */
 class XKeyGrabber {
 public:
-    XKeyGrabber();
+    XKeyGrabber(XConnection& X);
 
     void updateNumlockMask();
 
     KeyCombo xEventToKeyCombo(XKeyEvent *ev);
 
-    void grabKeyCombo(const KeyCombo& keyCombo);
-    void ungrabKeyCombo(const KeyCombo& keyCombo);
+    void grabKeyCombo(KeyCombo keyCombo);
+    void ungrabKeyCombo(KeyCombo keyCombo);
     void ungrabAll();
+
+    void regrabAll();
 
     // TODO: This is not supposed to exist. It only does as a workaround,
     // because mouse.cpp still wants to know the numlock mask.
@@ -39,12 +43,14 @@ private:
     unsigned int numlockMask_ = 0;
     // for each (X11-)keycombo, we count in how many keybinds it is used.
     // it might be used in multiple because there are binds for both key press
-    // and key release:
+    // and key release. The map only contains KeyCombo objects with
+    // onRelease_ = false.
     std::map<KeyCombo,int> keycombo2bindCount_;
     // for each key code, whenever we see a key down event, remember
     // the modifier mask, such that we can re-use it for the key up event.
     std::map<unsigned int, unsigned int> keycode2modifierMask_;
     int keyComboCount(const KeyCombo& x11KeyCombo);
     void setKeyComboCount(const KeyCombo& x11KeyCombo, int newCount);
+    XConnection& X_;
 };
 

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -32,6 +32,7 @@
 #include "utils.h"
 #include "watchers.h"
 #include "xconnection.h"
+#include "xkeygrabber.h"
 
 using std::make_pair;
 using std::function;
@@ -535,14 +536,14 @@ void XMainLoop::focusin(XFocusChangeEvent* event) {
 
 void XMainLoop::keypressOrRelease(XKeyEvent* event) {
     // HSDebug("name is: KeyPress or KeyRelease\n");
-    root_->keys()->handleKeyPress(event);
+    root_->keys()->handleKeyComboEvent(root_->xKeyGrabber_->xEventToKeyCombo(event));
 }
 
 void XMainLoop::mappingnotify(XMappingEvent* ev) {
     // regrab when keyboard map changes
     XRefreshKeyboardMapping(ev);
     if(ev->request == MappingKeyboard) {
-        root_->keys()->regrabAll();
+        root_->xKeyGrabber_->regrabAll();
         //TODO: mouse_regrab_all();
     }
 }


### PR DESCRIPTION
This makes KeyManager independent of X and avoids some usages of the
global variable `g_display`.

In the MouseManager, instead of removing the masks that we ignore, we
now just filter for the masks we are interested in.