### PR TITLE
New setting 'show_frame_decorations'

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -12,6 +12,9 @@ now incompatible with the 'toggle' command. Use 'cycle_values' instead:
 
     hc cycle_value settings.smart_frame_surroundings off hide_gaps hide_all
 
+Instead of 'always_show_frame', the new 'show_frame_decorations' setting should
+be used.
+
 0.9.2 to 0.9.3
 --------------
 The command 'cycle_value' now expects an attribute path instead of a settings

--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ Current git version
     following new values: 'off', 'hide_all', and 'hide_gaps'. Setting it to
     'hide_gaps' will only hide frame gaps when applicable, 'hide_all' and 'off'
     mirror the old behaviour with regards to 'true' and 'false'.
+  * New setting 'show_frame_decorations' that control, when frame decorations
+    are shown. This should be moved instead of the old 'always_show_frame'
   * New frame attribute 'content_geometry'
   * New monitor attribute 'content_geometry'
 

--- a/NEWS
+++ b/NEWS
@@ -12,8 +12,8 @@ Current git version
     following new values: 'off', 'hide_all', and 'hide_gaps'. Setting it to
     'hide_gaps' will only hide frame gaps when applicable, 'hide_all' and 'off'
     mirror the old behaviour with regards to 'true' and 'false'.
-  * New setting 'show_frame_decorations' that control, when frame decorations
-    are shown. This should be moved instead of the old 'always_show_frame'
+  * New setting 'show_frame_decorations' that controls when frame decorations
+    are shown. This should be used instead of the old 'always_show_frame'
   * New frame attribute 'content_geometry'
   * New monitor attribute 'content_geometry'
 

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -243,7 +243,7 @@ keybind 'KEY' 'COMMAND' ['ARGS ...']::
     first press 'Mod1-Shift-p' and then release 'p'.  Examples:
 
         * keybind Mod4+Ctrl+q quit
-        * keybind Mod1-i toggle always_show_frame
+        * keybind Mod4-Shift-d attr clients.focus.decorated toggle
         * keybind Mod1-Shift-space cycle_layout -1
         * +keybind Release-Mod4-Shift-p spawn scrot+ takes a screenshot when the
           +p+ is released while Mod4 and Shift are still pressed.

--- a/share/autostart
+++ b/share/autostart
@@ -118,7 +118,7 @@ hc set frame_border_normal_color '#101010cc'
 hc set frame_bg_normal_color '#565656aa'
 hc set frame_bg_active_color '#345F0Caa'
 hc set frame_border_width 1
-hc set always_show_frame on
+hc set show_frame_decorations 'focus_if_ambiguous'
 hc set frame_bg_transparent on
 hc set frame_transparent_width 5
 hc set frame_gap 4

--- a/share/autostart
+++ b/share/autostart
@@ -118,7 +118,7 @@ hc set frame_border_normal_color '#101010cc'
 hc set frame_bg_normal_color '#565656aa'
 hc set frame_bg_active_color '#345F0Caa'
 hc set frame_border_width 1
-hc set show_frame_decorations 'focused_if_ambiguous'
+hc set show_frame_decorations 'focused_if_multiple'
 hc set frame_bg_transparent on
 hc set frame_transparent_width 5
 hc set frame_gap 4

--- a/share/autostart
+++ b/share/autostart
@@ -118,7 +118,7 @@ hc set frame_border_normal_color '#101010cc'
 hc set frame_bg_normal_color '#565656aa'
 hc set frame_bg_active_color '#345F0Caa'
 hc set frame_border_width 1
-hc set show_frame_decorations 'focus_if_ambiguous'
+hc set show_frame_decorations 'focused_if_ambiguous'
 hc set frame_bg_transparent on
 hc set frame_transparent_width 5
 hc set frame_gap 4

