### PR TITLE
Rename debug-css to debug_css

### DIFF
--- a/src/css.cpp
+++ b/src/css.cpp
@@ -377,13 +377,13 @@ void debugCssCommand(CallOrComplete invoc)
     bool treeIndexPresent = false;
     vector<int> treeIndex = {};
     ArgParse ap;
-    ap.mandatory(cssSource);
     ap.flags({
         {"--print-css", &print },
         {"--tree=", tree },
         {"--print-tree", &printTree },
         {"--query-tree-indices=", cssSelectorStr },
         {"--compute-style=", treeIndex, &treeIndexPresent},
+        {"--stylesheet=", cssSource },
     });
     ap.command(invoc,
         [&] (Output output) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -236,7 +236,7 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                        &Watchers::watchCompletion }},
         {"mktemp",         { tmp, &Tmp::mktemp,
                                   &Tmp::mktempComplete }},
-        {"debug-css",      { &debugCssCommand } },
+        {"debug_css",      { &debugCssCommand } },
     };
     return unique_ptr<CommandTable>(new CommandTable(init));
 }


### PR DESCRIPTION
This makes the command name fit to the usual underscore-separated style
used in hlwm. Also, this turns the stylesheet parameter into an optional
flag `--stylesheet=...`.