### PR TITLE
Css: Only load font when needed

### DIFF
--- a/src/boxstyle.cpp
+++ b/src/boxstyle.cpp
@@ -371,6 +371,16 @@ void CssValueParser::foreachParser(function<void (const CssValueParser&)> loopBo
     }
 }
 
+HSFont BoxStyle::getFont() const
+{
+    return font.cases<HSFont>(
+    [](const Unit<BoxStyle::initial>& u) {
+        return HSFont::defaultFont();
+    }, [](const HSFont& f) {
+        return f;
+    });
+}
+
 std::map<string, string> BoxStyle::changedProperties() const
 {
     std::map<string,string> properties;

--- a/src/boxstyle.cpp
+++ b/src/boxstyle.cpp
@@ -13,6 +13,7 @@ using std::vector;
 const char BoxStyle::auto_[] = "auto";
 const char BoxStyle::solid[] = "solid";
 const char BoxStyle::transparent[] = "transparent";
+const char BoxStyle::initial[] = "initial";
 
 std::map<string, CssValueParser> CssValueParser::propName2Parser_;
 

--- a/src/boxstyle.h
+++ b/src/boxstyle.h
@@ -92,6 +92,8 @@ public:
     Either<Unit<auto_>,CssLen> textHeight = Unit<auto_>();
     Either<Unit<initial>,HSFont> font = Unit<initial>();
 
+    HSFont getFont() const;
+
     std::map<std::string, std::string> changedProperties() const;
     static const BoxStyle empty() {
         return {};

--- a/src/boxstyle.h
+++ b/src/boxstyle.h
@@ -44,6 +44,7 @@ public:
     static const char auto_[];
     static const char solid[];
     static const char transparent[];
+    static const char initial[];
 
     Either<Unit<transparent>,Color> backgroundColor = Unit<transparent>();
 
@@ -89,7 +90,7 @@ public:
     TextAlign textAlign = TextAlign::left;
     Either<Unit<auto_>,CssLen> textDepth = Unit<auto_>();
     Either<Unit<auto_>,CssLen> textHeight = Unit<auto_>();
-    HSFont font = HSFont::fromStr("");
+    Either<Unit<initial>,HSFont> font = Unit<initial>();
 
     std::map<std::string, std::string> changedProperties() const;
     static const BoxStyle empty() {

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -59,7 +59,7 @@ HSFont HSFont::fromStr(const string& source)
 HSFont HSFont::defaultFont()
 {
     HSFont font;
-    string fontSource = "size=7";
+    string fontSource = ":size=7";
     if (s_defaultFont) {
         font.fontData_ = s_defaultFont;
         font.source_ = fontSource;

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -75,6 +75,11 @@ HSFont HSFont::defaultFont()
     }
 }
 
+void HSFont::shutdown()
+{
+    s_defaultFont.reset();
+}
+
 HSFont::HSFont()
 {
 }

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -28,6 +28,12 @@ Finite<TextAlign>::ValueList Finite<TextAlign>::values = ValueListPlain {
 std::map<string, weak_ptr<FontData>> HSFont::s_fontDescriptionToData;
 
 /**
+ * @brief remember a default font, which is used whenever text needs
+ * to be drawn, without any concrete font provided.
+ */
+std::shared_ptr<FontData> HSFont::s_defaultFont;
+
+/**
  * @brief Create a FontData object. If the font description
  * is invalid or the font is not found, an exception is thrown.
  * @param The font description as the user would enter it
@@ -48,6 +54,20 @@ HSFont HSFont::fromStr(const string& source)
     font.source_ = source;
     font.fontData_ = data;
     return font;
+}
+
+HSFont HSFont::defaultFont()
+{
+    if (s_defaultFont) {
+        HSFont font;
+        font.fontData_ = s_defaultFont;
+        font.source_ = "";
+        return font;
+    } else {
+        HSFont font = fromStr("*");
+        s_defaultFont = font.fontData_;
+        return font;
+    }
 }
 
 HSFont::HSFont()

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -58,13 +58,18 @@ HSFont HSFont::fromStr(const string& source)
 
 HSFont HSFont::defaultFont()
 {
+    HSFont font;
+    string fontSource = "size=7";
     if (s_defaultFont) {
-        HSFont font;
         font.fontData_ = s_defaultFont;
-        font.source_ = "";
+        font.source_ = fontSource;
         return font;
     } else {
-        HSFont font = fromStr("*");
+        font.fontData_ = make_shared<FontData>();
+        try {
+            font = fromStr(fontSource);
+        } catch (const std::exception&) {
+        }
         s_defaultFont = font.fontData_;
         return font;
     }

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -31,7 +31,7 @@ std::map<string, weak_ptr<FontData>> HSFont::s_fontDescriptionToData;
  * @brief remember a default font, which is used whenever text needs
  * to be drawn, without any concrete font provided.
  */
-std::shared_ptr<FontData> HSFont::s_defaultFont;
+shared_ptr<FontData> HSFont::s_defaultFont;
 
 /**
  * @brief Create a FontData object. If the font description

--- a/src/font.h
+++ b/src/font.h
@@ -34,6 +34,7 @@ class HSFont
 {
 public:
     static HSFont fromStr(const std::string& source);
+    static HSFont defaultFont();
     std::string str() { return source_; }
     bool operator==(const HSFont& o) const {
         return source_ == o.source_;
@@ -47,6 +48,7 @@ private:
     std::string source_;
     std::shared_ptr<FontData> fontData_;
     static std::map<std::string, std::weak_ptr<FontData>> s_fontDescriptionToData;
+    static std::shared_ptr<FontData> s_defaultFont;
 };
 
 

--- a/src/font.h
+++ b/src/font.h
@@ -43,6 +43,7 @@ public:
         return source_ != o.source_;
     }
     FontData& data() const { return *fontData_; }
+    static void shutdown();
 private:
     HSFont();
     std::string source_;

--- a/src/fontdata.cpp
+++ b/src/fontdata.cpp
@@ -29,23 +29,46 @@ void FontData::initFromStr(const string& source)
     if (!s_xconnection) {
         throw std::invalid_argument("X connection not established yet!");
     }
+    XConnection& xcon = *s_xconnection;
+    bool suc = false;
+    suc = suc || loadXftFont(xcon, source);
+    suc = suc || loadXFontSet(xcon, source);
+    suc = suc || loadXFontStruct(xcon, source);
+    if (!suc) {
+        throw std::invalid_argument(
+                string("cannot allocate font \'") + source + "\'");
+    }
+}
+
+bool FontData::loadXftFont(XConnection& xcon, const string& source)
+{
     // if the font starts with a '-', then treat it as a XLFD and
     // don't pass it to xft
     if (!source.empty() && source[0] != '-') {
-        xftFont_ = XftFontOpenName(s_xconnection->display(),
-                                   s_xconnection->screen(),
+        xftFont_ = XftFontOpenName(xcon.display(),
+                                   xcon.screen(),
                                    source.c_str());
     }
     if (xftFont_) {
         ascent = xftFont_->ascent;
         descent = xftFont_->descent;
-        return;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool FontData::loadXFontSet(XConnection& xcon, const string& source)
+{
+    if (source.empty()) {
+        // empty string crashes XCreateFontSet()
+        return false;
     }
     // fall back to plain X fonts with unicode support
     char** missingCharSetList = nullptr;
     int missingCharSetCount = 0;
     char* defString = nullptr;
-    xFontSet_ = XCreateFontSet(s_xconnection->display(), source.c_str(),
+    xFontSet_ = XCreateFontSet(xcon.display(), source.c_str(),
                                &missingCharSetList, &missingCharSetCount,
                                &defString);
     stringstream msg;
@@ -71,21 +94,24 @@ void FontData::initFromStr(const string& source)
         // for a baseline at (0,0)
         ascent = -overallInk.y;
         descent = overallInk.height + overallInk.y;
-        return;
+        return true;
     } else {
         if (missingCharSetCount > 0) {
             throw std::invalid_argument(msg.str());
         }
     }
+    return false;
+}
 
-    xFontStruct_ = XLoadQueryFont(s_xconnection->display(), source.c_str());
+bool FontData::loadXFontStruct(XConnection& xcon, const string& source)
+{
+    xFontStruct_ = XLoadQueryFont(xcon.display(), source.c_str());
     if (xFontStruct_) {
         ascent = xFontStruct_->ascent;
         descent = xFontStruct_->descent;
-        return;
+        return true;
     }
-    throw std::invalid_argument(
-            string("cannot allocate font \'") + source + "\'");
+    return false;
 }
 
 /**

--- a/src/fontdata.cpp
+++ b/src/fontdata.cpp
@@ -26,9 +26,6 @@ FontData::~FontData() {
 //! try to parse a font description or throw an exception
 void FontData::initFromStr(const string& source)
 {
-    if (source.empty()) {
-        return;
-    }
     if (!s_xconnection) {
         throw std::invalid_argument("X connection not established yet!");
     }

--- a/src/fontdata.h
+++ b/src/fontdata.h
@@ -29,4 +29,10 @@ public:
 
     static XConnection* s_xconnection;
 private:
+    // loaders for different fonts. They load the font into the
+    // pointers above, and return a boolean indicating success.
+    // on error, they may still throw an exception
+    bool loadXftFont(XConnection& xcon, const std::string& source);
+    bool loadXFontSet(XConnection& xcon, const std::string& source);
+    bool loadXFontStruct(XConnection& xcon, const std::string& source);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "commandio.h"
 #include "css.h"
 #include "ewmh.h"
+#include "font.h"
 #include "fontdata.h"
 #include "frametree.h"
 #include "globalcommands.h"
@@ -454,6 +455,7 @@ int main(int argc, char* argv[]) {
     root.reset();
     Root::setRoot(root);
     // and then close the x connection
+    HSFont::shutdown();
     FontData::s_xconnection = nullptr;
     delete ipcServer;
     delete ewmh;

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -108,10 +108,15 @@ void Widget::computeMinimumSize()
 
     Point2D textSize = {0, 0};
     if (textContent_) {
-        FontData& data = style.font.data();
+        HSFont font = style.font.cases<HSFont>(
+        [](const Unit<BoxStyle::initial>& u) {
+            return HSFont::defaultFont();
+        }, [](const HSFont& font) {
+            return font;
+        });
         textSize.y =
-                style.textHeight.rightOr(data.ascent)
-                + style.textDepth.rightOr(data.descent);
+                style.textHeight.rightOr(font.data().ascent)
+                + style.textDepth.rightOr(font.data().descent);
     }
     minimumSizeCached_ = surroundingsSize +
             Point2D::fold(

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -108,12 +108,7 @@ void Widget::computeMinimumSize()
 
     Point2D textSize = {0, 0};
     if (textContent_) {
-        HSFont font = style.font.cases<HSFont>(
-        [](const Unit<BoxStyle::initial>& u) {
-            return HSFont::defaultFont();
-        }, [](const HSFont& font) {
-            return font;
-        });
+        HSFont font = style.getFont();
         textSize.y =
                 style.textHeight.rightOr(font.data().ascent)
                 + style.textDepth.rightOr(font.data().descent);

--- a/src/x11-widgetrender.cpp
+++ b/src/x11-widgetrender.cpp
@@ -92,12 +92,18 @@ void X11WidgetRender::render(const Widget& widget)
     if (widget.textContent_) {
         Rectangle contentGeo = widget.contentGeometryCached();
         Point2D textPos = contentGeo.tl();
-        int textHeight = style.textHeight.rightOr(style.font.data().ascent);
-        int textDepth = style.textDepth.rightOr(style.font.data().descent);
+        HSFont font = style.font.cases<HSFont>(
+        [](const Unit<BoxStyle::initial>& u) {
+            return HSFont::defaultFont();
+        }, [](const HSFont& font) {
+            return font;
+        });
+        int textHeight = style.textHeight.rightOr(font.data().ascent);
+        int textDepth = style.textDepth.rightOr(font.data().descent);
         int extraSpace = contentGeo.height - textHeight - textDepth;
         textPos.y += extraSpace / 2 + textHeight;
         if (textHeight != 0) {
-            drawText(pixmap_, gc_, style.font.data(), style.fontColor,
+            drawText(pixmap_, gc_, font.data(), style.fontColor,
                      textPos - pixmapPos_, widget.textContent_(), contentGeo.width, style.textAlign);
         }
     }

--- a/src/x11-widgetrender.cpp
+++ b/src/x11-widgetrender.cpp
@@ -92,12 +92,7 @@ void X11WidgetRender::render(const Widget& widget)
     if (widget.textContent_) {
         Rectangle contentGeo = widget.contentGeometryCached();
         Point2D textPos = contentGeo.tl();
-        HSFont font = style.font.cases<HSFont>(
-        [](const Unit<BoxStyle::initial>& u) {
-            return HSFont::defaultFont();
-        }, [](const HSFont& f) {
-            return f;
-        });
+        HSFont font = style.getFont();
         int textHeight = style.textHeight.rightOr(font.data().ascent);
         int textDepth = style.textDepth.rightOr(font.data().descent);
         int extraSpace = contentGeo.height - textHeight - textDepth;

--- a/src/x11-widgetrender.cpp
+++ b/src/x11-widgetrender.cpp
@@ -95,8 +95,8 @@ void X11WidgetRender::render(const Widget& widget)
         HSFont font = style.font.cases<HSFont>(
         [](const Unit<BoxStyle::initial>& u) {
             return HSFont::defaultFont();
-        }, [](const HSFont& font) {
-            return font;
+        }, [](const HSFont& f) {
+            return f;
         });
         int textHeight = style.textHeight.rightOr(font.data().ascent);
         int textDepth = style.textDepth.rightOr(font.data().descent);

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -238,6 +238,11 @@ def test_css_property_applier(hlwm):
         border-left-width: 5px;
         """,
         'display: flex': '',  # flex is the default
+        'font: initial': '',
+        'font: sans; font: initial': '',  # initial is the default
+        'font: fixed': """\
+        font: fixed;
+        """,
     }
     simple_props = [
         'min-height: 5px',

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -94,7 +94,7 @@ def test_tight_decoration(hlwm, tight_dec):
 
 
 def test_font_type_existing_font(hlwm):
-    for value in ['*FIXED*', '*FiXed*', 'fixed']:
+    for value in ['*FIXED*', '*FiXed*', 'fixed', 'monospace:14', 'serif:bold:12']:
         hlwm.call(['set_attr', 'theme.title_font', value])
 
         assert hlwm.attr.theme.title_font() == value
@@ -247,4 +247,4 @@ def test_tabs_cleared_in_floating(hlwm, x11):
 
 def test_font_not_empty(hlwm):
     hlwm.call_xfail("set_attr theme.title_font ''") \
-        .expect_stderr("unknown font description")
+        .expect_stderr("cannot allocate font ''")

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -106,6 +106,11 @@ def test_font_type_non_existing_font(hlwm):
         .expect_stderr(f"(cannot allocate font.*'{value}'|{value}.*The following charsets are unknown)")
 
 
+def test_font_not_empty(hlwm):
+    hlwm.call_xfail("set_attr theme.title_font ''") \
+        .expect_stderr("cannot allocate font ''")
+
+
 @pytest.mark.parametrize("floating", [True, False])
 def test_decoration_geometry_vs_content_geometry(hlwm, floating):
     hlwm.attr.tags.focus.floating = floating
@@ -243,8 +248,3 @@ def test_tabs_cleared_in_floating(hlwm, x11):
 
     assert hlwm.attr.clients[w2].floating_geometry() \
         == hlwm.attr.clients[w2].content_geometry()
-
-
-def test_font_not_empty(hlwm):
-    hlwm.call_xfail("set_attr theme.title_font ''") \
-        .expect_stderr("cannot allocate font ''")

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -243,3 +243,8 @@ def test_tabs_cleared_in_floating(hlwm, x11):
 
     assert hlwm.attr.clients[w2].floating_geometry() \
         == hlwm.attr.clients[w2].content_geometry()
+
+
+def test_font_not_empty(hlwm):
+    hlwm.call_xfail("set_attr theme.title_font ''") \
+        .expect_stderr("unknown font description")

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -248,3 +248,33 @@ def test_tabs_cleared_in_floating(hlwm, x11):
 
     assert hlwm.attr.clients[w2].floating_geometry() \
         == hlwm.attr.clients[w2].content_geometry()
+
+
+def test_font_initial(hlwm):
+    hlwm.attr.theme.name = '/dev/null'
+    # compute title bar height for a very small font
+    hlwm.attr.theme.style_override = """
+    * {
+        font: :size=1;
+    }
+    """
+    winid, _ = hlwm.create_client()
+    content = hlwm.attr.clients[winid].content_geometry()
+    dec = hlwm.attr.clients[winid].decoration_geometry()
+    title_height_before = content.y - dec.y
+
+    # compute title bar height for 'initial' font
+    hlwm.attr.theme.style_override = """
+    * {
+        font: initial;
+    }
+    """
+    winid, _ = hlwm.create_client()
+    content = hlwm.attr.clients[winid].content_geometry()
+    dec = hlwm.attr.clients[winid].decoration_geometry()
+    title_height_after = content.y - dec.y
+
+    # we assume that the 'initial' font is bigger than just the smallest
+    # font picked before. In particular, if the assertion passes, we know that
+    # window titles are shown:
+    assert title_height_before < title_height_after

--- a/themes/separate-tabs.css
+++ b/themes/separate-tabs.css
@@ -102,9 +102,24 @@
     color: #4C284C;
 }
 
+/** hide decoration for minimal and fullscreen clients */
+.client-decoration.minimal .panel ,
+.client-decoration.fullscreen .panel {
+    display: none;
+}
+
+.client-decoration.minimal ,
+.client-decoration.fullscreen ,
+.client-decoration.fullscreen > * {
+    border-width: 0px;
+    background-color: black;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 * {
-    font: -*-fixed-medium-r-*-*-13-*-*-*-*-*-*-*;
+    /* font: -*-fixed-medium-r-*-*-13-*-*-*-*-*-*-*; */
     /* font: Dejavu Sans:pixelsize=12; */
 }
 

--- a/themes/separate-tabs.css
+++ b/themes/separate-tabs.css
@@ -102,24 +102,3 @@
     color: #4C284C;
 }
 
-/** hide decoration for minimal and fullscreen clients */
-.client-decoration.minimal .panel ,
-.client-decoration.fullscreen .panel {
-    display: none;
-}
-
-.client-decoration.minimal ,
-.client-decoration.fullscreen ,
-.client-decoration.fullscreen > * {
-    border-width: 0px;
-    background-color: black;
-    padding: 0px;
-    margin: 0px;
-}
-
-
-* {
-    /* font: -*-fixed-medium-r-*-*-13-*-*-*-*-*-*-*; */
-    /* font: Dejavu Sans:pixelsize=12; */
-}
-


### PR DESCRIPTION
Introduce a new default value for fonts 'initial'. The value resolves to
an arbitrary font in the rare occassion that it is actually used for
rendering text. By this, we fix the following:

  1. the empty string "" should not be a valid font description.
  2. shared pointers of FontData objects (for "") should not be copied
     all over the place when BoxStyles are inherited.