### PR TITLE
Filter Numlock/Caps Lock modifiers out of mouse events to match key events

### DIFF
--- a/src/mousemanager.cpp
+++ b/src/mousemanager.cpp
@@ -318,8 +318,10 @@ MouseManager::MouseFunction MouseManager::string2mousefunction(const string& nam
 }
 
 std::experimental::optional<MouseManager::MouseBinding> MouseManager::mouse_binding_find(unsigned int modifiers, unsigned int button) {
+    unsigned int numlockMask = Root::get()->xKeyGrabber_->getNumlockMask();
     MouseCombo mb = {};
-    mb.modifiers_ = modifiers & ModifierCombo::allModifierMasks;
+    mb.modifiers_ = modifiers & ModifierCombo::allModifierMasks
+        & ~(numlockMask | LockMask);
     mb.button_ = button;
 
     auto found = std::find_if(binds.begin(), binds.end(),


### PR DESCRIPTION
In the most recent commit 78a1e126, the MouseManager was changed to filter event modifiers to all supported modifiers instead of masking out a seperate list of modifiers. However, since Numlock is bound to Mod2 for most keymaps which was not masked out anymore, which means mousebinds (like the ones in the sample autostart) will only work if Numlock is off -- unless you define another mousebind including Mod2 for every action, so they work in both states.

This is just a small change to mask the locks out again, as before. It is not a big commit, but that change in behaviour feels unintended and this is probably the simplest way to have it behave in a more consistent way: It now behaves the same as key events again, where Numlock/Caps Lock are also masked out in case they are set as modifier keys (src/xkeygrabber.cpp, line 49).