### PR TITLE
Update regular expression parser error

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -322,7 +322,7 @@ def test_condition_class(hlwm):
 
 @pytest.mark.parametrize('rulearg,errormsg', [
     ("fullscreen=foo", 'only.*are valid booleans'),
-    ("keymask=(", 'Parenthesis is not closed'),
+    ("keymask=(", r'(Parenthesis is not closed|Mismatched.*\(.*\).*in regular)'),
     ("floatplacement=bar", 'Expecting one of: center, '),
     ("floating_geometry=4x5+1024+1024", 'Rectangle too small'),
     ("floating_geometry=totallywrong", 'Rectangle too small'),  # TODO: make rectangle parsing fail


### PR DESCRIPTION
On my setup (archlinux with gcc 12.1.0-2), the error message for
mismatched parentheses regular expressions has changed. This commit just
updates the error message in the test cases.