### PR TITLE
tests: Work around endianess in image data

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -826,7 +826,7 @@ class X11:
         return w, self.winid_str(w)
 
     def screenshot(self, win_handle) -> RawImage:
-        """screenshot of a windows content, not including its border"""
+        """screenshot of a window's content, not including its border"""
         geom = win_handle.get_geometry()
         attr = win_handle.get_attributes()
         # Xlib defines AllPlanes as: ((unsigned long)~0L)
@@ -860,7 +860,14 @@ class X11:
             assert raw.depth in [32, 24]
             # both for depth 32 and 24, the order is BGRA
             pixelsize = 4
-            (blue, green, red) = (0, 1, 2)
+            # actually, there should be an attribute raw.byte_order which
+            # tells the byte order in the present XImage,
+            # but this is unfortunately missing in python-xlib. so let's
+            # work around this using the system's settings:
+            if sys.byteorder == 'little':
+                (blue, green, red) = (0, 1, 2)
+            else:
+                (blue, green, red) = (3, 2, 1)
             size = geom.width * geom.height
             assert len(raw.data) == pixelsize * size
             rgbvals = [(raw.data[pixelsize * (y * geom.width + x) + red],


### PR DESCRIPTION
The raw data of an image obtained from a screenshot depends on the
endianess. I couldn't make colormap.query_colors() work for depth 32 or
24, which would be the clean solution. Instead, we still parse the
binary image data manually and depend on the endianess of the system. In
principle, this could still be different from the image's endianess in
distributed X11 setups, but this should not happen when running the test
suite.

I could reproduce the issue #1486 on the ppc64 system gcc203 of the
gcc compile farm.

This fixes #1486.