### PR TITLE
feat: add show_frame_decorations if_empty to show frame placeholders

### DIFF
--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -154,6 +154,9 @@ void FrameDecoration::updateVisibility(const FrameDecorationData& data, bool isF
     case ShowFrameDecorations::nonempty:
         show = data.hasClients;
         break;
+    case ShowFrameDecorations::if_empty:
+        show = !data.hasClients;
+        break;
     case ShowFrameDecorations::focused:
         show = data.hasClients || isFocused;
         break;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -35,6 +35,7 @@ Finite<ShowFrameDecorations>::ValueList Finite<ShowFrameDecorations>::values = V
     { ShowFrameDecorations::focused_if_multiple, "focused_if_multiple" },
     { ShowFrameDecorations::if_multiple, "if_multiple" },
     { ShowFrameDecorations::nonempty, "nonempty" },
+    { ShowFrameDecorations::if_empty, "if_empty" },
     { ShowFrameDecorations::none, "none" },
 };
 
@@ -281,6 +282,7 @@ Settings::Settings()
                 "- \'none\' shows no frame decorations at all, \n"
                 "- \'nonempty\' shows decorations of frames that have client windows, \n"
                 "- \'if_multiple\' shows decorations on the tags with at least two frames, \n"
+                "- \'if_empty\' shows decorations of frames that have no client windows, \n"
                 "- \'focused\' shows the decoration of focused and nonempty frames, \n"
                 "- \'focused_if_multiple\' shows decorations of focused and non-empty frames on tags with at least two frames."
                 );

--- a/src/settings.h
+++ b/src/settings.h
@@ -29,6 +29,7 @@ enum class ShowFrameDecorations {
     nonempty,
     focused_if_multiple,
     focused,
+    if_empty,
     if_multiple,
     all,
 };

--- a/tests/test_frame_decorations.py
+++ b/tests/test_frame_decorations.py
@@ -2,16 +2,19 @@ import pytest
 
 
 @pytest.mark.parametrize("running_clients_num", [0, 1, 2])
-def test_show_frame_decorations_one_frame(hlwm, x11, running_clients, running_clients_num):
+def test_show_frame_decorations_one_frame(
+    hlwm, x11, running_clients, running_clients_num
+):
     expected_frame_count = {
-        'all': 1,
-        'focused': 1,
-        'focused_if_multiple': 1 if running_clients_num > 0 else 0,
-        'nonempty': 1 if running_clients_num > 0 else 0,
-        'if_multiple': 1 if running_clients_num > 0 else 0,
-        'none': 0,
+        "all": 1,
+        "focused": 1,
+        "focused_if_multiple": 1 if running_clients_num > 0 else 0,
+        "nonempty": 1 if running_clients_num > 0 else 0,
+        "if_multiple": 1 if running_clients_num > 0 else 0,
+        "if_empty": 0 if running_clients_num > 0 else 1,
+        "none": 0,
     }
-    for v in hlwm.complete(['set', 'show_frame_decorations']):
+    for v in hlwm.complete(["set", "show_frame_decorations"]):
         hlwm.attr.settings.show_frame_decorations = v
         assert len(x11.get_hlwm_frames(only_visible=True)) == expected_frame_count[v]
 
@@ -22,15 +25,16 @@ def test_show_frame_decorations_focus(hlwm, x11):
     layout = f"""
     (split horizontal:0.5:1 (clients max:0 {winid}) (clients max:0))
     """
-    hlwm.call(['load', layout.strip()])
+    hlwm.call(["load", layout.strip()])
     expected_frame_count = {
-        'all': 2,
-        'focused': 2,
-        'focused_if_multiple': 2,
-        'nonempty': 1,
-        'if_multiple': 2,
-        'none': 0,
+        "all": 2,
+        "focused": 2,
+        "focused_if_multiple": 2,
+        "nonempty": 1,
+        "if_multiple": 2,
+        "if_empty": 1,
+        "none": 0,
     }
-    for v in hlwm.complete(['set', 'show_frame_decorations']):
+    for v in hlwm.complete(["set", "show_frame_decorations"]):
         hlwm.attr.settings.show_frame_decorations = v
         assert len(x11.get_hlwm_frames(only_visible=True)) == expected_frame_count[v]


### PR DESCRIPTION
Added `if_empty` option to `show_frame_directions`. This is useful to show a placeholder for frames which have no children. See the transparent dark regions in the screenshot.

![frame-decorations-if-empty](https://user-images.githubusercontent.com/32134/178191381-d6a1e228-5b0d-46c1-a1f5-c4451865b9d0.png)
