### PR TITLE
Make ewmhnotify behave as expected

### DIFF
--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -1140,10 +1140,9 @@ Each 'CONSEQUENCE' consists of a 'NAME'='VALUE' pair. Valid 'NAMES' are:
     a boolean; it defaults to *on*.
 
 +ewmhnotify+::
-    sets whether hlwm should let the client know about EMWH changes (currently
-    only the fullscreen state). If this is set, applications do not change to
-    their fullscreen-mode while still being fullscreen. 'VALUE' is a boolean,
-    it defaults to *on*.
+    sets whether hlwm should let the client know about the EMWH fullscreen
+    state. If this is set, applications do not change to their fullscreen-mode
+    while still being fullscreen. 'VALUE' is a boolean, it defaults to *on*.
 
 +fullscreen+::
     sets the fullscreen flag of the client. 'VALUE' is a boolean.

--- a/src/client.h
+++ b/src/client.h
@@ -39,7 +39,7 @@ public:
     Attribute_<Rectangle> float_size_;     // floating size without the window border
     HSTag*      tag_ = {};
     Slice* slice = {};
-    bool        ewmhfullscreen_ = false; // ewmh fullscreen state
+    Attribute_<bool> ewmhfullscreen_; // ewmh fullscreen state
     bool        neverfocus_ = false; // do not give the focus via XSetInputFocus
     Attribute_<bool> decorated_;
     Attribute_<bool> visible_;

--- a/src/ewmh.cpp
+++ b/src/ewmh.cpp
@@ -443,7 +443,7 @@ void Ewmh::handleClientMessage(XClientMessageEvent* me) {
                 void    (*callback)(Client*, bool);
             } client_atoms[] = {
                 { NetWmStateFullscreen,
-                    client->fullscreen_,     [](Client* c, bool state){ c->fullscreen_ = state; } },
+                    client->ewmhfullscreen_,     [](Client* c, bool state){ c->ewmhfullscreen_ = state; } },
                 { NetWmStateDemandsAttention,
                     client->urgent_,         [](Client* c, bool state){ c->urgent_ = state; } },
             };


### PR DESCRIPTION
The purpose of disabling `ewmhnotify` is to set the hlwm-fullscreen
state independent of the ewmh fullscreen state (either to have one
enabled and the other disabled, or vice versa). To make this more easy
to use, this de-coupling should happen in both directions.

The main purpose seems to make firefox think that it is in fullscreen
state (such that it hides the gui) without firefix covering the whole
monitor (#1488).