### PR TITLE
Test mouse binds independent of numlock state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -951,7 +951,7 @@ class X11:
     def set_numlock_state(self, enabled):
         if self.get_numlock_state() != enabled:
             cmd = ['xdotool', 'key', '--clearmodifiers', 'Num_Lock']
-            subprocess.run(cmd, universal_newlines=True, check=True)
+            subprocess.run(cmd, check=True)
             for _ in range(0, 10):
                 self.display.sync()
                 if self.get_numlock_state() == enabled:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -945,6 +945,19 @@ class X11:
             res.append(self.window(winid_decimal_str))
         return res
 
+    def get_numlock_state(self):
+        return (self.display.get_keyboard_control().led_mask & 2) != 0
+
+    def set_numlock_state(self, enabled):
+        if self.get_numlock_state() != enabled:
+            cmd = ['xdotool', 'key', '--clearmodifiers', 'Num_Lock']
+            subprocess.run(cmd, universal_newlines=True, check=True)
+            for _ in range(0, 10):
+                self.display.sync()
+                if self.get_numlock_state() == enabled:
+                    return
+            assert self.get_numlock_state() == enabled
+
     def shutdown(self):
         # Destroy all created windows:
         for window in self.windows:


### PR DESCRIPTION
Test that mouse bindings are independent of the numlock state. This adds
the test for the fix in #1490.