--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -145,9 +145,21 @@ void FrameDecoration::render(const FrameDecorationData& data, bool isFocused) {
 
 void FrameDecoration::updateVisibility(const FrameDecorationData& data, bool isFocused)
 {
-    bool show = settings->always_show_frame()
-              || data.hasClients
-              || isFocused;
+    bool show = false;
+    ShowFrameDecorations when = settings->show_frame_decorations();
+    if (when >= ShowFrameDecorations::nonempty) {
+        show = show || data.hasClients;
+    }
+    if (when >= ShowFrameDecorations::focused) {
+        show = show || isFocused;
+    }
+    if (when >= ShowFrameDecorations::focused_if_ambiguous) {
+        bool isRootFrame = frame_.parent_.expired();
+        show = show || (isFocused && !isRootFrame);;
+    }
+    if (when >= ShowFrameDecorations::all) {
+        show = true;
+    }
     XConnection& xcon = XConnection::get();
     if (show != visible) {
         visible = show;

--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -146,19 +146,26 @@ void FrameDecoration::render(const FrameDecorationData& data, bool isFocused) {
 void FrameDecoration::updateVisibility(const FrameDecorationData& data, bool isFocused)
 {
     bool show = false;
-    ShowFrameDecorations when = settings->show_frame_decorations();
-    if (when >= ShowFrameDecorations::nonempty) {
-        show = show || data.hasClients;
-    }
-    if (when >= ShowFrameDecorations::focused) {
-        show = show || isFocused;
-    }
-    if (when >= ShowFrameDecorations::focused_if_ambiguous) {
-        bool isRootFrame = frame_.parent_.expired();
-        show = show || (isFocused && !isRootFrame);;
-    }
-    if (when >= ShowFrameDecorations::all) {
+    bool isRootFrame = frame_.parent_.expired();
+    switch (settings->show_frame_decorations()) {
+    case ShowFrameDecorations::none:
+        show = false;
+        break;
+    case ShowFrameDecorations::nonempty:
+        show = data.hasClients;
+        break;
+    case ShowFrameDecorations::focused:
+        show = data.hasClients || isFocused;
+        break;
+    case ShowFrameDecorations::focused_if_multiple:
+        show = data.hasClients || (isFocused && !isRootFrame);
+        break;
+    case ShowFrameDecorations::if_multiple:
+        show = data.hasClients || !isRootFrame;
+        break;
+    case ShowFrameDecorations::all:
         show = true;
+        break;
     }
     XConnection& xcon = XConnection::get();
     if (show != visible) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -32,7 +32,8 @@ template<>
 Finite<ShowFrameDecorations>::ValueList Finite<ShowFrameDecorations>::values = ValueListPlain {
     { ShowFrameDecorations::all, "all" },
     { ShowFrameDecorations::focused, "focused" },
-    { ShowFrameDecorations::focused_if_ambiguous, "focused_if_ambiguous" },
+    { ShowFrameDecorations::focused_if_multiple, "focused_if_multiple" },
+    { ShowFrameDecorations::if_multiple, "if_multiple" },
     { ShowFrameDecorations::nonempty, "nonempty" },
     { ShowFrameDecorations::none, "none" },
 };
@@ -276,11 +277,12 @@ Settings::Settings()
                 );
 
     show_frame_decorations.setDoc(
-                "This controls, which frame decorations are shown at all. "
-                "\'none\' shows no frame decorations at all, "
-                "\'nonempty\' shows frame decorations of frames that have client windows, "
-                "\'focused_if_ambiguous\' additionally shows decoration of the focused frame on tags with multiple frames, "
-                "\'focused\' additionally shows the decoration of the focused frame."
+                "This controls, which frame decorations are shown at all. \n"
+                "\'none\' shows no frame decorations at all, \n"
+                "\'nonempty\' shows decorations of frames that have client windows, \n"
+                "\'if_multiple\' shows decorations on the tags with at least two frames, \n"
+                "\'focused\' shows the decoration of focused and nonempty frames, \n"
+                "\'focused_if_multiple\' shows decorations of focused and non-empty frames on tags with at least two frames."
                 );
 
     frame_active_opacity.setDoc(

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -278,11 +278,11 @@ Settings::Settings()
 
     show_frame_decorations.setDoc(
                 "This controls, which frame decorations are shown at all. \n"
-                "\'none\' shows no frame decorations at all, \n"
-                "\'nonempty\' shows decorations of frames that have client windows, \n"
-                "\'if_multiple\' shows decorations on the tags with at least two frames, \n"
-                "\'focused\' shows the decoration of focused and nonempty frames, \n"
-                "\'focused_if_multiple\' shows decorations of focused and non-empty frames on tags with at least two frames."
+                "- \'none\' shows no frame decorations at all, \n"
+                "- \'nonempty\' shows decorations of frames that have client windows, \n"
+                "- \'if_multiple\' shows decorations on the tags with at least two frames, \n"
+                "- \'focused\' shows the decoration of focused and nonempty frames, \n"
+                "- \'focused_if_multiple\' shows decorations of focused and non-empty frames on tags with at least two frames."
                 );
 
     frame_active_opacity.setDoc(

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -145,7 +145,7 @@ Settings::Settings()
     show_frame_decorations.changed().connect(&all_monitors_apply_layout);
     smart_frame_surroundings.changed().connect(&all_monitors_apply_layout);
     wmname.changed().connect([]() { Ewmh::get().updateWmName(); });
-    // connect deprectaed attribute to new settings:
+    // connect deprecated attribute to new settings:
     always_show_frame.changedByUser().connect([this](bool alwaysShow) {
         this->show_frame_decorations =
                 alwaysShow

--- a/src/settings.h
+++ b/src/settings.h
@@ -25,11 +25,12 @@ template<> Finite<SmartFrameSurroundings>::ValueList Finite<SmartFrameSurroundin
 template<> inline Type Attribute_<SmartFrameSurroundings>::staticType() { return Type::NAMES; }
 
 enum class ShowFrameDecorations {
-    none = 0,
-    nonempty = 1,
-    focused_if_ambiguous = 2,
-    focused = 3,
-    all = 4,
+    none,
+    nonempty,
+    focused_if_multiple,
+    focused,
+    if_multiple,
+    all,
 };
 
 template <>
@@ -72,7 +73,7 @@ public:
     Attribute_<int>           frame_normal_opacity = {"frame_normal_opacity", 100};
     Attribute_<bool>          focus_crosses_monitor_boundaries = {"focus_crosses_monitor_boundaries", true};
     Attribute_<bool>          always_show_frame = {"always_show_frame", false};
-    Attribute_<ShowFrameDecorations> show_frame_decorations = {"show_frame_decorations", ShowFrameDecorations::focused_if_ambiguous};
+    Attribute_<ShowFrameDecorations> show_frame_decorations = {"show_frame_decorations", ShowFrameDecorations::focused_if_multiple};
     Attribute_<bool>          default_direction_external_only = {"default_direction_external_only", false};
     Attribute_<LayoutAlgorithm> default_frame_layout = {"default_frame_layout", LayoutAlgorithm::vertical};
     Attribute_<bool>          focus_follows_mouse = {"focus_follows_mouse", false};

--- a/src/settings.h
+++ b/src/settings.h
@@ -24,6 +24,20 @@ struct is_finite<SmartFrameSurroundings> : std::true_type {};
 template<> Finite<SmartFrameSurroundings>::ValueList Finite<SmartFrameSurroundings>::values;
 template<> inline Type Attribute_<SmartFrameSurroundings>::staticType() { return Type::NAMES; }
 
+enum class ShowFrameDecorations {
+    none = 0,
+    nonempty = 1,
+    focused_if_ambiguous = 2,
+    focused = 3,
+    all = 4,
+};
+
+template <>
+struct is_finite<ShowFrameDecorations> : std::true_type {};
+template<> Finite<ShowFrameDecorations>::ValueList Finite<ShowFrameDecorations>::values;
+template<> inline Type Attribute_<ShowFrameDecorations>::staticType() { return Type::NAMES; }
+
+
 class Settings : public Object {
 public:
     using string = std::string;
@@ -58,6 +72,7 @@ public:
     Attribute_<int>           frame_normal_opacity = {"frame_normal_opacity", 100};
     Attribute_<bool>          focus_crosses_monitor_boundaries = {"focus_crosses_monitor_boundaries", true};
     Attribute_<bool>          always_show_frame = {"always_show_frame", false};
+    Attribute_<ShowFrameDecorations> show_frame_decorations = {"show_frame_decorations", ShowFrameDecorations::focused_if_ambiguous};
     Attribute_<bool>          default_direction_external_only = {"default_direction_external_only", false};
     Attribute_<LayoutAlgorithm> default_frame_layout = {"default_frame_layout", LayoutAlgorithm::vertical};
     Attribute_<bool>          focus_follows_mouse = {"focus_follows_mouse", false};

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -932,14 +932,18 @@ class X11:
         geom.y = y
         return geom
 
-    def get_hlwm_frames(self):
+    def get_hlwm_frames(self, only_visible=False):
         """get list of window handles of herbstluftwm
         frame decoration windows"""
-        cmd = ['xdotool', 'search', '--class', '_HERBST_FRAME']
+        cmd = ['xdotool', 'search']
+        if only_visible:
+            cmd += ['--onlyvisible']
+        cmd += ['--class', '_HERBST_FRAME']
         frame_wins = subprocess.run(cmd,
                                     stdout=subprocess.PIPE,
-                                    universal_newlines=True,
-                                    check=True)
+                                    universal_newlines=True)
+        # we need to ignore the exit code, because xdotool returns exit
+        # code 1 if no windows were found.
         res = []
         for winid_decimal_str in frame_wins.stdout.splitlines():
             res.append(self.window(winid_decimal_str))

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -214,6 +214,7 @@ def test_title_ellipsis_is_used(hlwm, x11, font):
 
 @pytest.mark.parametrize("frame_bg_transparent", ['on', 'off'])
 def test_frame_bg_transparent(hlwm, x11, frame_bg_transparent):
+    hlwm.attr.settings.show_frame_decorations = 'all'
     hlwm.attr.settings.frame_gap = 24  # should not matter
     hlwm.attr.settings.frame_border_width = 0
     hlwm.attr.settings.frame_bg_active_color = '#ef0000'
@@ -240,6 +241,7 @@ def test_frame_bg_transparent(hlwm, x11, frame_bg_transparent):
 
 @pytest.mark.parametrize("frame_bg_transparent", ['on', 'off'])
 def test_frame_holes_for_tiled_client(hlwm, x11, frame_bg_transparent):
+    hlwm.attr.settings.show_frame_decorations = 'all'
     hlwm.attr.settings.frame_bg_active_color = '#efcd32'
     hlwm.attr.settings.frame_bg_transparent = frame_bg_transparent
     hlwm.attr.settings.frame_transparent_width = 8
@@ -263,6 +265,7 @@ def test_frame_holes_for_tiled_client(hlwm, x11, frame_bg_transparent):
 
 @pytest.mark.parametrize("frame_bg_transparent", ['on', 'off'])
 def test_frame_holes_for_pseudotiled_client(hlwm, x11, frame_bg_transparent):
+    hlwm.attr.settings.show_frame_decorations = 'all'
     bgcol = (0xef, 0xcd, 0x32)
     hlwm.attr.settings.frame_bg_active_color = RawImage.rgb2string(bgcol)
     hlwm.attr.settings.frame_bg_transparent = frame_bg_transparent

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -111,6 +111,7 @@ def types_and_shorthands():
         'string': 's',
         'regex': 'r',
         'SmartFrameSurroundings': 'n',
+        'ShowFrameDecorations': 'n',
         'SplitAlign': 'n',
         'LayoutAlgorithm': 'n',
         'TextAlign': 'n',

--- a/tests/test_frame_decorations.py
+++ b/tests/test_frame_decorations.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+@pytest.mark.parametrize("running_clients_num", [0, 1, 2])
+def test_show_frame_decorations_one_frame(hlwm, x11, running_clients, running_clients_num):
+    expected_frame_count = {
+        'all': 1,
+        'focused': 1,
+        'focused_if_ambiguous': 1 if running_clients_num > 0 else 0,
+        'nonempty': 1 if running_clients_num > 0 else 0,
+        'none': 0,
+    }
+    for v in hlwm.complete(['set', 'show_frame_decorations']):
+        hlwm.attr.settings.show_frame_decorations = v
+        assert len(x11.get_hlwm_frames(only_visible=True)) == expected_frame_count[v]
+
+
+def test_show_frame_decorations_focus(hlwm, x11):
+    winid, _ = hlwm.create_client()
+    # create a split on the right, and focus the empty frame
+    layout = f"""
+    (split horizontal:0.5:1 (clients max:0 {winid}) (clients max:0))
+    """
+    hlwm.call(['load', layout.strip()])
+    expected_frame_count = {
+        'all': 2,
+        'focused': 2,
+        'focused_if_ambiguous': 2,
+        'nonempty': 1,
+        'none': 0,
+    }
+    for v in hlwm.complete(['set', 'show_frame_decorations']):
+        hlwm.attr.settings.show_frame_decorations = v
+        assert len(x11.get_hlwm_frames(only_visible=True)) == expected_frame_count[v]

--- a/tests/test_frame_decorations.py
+++ b/tests/test_frame_decorations.py
@@ -6,8 +6,9 @@ def test_show_frame_decorations_one_frame(hlwm, x11, running_clients, running_cl
     expected_frame_count = {
         'all': 1,
         'focused': 1,
-        'focused_if_ambiguous': 1 if running_clients_num > 0 else 0,
+        'focused_if_multiple': 1 if running_clients_num > 0 else 0,
         'nonempty': 1 if running_clients_num > 0 else 0,
+        'if_multiple': 1 if running_clients_num > 0 else 0,
         'none': 0,
     }
     for v in hlwm.complete(['set', 'show_frame_decorations']):
@@ -25,8 +26,9 @@ def test_show_frame_decorations_focus(hlwm, x11):
     expected_frame_count = {
         'all': 2,
         'focused': 2,
-        'focused_if_ambiguous': 2,
+        'focused_if_multiple': 2,
         'nonempty': 1,
+        'if_multiple': 2,
         'none': 0,
     }
     for v in hlwm.complete(['set', 'show_frame_decorations']):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -168,3 +168,21 @@ def test_smart_frame_surroundings(hlwm, x11):
     frame_x11 = x11.get_hlwm_frames()[0]
     frame_geom = frame_x11.get_geometry()
     assert (frame_geom.width, frame_geom.height) == (776, 576)
+
+
+def test_always_show_frame(hlwm):
+    # test old->new setting
+    settings = hlwm.attr.settings
+    settings.always_show_frame = True
+    assert settings.show_frame_decorations() == 'all'
+    settings.always_show_frame = False
+    assert settings.show_frame_decorations() == 'focused'
+
+    # test new->old setting
+    settings.always_show_frame = True
+    settings.show_frame_decorations = 'nonempty'
+    assert settings.always_show_frame() is False
+    settings.show_frame_decorations = 'all'
+    assert settings.always_show_frame() is True
+    settings.show_frame_decorations = 'focused'
+    assert settings.always_show_frame() is False


### PR DESCRIPTION
This new settings gives a more fine-grained control when frame decorations
are shown. The new setting strictly generalizes the always_show_frame
setting, which now only exists for backwards-compatibility.

The feature was requested in #1183, where it was reported that many
people find the initial frame decorations of a single big frame ugly
when starting hlwm for the first time. To address this, it maybe makes
sense to hide it per default. Thus, the setting is set to
`focused_if_multiple` in the in the default autostart.

Also, changing this default in settings.h should prevent new users
without an autostart from being confused by the red root frame (see
e.g. #599).