### PR TITLE
tests: Improve stdout/stderr synchronization

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,14 +76,15 @@ class HlwmBridge(herbstluftwm.Herbstluftwm):
 
         outcome = 'succeeded' if proc.returncode == 0 else 'failed'
         allout = proc.stdout + proc.stderr
+        logfile = sys.stderr
         if allout:
             if log_output:
-                print(f'Client command {args} {outcome} with output:\n{allout}')
+                print(f'Client command {args} {outcome} with output:\n{allout}', file=logfile)
             else:
-                print(f'Client command {args} {outcome} with output', end='')
-                print(' (output suppressed).')
+                print(f'Client command {args} {outcome} with output', end='', file=logfile)
+                print(' (output suppressed).', file=logfile)
         else:
-            print(f'Client command {args} {outcome} (no output)')
+            print(f'Client command {args} {outcome} (no output)', file=logfile)
 
         # Take this opportunity read and echo any hlwm output captured in the
         # meantime:
@@ -304,6 +305,9 @@ class HlwmProcess:
         - env is the environment dictionary
         - args is a list of additional command line arguments
         """
+        self.stdout_scanners = []
+        self.stderr_scanners = []
+
         self.bin_path = os.path.join(BINDIR, 'herbstluftwm')
         self.proc = subprocess.Popen(
             [self.bin_path, '--exit-on-xerror', '--verbose'] + args, env=env,
@@ -318,42 +322,109 @@ class HlwmProcess:
         self.output_selector = sel
 
         # Wait for marker output from wrapper script:
-        self.read_and_echo_output(until_stdout=autostart_stdout_message)
+        self.wait_for_scanner_match(self.new_stdout_scanner(autostart_stdout_message))
 
-    def read_and_echo_output(self, until_stdout=None, until_stderr=None, until_eof=False):
-        expect_sth = ((until_stdout or until_stderr) is not None)
+    class ChannelScanner:
+        def __init__(self, matcher):
+            self.matcher = matcher
+            self.buffer = ''
+            self.match_found = HlwmProcess.ChannelScanner.run_matcher(self.matcher, self.buffer)
+
+        @staticmethod
+        def run_matcher(matcher, buffer):
+            if isinstance(matcher, str):
+                print(f"'{matcher}' in buffer = {matcher in buffer}", flush=True)
+                return matcher in buffer
+            elif hasattr(matcher, 'search'):
+                return matcher.search(buffer)
+            else:
+                raise Exception('unknown matcher type. matcher must be a string or have a search method')
+
+        def feed_line(self, line):
+            """a new line in this buffer was read;
+            line ends with a newline character"""
+            if not self.match_found:
+                # only continue to gather lines if match was not found
+                self.buffer += line
+                # look for a match again:
+                self.match_found = HlwmProcess.ChannelScanner.run_matcher(self.matcher, self.buffer)
+
+    def wait_for_scanner_match(self, channel_scanner):
+        """process stdout/stderr of hlwm until the given scanner matches"""
+        while not channel_scanner.match_found:
+            self.read_and_echo_output(wait_for_one_line=True)
+
+    def new_stdout_scanner(self, *channel_scanner_args):
+        scanner = HlwmProcess.ChannelScanner(*channel_scanner_args)
+        self.stdout_scanners.append(scanner)
+        return scanner
+
+    def new_stderr_scanner(self, *channel_scanner_args):
+        scanner = HlwmProcess.ChannelScanner(*channel_scanner_args)
+        self.stderr_scanners.append(scanner)
+        return scanner
+
+    def read_and_echo_output_until_stdout(self, stdout_matcher):
+        scanner = self.new_stdout_scanner(stdout_matcher)
+        self.wait_for_scanner_match(scanner)
+
+    def read_and_echo_output_until_stderr(self, stderr_matcher):
+        scanner = self.new_stderr_scanner(stderr_matcher)
+        self.wait_for_scanner_match(scanner)
+
+    def read_and_echo_output(self, until_eof=False, wait_for_one_line=False):
+        """
+        read stdout and stderr from herbstluftwm,
+        pass them through the stdout/stderr scanners,
+        and then finally forward to actual stdout/stderr.
+        If 'wait_for_one_line' is not set, then this method
+        immediatelly returns whenever no bytes are ready.
+        If 'wait_for_one_line' is set, then this method
+        blocks until at least one line has been processed.
+        """
         max_wait = 15
+        # Mark the start of the scanning phase to make it easier to debug
+        # if we run into the 'match not found' exception at the end.
 
         # Track which file objects have EOFed:
         eof_fileobjs = set()
         fileobjs = set(k.fileobj for k in self.output_selector.get_map().values())
 
-        stderr = ''
+        # gather the current line as bytes.
         stderr_bytes = bytes()
-        stdout = ''
         stdout_bytes = bytes()
 
-        def match_found():
-            if until_stdout:
-                if isinstance(until_stdout, str) and until_stdout in stdout:
-                    return True
-                if hasattr(until_stdout, 'search') and until_stdout.search(stdout):
-                    return True
-            if until_stderr:
-                if isinstance(until_stderr, str) and until_stderr in stderr:
-                    return True
-                if hasattr(until_stderr, 'search') and until_stderr.search(stderr):
-                    return True
-            return False
+        def feed_ready_byte_chunk(byte_chunk, scanners, target_file):
+            """decode the given bytes,
+            pass it to all scanners,
+            and then forward bytes to actual target stream/file.
+            if a scanner matches, then it is removed from the scanners list.
+            """
+            decoded = byte_chunk.decode()
+            removal_indices = []
+            for idx, scanner in enumerate(scanners):
+                scanner.feed_line(decoded)
+                if scanner.match_found:
+                    removal_indices.append(idx)
+            # remove in reverse order such that indices are preserved
+            for idx in reversed(removal_indices):
+                scanners.pop(idx)
+            target_file.write(decoded)
+            target_file.flush()
 
         started = datetime.now()
+        output_observed = False
         while (datetime.now() - started).total_seconds() < max_wait:
-            select_timeout = 1
-            # If we're not polling for a matching string (anymore), there is no
-            # need for a dampening timeout:
-            if not expect_sth or match_found():
+            if wait_for_one_line and not output_observed:
+                select_timeout = 1
+            else:
                 select_timeout = 0
             selected = self.output_selector.select(timeout=select_timeout)
+
+            if not until_eof and not (wait_for_one_line and not output_observed):
+                if selected == []:
+                    break
+
             for key, events in selected:
                 # Read only single byte, otherwise we might block:
                 ch = key.fileobj.read(1)
@@ -365,19 +436,15 @@ class HlwmProcess:
                 if key.fileobj == self.proc.stderr:
                     stderr_bytes += ch
                     if ch == b'\n':
-                        stderr += stderr_bytes.decode()
-                        # Pass it through to the real stderr:
-                        key.data.write(stderr_bytes.decode())
-                        key.data.flush()
+                        output_observed = True
+                        feed_ready_byte_chunk(stderr_bytes, self.stderr_scanners, key.data)
                         stderr_bytes = b''
 
                 if key.fileobj == self.proc.stdout:
                     stdout_bytes += ch
                     if ch == b'\n':
-                        stdout += stdout_bytes.decode()
-                        # Pass it through to the real stdout:
-                        key.data.write(stdout_bytes.decode())
-                        key.data.flush()
+                        output_observed = True
+                        feed_ready_byte_chunk(stdout_bytes, self.stdout_scanners, key.data)
                         stdout_bytes = b''
 
             if until_eof:
@@ -388,28 +455,14 @@ class HlwmProcess:
                 else:
                     continue
 
-            if selected != []:
-                # There is still data available, so keep reading (no matter
-                # what):
-                continue
-
-            # But stop reading if there is nothing to look for or we have
-            # already found it:
-            if not expect_sth or match_found():
-                break
-
-        # decode remaining bytes for the final match_found() check
+        # decode remaining bytes
         if stderr_bytes != b'':
-            stderr += stderr_bytes.decode()
-            sys.stderr.write(stderr_bytes.decode())
-            sys.stderr.flush()
+            feed_ready_byte_chunk(stderr_bytes, self.stderr_scanners, sys.stderr)
         if stdout_bytes != b'':
-            stdout += stdout_bytes.decode()
-            sys.stdout.write(stdout_bytes.decode())
-            sys.stdout.flush()
+            feed_ready_byte_chunk(stdout_bytes, self.stdout_scanners, sys.stdout)
         duration = (datetime.now() - started).total_seconds()
-        if expect_sth and not match_found():
-            assert False, f'Expected string not encountered within {duration:.1f} seconds'
+        if wait_for_one_line and not output_observed:
+            assert False, f'Expected output not encountered within {duration:.1f} seconds.'
 
     @contextmanager
     def wait_stdout_match(self, match):
@@ -421,8 +474,9 @@ class HlwmProcess:
         unchecked_call(..., read_hlwm_output=False) instead
         """
         self.read_and_echo_output()
