### PR TITLE
Add --bidirectional arg for keybind

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -15,6 +15,9 @@ now incompatible with the 'toggle' command. Use 'cycle_values' instead:
 Instead of 'always_show_frame', the new 'show_frame_decorations' setting should
 be used.
 
+In the 'keybind' command, if both the key press and the key release are bound,
+this need to be explicitly specified by passing '--bidirectional' to keybind.
+
 0.9.2 to 0.9.3
 --------------
 The command 'cycle_value' now expects an attribute path instead of a settings

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -231,16 +231,19 @@ unlock::
     Decreases the 'monitors_locked' setting. If 'monitors_locked' is changed to
     0, then all monitors are repainted again. See also: *lock*
 
-keybind 'KEY' 'COMMAND' ['ARGS ...']::
+keybind [*--bidirectional*] 'KEY' 'COMMAND' ['ARGS ...']::
     Adds a key binding. If there is already a binding for this 'KEY',
     it will be overwritten. When 'KEY' is pressed, the internal 'COMMAND' (with its
     'ARGS') is executed. A key binding is a (possibly empty) list of modifiers
     (Mod1, Mod2, Mod3, Mod4, Mod5, Alt, Super, Control/Ctrl, Shift) and one key
     (see keysymdef.h for a list of keys). Modifiers and the key are concatenated
     with '-' or '+' as separator. If 'KEY' is prefixed with 'Release-' then the
-    keybinding is only active during the corresponding key release event: that
-    is, in order to run the key binding for 'Release-Mod1-Shift-p' one needs to
-    first press 'Mod1-Shift-p' and then release 'p'.  Examples:
+    keybinding is only active during the corresponding key release event.
+    In order to run the key binding for 'Release-Mod1-Shift-p' one needs to
+    first press 'Mod1-Shift-p' and then release 'p'.
+    If a release-event is bound, then also the corresponding press-event is
+    overwritten, and vice versa. To bind both the press and the release event at
+    the same time, pass *--bidirectional*. Examples:
 
         * keybind Mod4+Ctrl+q quit
         * keybind Mod4-Shift-d attr clients.focus.decorated toggle

--- a/src/keycombo.cpp
+++ b/src/keycombo.cpp
@@ -98,6 +98,17 @@ template<> void Converter<ModifiersWithString>::complete(Completion& complete, M
     ModifiersWithString::complete(complete, [] (Completion&, string) {});
 }
 
+/**
+ * @brief the KeyCombo with onRelease_ flipped.
+ * @return
+ */
+KeyCombo KeyCombo::otherDirection()
+{
+    KeyCombo other = *this;
+    other.onRelease_ = !other.onRelease_;
+    return other;
+}
+
 /*!
  * Provides a canonical string representation of the key combo
  */

--- a/src/keycombo.h
+++ b/src/keycombo.h
@@ -72,6 +72,8 @@ public:
 
     static constexpr auto releaseModifier = "Release";
 
+    KeyCombo otherDirection();
+
     std::string str() const;
     bool operator==(const KeyCombo& other) const;
     bool operator<(const KeyCombo& other) const;

--- a/src/keymanager.h
+++ b/src/keymanager.h
@@ -74,7 +74,7 @@ public:
     Signal keyComboAllInactive;
 
     void keybindCommand(CallOrComplete invoc);
-    int addKeybind(KeyBinding newBinding, Output output);
+    int addKeybind(KeyBinding newBinding, bool bidirectional, Output output);
     int listKeybindsCommand(Output output) const;
     int removeKeybindCommand(Input input, Output output);
 

--- a/tests/test_keybind.py
+++ b/tests/test_keybind.py
@@ -144,6 +144,7 @@ def test_invalid_keys_inactive_via_rule(hlwm, keyboard):
 @pytest.mark.parametrize('prefix', ['', 'Mod1+'])
 def test_complete_keybind_offers_all_mods_and_syms(hlwm, prefix):
     complete = hlwm.complete(['keybind', prefix], partial=True, position=1)
+    complete = [c for c in complete if c != '--bidirectional ']
 
     assert len(complete) > 200  # plausibility check
     all_mods = ['Alt', 'Control', 'Ctrl', 'Mod1', 'Mod2', 'Mod3', 'Mod4', 'Mod5', 'Shift', 'Super']
@@ -158,8 +159,11 @@ def test_complete_keybind_offers_all_mods_and_syms(hlwm, prefix):
 
 def test_complete_keybind_after_combo_offers_all_commands(hlwm):
     complete = hlwm.complete('keybind x', position=2)
