### PR TITLE
IPC Server: fix type of command status

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,7 +16,7 @@ Current git version
     are shown. This should be used instead of the old 'always_show_frame'
   * New frame attribute 'content_geometry'
   * New monitor attribute 'content_geometry'
-  * Fix bug in ipc protocoll for big-endian systems
+  * Fix bug in ipc protocol for big-endian systems
 
 Release 0.9.4 on 2022-03-16
 ---------------------------

--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,7 @@ Current git version
     are shown. This should be used instead of the old 'always_show_frame'
   * New frame attribute 'content_geometry'
   * New monitor attribute 'content_geometry'
+  * Fix bug in ipc protocoll for big-endian systems
 
 Release 0.9.4 on 2022-03-16
 ---------------------------

--- a/src/ipc-server.cpp
+++ b/src/ipc-server.cpp
@@ -52,7 +52,9 @@ bool IpcServer::handleConnection(Window win, CallHandler callback) {
     }
     auto result = callback(maybeArguments.value());
     // send output back
-    int status = result.exitCode;
+    // here, it is important to use 'long' because XChangeProperty() requires
+    // data of type long.
+    long status = static_cast<long>(result.exitCode);
     // Mark this command as executed
     XDeleteProperty(X.display(), win, X.atom(HERBST_IPC_ARGS_ATOM));
     X.setPropertyString(win, X.atom(HERBST_IPC_OUTPUT_ATOM), result.output);


### PR DESCRIPTION
The Xlib function XChangeProperty() requires the data array to be
an array of 'long'. This causes wrong behaviour if long is larger than
int and if byte order is big-endian.

I could reproduce the issue #1414 on the ppc64 system gcc203 of the
gcc compile farm. Unfortunately, I don't see how I can verify the now
fixed issue in a test case.

There is another issue in the status property: the atom should have type
XA_CARDINAL instead of XA_ATOM. Changing this would require the
corresponding change in herbstclient. Strictly speaking, this would be
an incompatible change in the IPC protocol.

This fixes #1414.