+        scanner = self.new_stdout_scanner(match)
         yield
-        self.read_and_echo_output(until_stdout=match)
+        self.wait_for_scanner_match(scanner)
 
     @contextmanager
     def wait_stderr_match(self, match):
@@ -434,8 +488,9 @@ class HlwmProcess:
         unchecked_call(..., read_hlwm_output=False) instead
         """
         self.read_and_echo_output()
+        scanner = self.new_stderr_scanner(match)
         yield
-        self.read_and_echo_output(until_stderr=match)
+        self.wait_for_scanner_match(scanner)
 
     def investigate_timeout(self, reason):
         """if some kind of client request observes a timeout, investigate the
@@ -815,7 +870,6 @@ class X11:
                               Xatom.CARDINAL,
                               32,
                               [pid])
-
         pre_map(w)
         w.map()
         pre_sync(w)

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -60,7 +60,7 @@ def test_no_autostart(xvfb):
     }
     env = conftest.extend_env_with_whitelist(env)
     hlwm_proc = HlwmProcess('', env, [])
-    hlwm_proc.read_and_echo_output(until_stderr='Will not run autostart file.')
+    hlwm_proc.read_and_echo_output_until_stderr('Will not run autostart file.')
     hlwm_proc.shutdown()
 
 

--- a/tests/test_ewmh.py
+++ b/tests/test_ewmh.py
@@ -141,7 +141,7 @@ def test_tags_restored_after_wmexec(hlwm, hlwm_process):
     p = hlwm.unchecked_call(['wmexec', hlwm_process.bin_path, '--verbose'],
                             read_hlwm_output=False)
     assert p.returncode == 0