+    complete = [c for c in complete if c != '--bidirectional']
 
-    assert complete == hlwm.complete('', position=0)
+    commands = hlwm.complete('', position=0)
+    assert complete == commands
+    assert commands == hlwm.complete('keybind --bidirectional x', position=3)
 
 
 def test_keys_inactive_regrab_all(hlwm, keyboard):
@@ -359,7 +363,7 @@ def test_keybind_triggers_only_once(hlwm, keyboard):
 
 def test_key_release_works_after_bind(hlwm, keyboard):
     hlwm.call(['new_attr', 'string', 'my_test', 'initial'])
-    hlwm.call(['keybind', 'Release+x', 'set_attr', 'my_test', 'release'])
+    hlwm.call(['keybind', '--bidirectional', 'Release+x', 'set_attr', 'my_test', 'release'])
 
     keyboard.down('x')
     assert hlwm.attr.my_test() == 'initial'
@@ -370,8 +374,8 @@ def test_key_release_works_after_bind(hlwm, keyboard):
 
 def test_key_release_and_press(hlwm, keyboard):
     hlwm.call(['new_attr', 'string', 'my_test', 'initial'])
-    hlwm.call(['keybind', 'Mod1-x', 'set_attr', 'my_test', 'press'])
-    hlwm.call(['keybind', 'Release-Mod1-x', 'set_attr', 'my_test', 'release'])
+    hlwm.call(['keybind', '--bidirectional', 'Mod1-x', 'set_attr', 'my_test', 'press'])
+    hlwm.call(['keybind', '--bidirectional', 'Release-Mod1-x', 'set_attr', 'my_test', 'release'])
     assert hlwm.attr.my_test() == 'initial'
 
     keyboard.down('alt+x')
@@ -393,7 +397,7 @@ def test_keys_inactive_key_can_be_removed(hlwm):
 
 def test_keys_inactive_affects_release_binds(hlwm, keyboard):
     hlwm.call(['new_attr', 'string', 'my_test', 'initial'])
-    hlwm.call(['keybind', 'Release-x', 'set_attr', 'my_test', 'release'])
+    hlwm.call(['keybind', '--bidirectional', 'Release-x', 'set_attr', 'my_test', 'release'])
     winid, proc = hlwm.create_client(term_command='read -n 1')
     hlwm.attr.clients[winid].keys_inactive = 'x'
 
@@ -411,8 +415,8 @@ def test_keys_inactive_affects_release_binds(hlwm, keyboard):
 
 def test_key_release_after_unbinding_press(hlwm, keyboard):
     hlwm.call(['new_attr', 'string', 'my_test', 'initial'])
-    hlwm.call(['keybind', 'Mod1-x', 'set_attr', 'my_test', 'press'])
-    hlwm.call(['keybind', 'Release-Mod1-x', 'set_attr', 'my_test', 'release'])
+    hlwm.call(['keybind', '--bidirectional', 'Mod1-x', 'set_attr', 'my_test', 'press'])
+    hlwm.call(['keybind', '--bidirectional', 'Release-Mod1-x', 'set_attr', 'my_test', 'release'])
     hlwm.call(['keyunbind', 'Mod1-x'])
     assert hlwm.attr.my_test() == 'initial'
 
@@ -429,8 +433,8 @@ def test_key_release_reuses_mod_mask(hlwm, keyboard):
     that was once active back then when the key press happend.
     """
     hlwm.call(['new_attr', 'string', 'my_test', 'initial'])
-    hlwm.call(['keybind', 'Mod1-x', 'set_attr', 'my_test', 'press'])
-    hlwm.call(['keybind', 'Release-Mod1-x', 'set_attr', 'my_test', 'release'])
+    hlwm.call(['keybind', '--bidirectional', 'Mod1-x', 'set_attr', 'my_test', 'press'])
+    hlwm.call(['keybind', '--bidirectional', 'Release-Mod1-x', 'set_attr', 'my_test', 'release'])
     assert hlwm.attr.my_test() == 'initial'
 
     keyboard.down('alt')
@@ -450,8 +454,8 @@ def test_key_release_reuses_mod_mask(hlwm, keyboard):
 
 def test_key_release_of_modifier(hlwm, keyboard):
     hlwm.call(['new_attr', 'string', 'my_test', 'initial'])
-    hlwm.call(['keybind', 'Super_L', 'set_attr', 'my_test', 'press'])
-    hlwm.call(['keybind', 'Release-Super_L', 'set_attr', 'my_test', 'release'])
+    hlwm.call(['keybind', '--bidirectional', 'Super_L', 'set_attr', 'my_test', 'press'])
+    hlwm.call(['keybind', '--bidirectional', 'Release-Super_L', 'set_attr', 'my_test', 'release'])
     assert hlwm.attr.my_test() == 'initial'
     keyboard.down('Super_L')
     assert hlwm.attr.my_test() == 'press'
@@ -461,8 +465,8 @@ def test_key_release_of_modifier(hlwm, keyboard):
 
 def test_key_press_after_unbinding_release(hlwm, keyboard):
     hlwm.call(['new_attr', 'string', 'my_test', 'initial'])
-    hlwm.call(['keybind', 'Mod1-x', 'set_attr', 'my_test', 'press'])
-    hlwm.call(['keybind', 'Release-Mod1-x', 'set_attr', 'my_test', 'release'])
+    hlwm.call(['keybind', '--bidirectional', 'Mod1-x', 'set_attr', 'my_test', 'press'])
+    hlwm.call(['keybind', '--bidirectional', 'Release-Mod1-x', 'set_attr', 'my_test', 'release'])
     hlwm.call(['keyunbind', 'Release-Mod1-x'])
     assert hlwm.attr.my_test() == 'initial'
 
@@ -488,7 +492,7 @@ def test_client_does_not_see_bound_key(hlwm, keyboard, bind_press, bind_release,
     if bind_press:
         hlwm.call(['keybind', 'z', 'set_attr', 'my_test', 'grabbed'])
     if bind_release:
-        hlwm.call(['keybind', 'Release+z', 'set_attr', 'my_test', 'grabbed'])
+        hlwm.call(['keybind', '--bidirectional', 'Release+z', 'set_attr', 'my_test', 'grabbed'])
 
     if client_spawn_position == 'pre_unbind':
         winid, proc = hlwm.create_client(term_command='read -n 1')
@@ -521,3 +525,41 @@ def test_client_does_not_see_bound_key(hlwm, keyboard, bind_press, bind_release,
             assert False, "Expected client to quit, but it is still running"
     else:
         assert hlwm.attr.my_test() == "grabbed"
+
+
+@pytest.mark.parametrize('bidir', [True, False])
+@pytest.mark.parametrize('press_exists', [True, False])
+@pytest.mark.parametrize('release_exists', [True, False])
+@pytest.mark.parametrize('bind_type', ['', 'Release-'])
+def test_keybind_removes_other_event_unless_bidir(hlwm, keyboard, press_exists, release_exists, bind_type, bidir):
+    hlwm.attr.my_counter = 0
+    if press_exists:
+        hlwm.call(['keybind', '--bidirectional', 'x', 'set_attr', 'my_counter', '+=1'])
+    if release_exists:
+        hlwm.call(['keybind', '--bidirectional', 'Release-x', 'set_attr', 'my_counter', '+=1'])
+
+    # test that the keybind works:
+    keyboard.press('x')
+    assert hlwm.attr.my_counter() == int(press_exists) + int(release_exists)
+    hlwm.attr.my_counter = 0  # reset counter
+
+    # overwrite some of the above keybindings:
+    hlwm.attr.my_test = 'initial'
+    cmd = ['keybind']
+    if bidir:
+        cmd += ['--bidirectional']
+    cmd += [bind_type + 'x', 'set_attr', 'my_test', 'success']
+    hlwm.call(cmd)
+
+    remaining_original_keybinds = 0
+    if bidir:
+        # the original key bindings only survive if '--bidirectional' was passed:
+        remaining_original_keybinds = int(press_exists and bind_type != '')
+        remaining_original_keybinds += int(release_exists and bind_type != 'Release-')
+
+    assert ('my_counter' in hlwm.call('list_keybinds').stdout) == (remaining_original_keybinds > 0)
+
+    # press the keybinding again
+    keyboard.press('x')
+    assert hlwm.attr.my_counter() == remaining_original_keybinds
+    assert hlwm.attr.my_test() == 'success'


### PR DESCRIPTION
If a keybind for a combo is added, the corresponding release bind is
removed automatically. So if e.g. some script binds 'Alt-x' and another
script binds 'Release-Alt-x', then not both keybindings are active.
Instead, the first Alt-x is removed when 'Release-Alt-x' is bound.

In the rare occassion where both press and release are bound, this new
'--bidirectional' needs to be used.