-    hlwm_process.read_and_echo_output(until_stdout='hlwm started')
+    hlwm_process.read_and_echo_output_until_stdout('hlwm started')
 
     assert hlwm.list_children('tags.by-name') == sorted(expected_tags)
     for idx, name in enumerate(expected_tags):
@@ -219,7 +219,7 @@ def test_ewmh_set_current_desktop(hlwm, x11, swap_monitors_to_get_tag, on_anothe
         hlwm.call('add_monitor 800x600+800+0 otherTag')
 
     x11.ewmh.setCurrentDesktop(tag_idx)
-    x11.display.sync()
+    x11.sync_with_hlwm()
 
     assert int(hlwm.get_attr('tags.focus.index')) == tag_idx
     if swap_monitors_to_get_tag or not on_another_monitor or tag_idx == 0:
@@ -231,7 +231,7 @@ def test_ewmh_set_current_desktop(hlwm, x11, swap_monitors_to_get_tag, on_anothe
 def test_ewmh_set_current_desktop_invalid_idx(hlwm, hlwm_process, x11):
     with hlwm_process.wait_stderr_match('_NET_CURRENT_DESKTOP: invalid index'):
         x11.ewmh.setCurrentDesktop(4)
-        x11.display.sync()
+        x11.sync_with_hlwm()
     assert int(hlwm.get_attr('tags.focus.index')) == 0
 
 
@@ -273,7 +273,7 @@ def test_ewmh_focus_client(hlwm, x11):
     assert hlwm.get_attr('clients.focus.winid') == winid_focus
 
     x11.ewmh.setActiveWindow(winHandleToBeFocused)
-    x11.display.flush()
+    x11.sync_with_hlwm()
 
     assert hlwm.get_attr('clients.focus.winid') == winid
 
@@ -291,7 +291,7 @@ def test_ewmh_focus_client_on_other_tag(hlwm, x11, on_another_monitor):
     assert 'focus' not in hlwm.list_children('clients')
 
     x11.ewmh.setActiveWindow(handle)
-    x11.display.flush()
+    x11.sync_with_hlwm()
 
     assert hlwm.get_attr('tags.focus.name') == 'tag2'
     assert hlwm.get_attr('clients.focus.winid') == winid
@@ -304,7 +304,7 @@ def test_ewmh_move_client_to_tag(hlwm, x11):
     assert hlwm.get_attr(f'clients.{winid}.tag') == 'default'
 
     x11.ewmh.setWmDesktop(winHandleToMove, 1)
-    x11.display.sync()
+    x11.sync_with_hlwm()
 
     assert hlwm.get_attr(f'clients.{winid}.tag') == 'otherTag'
 
@@ -323,7 +323,7 @@ def test_ewmh_make_client_urgent(hlwm, hc_idle, x11):
 
     demandsAttent = '_NET_WM_STATE_DEMANDS_ATTENTION'
     x11.ewmh.setWmState(winHandle, 1, demandsAttent)
-    x11.display.flush()
+    x11.sync_with_hlwm()
 
     assert hlwm.get_attr(f'clients.{winid}.urgent') == 'true'
     assert ['tag_flags'] in hc_idle.hooks()
@@ -344,7 +344,7 @@ def test_ewmh_focused_client_never_urgent(hlwm, hc_idle, x11, focused):
     # mark the client urgent
     demandsAttent = '_NET_WM_STATE_DEMANDS_ATTENTION'
     x11.ewmh.setWmState(winHandle, 1, demandsAttent)
-    x11.display.flush()
+    x11.sync_with_hlwm()
 
     assert hlwm.get_attr(f'clients.{winid}.urgent') == hlwm.bool(not focused)
     assert (['urgent', 'on', winid] in hc_idle.hooks()) == (not focused)
@@ -359,7 +359,7 @@ def test_ewmh_make_client_urgent_no_focus_stealing(hlwm, hc_idle, x11):
     winHandle, winid = x11.create_client()
 
     x11.ewmh.setActiveWindow(winHandle)
-    x11.display.flush()
+    x11.sync_with_hlwm()
 
     assert hlwm.get_attr(f'clients.{winid}.urgent') == 'true'
     demandsAttent = '_NET_WM_STATE_DEMANDS_ATTENTION'
@@ -397,6 +397,7 @@ def test_minimize_via_xlib(hlwm, x11):
     assert hlwm.get_attr(f'clients.{winid}.minimized') == 'false'
 
     xiconifywindow(x11.display, winHandle, x11.screen)
+    x11.sync_with_hlwm()
 
     assert hlwm.get_attr(f'clients.{winid}.minimized') == 'true'
 
@@ -406,7 +407,7 @@ def test_unminimize_via_xlib(hlwm, x11):
     hlwm.call(f'set_attr clients.{winid}.minimized true')
 
     winHandle.map()
-    x11.display.flush()
+    x11.sync_with_hlwm()
 
     assert hlwm.get_attr(f'clients.{winid}.minimized') == 'false'
 

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -100,6 +100,7 @@ def test_herbstclient_wait(hlwm, num_hooks_sent, num_hooks_recv, repeat):
     # two hc-calls and hope that this gives hc --wait enough time to boot up.
     hlwm.call('true')
     hlwm.call('true')
+
     for _ in range(0, num_hooks_sent):
         hlwm.call('emit_hook nonmatch nonarg')
         hlwm.call('emit_hook matcher somearg')

--- a/tests/test_herbstluftwm.py
+++ b/tests/test_herbstluftwm.py
@@ -34,7 +34,7 @@ def test_wmexec_to_self(hlwm, hlwm_process, with_client, explicit_arg):
     p = hlwm.unchecked_call(['wmexec'] + args,
                             read_hlwm_output=False)
     assert p.returncode == 0
-    hlwm_process.read_and_echo_output(until_stdout='hlwm started')
+    hlwm_process.read_and_echo_output_until_stdout('hlwm started')
 
     assert hlwm.attr.settings.snap_gap() != 13
     if with_client:
@@ -56,9 +56,9 @@ def test_wmexec_failure(hlwm, hlwm_process, args, errormsg):
     assert p.returncode == 0
     # but the actual exec fails:
     expected_error = f'execvp "{args[0]}" failed: {errormsg}'
-    hlwm_process.read_and_echo_output(until_stderr=expected_error)
+    hlwm_process.read_and_echo_output_until_stderr(expected_error)
     # and so hlwm does the exec to itself:
-    hlwm_process.read_and_echo_output(until_stdout='hlwm started')
+    hlwm_process.read_and_echo_output_until_stdout('hlwm started')
 
     assert hlwm.attr.settings.snap_gap() != 13
 

--- a/tests/test_meta_commands.py
+++ b/tests/test_meta_commands.py
@@ -658,9 +658,8 @@ def test_setenv_and_spawn(hlwm, hlwm_process):
     hlwm.call(['setenv', 'FOO', 'bar'])
 
     hlwm_process.read_and_echo_output()
-    hlwm.unchecked_call(['spawn', 'sh', '-c', 'echo FOO is $FOO .'],
-                        read_hlwm_output=False)
-    hlwm_process.read_and_echo_output(until_stdout='FOO is bar .')
+    with hlwm_process.wait_stdout_match('FOO is bar .'):
+        hlwm.call(['spawn', 'sh', '-c', 'echo FOO is $FOO .'])
 
 
 def test_setenv_completion_existing_var(hlwm):


### PR DESCRIPTION
Before, running an ordinary hlwm.call() in a wait_stdout_match() context
consumed the token we were waiting for, making to context fail.

The present change fixes this by improves read_and_echo_output() to
support scanning for multiple tokens at the same time. This makes the
wait_stdout_match() contexts much easier to use.