### PR TITLE
Make geometry based panel detection an attribute

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -5,6 +5,16 @@ This guide describes the list of incompatible changes between the different
 herbstluftwm releases and how to migrate scripts and configuration.
 See the link:NEWS[] file for a list of all changes and new features.
 
+0.9.5 to current git version
+----------------------------
+The geometry based detection of panels now is only active if the setting
+'panels.geometry_fallback' is activated. In order to restore the old behaviour,
+put
+
+    hc set_attr panels.geometry_fallback on
+
+in your autostart.
+
 0.9.4 to 0.9.5
 --------------
 The command 'smart_frame_surroundings' is no longer a boolean, and as such it is

--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,7 @@ Release 0.9.5 on 2022-07-30
   * New frame attribute 'content_geometry'
   * New tag attribute 'at_end'
   * New monitor attribute 'content_geometry'
+  * New attribute 'panels.geometry_fallback'
   * Fix bug in ipc protocol for big-endian systems
 
 Release 0.9.4 on 2022-03-16

--- a/src/panelmanager.h
+++ b/src/panelmanager.h
@@ -45,6 +45,7 @@ public:
     Signal panels_changed_;
     void rootWindowChanged(int width, int height);
     DynAttribute_<unsigned long> count;
+    Attribute_<bool> geometryFallback_;
 private:
     friend Panel;
     unsigned long getCount() {

--- a/src/signal.h
+++ b/src/signal.h
@@ -23,7 +23,14 @@ public:
 
     // connect signal to slot
     void connect(const Signal& slot) {
-        slots_0arg_.push_back(std::bind(&Signal::emit, slot));
+        slots_0arg_.push_back([&slot]() { slot.emit(); });
+        // WARNING: above lambda must not be replaced with a
+        // bind function:
+        //
+        //      slots_0arg_.push_back(std::bind(&Signal::emit, slot));
+        //
+        // because Signal::emit is virtual, so the wrong function
+        // may be called!
     }
 
     // emit the signal

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -186,7 +186,7 @@ def test_completable_commands(hlwm, request, run_destructives):
         # the command mentions a destructive command,
         # if and only if the sets are not disjoint
         mentions_destructive_command = \
-            not(destructive_commands.isdisjoint(set(command)))
+            not (destructive_commands.isdisjoint(set(command)))
         if mentions_destructive_command != run_destructives:
             # run commands involving destructive commands
             # iff run_destructives is set, and skip otherwise


### PR DESCRIPTION
If a panel does not define _NET_WM_STRUT, we formerly just used it's window size for determining the reserved space at the screen edge. This caused issues such as #1475. By making it a setting, only those users who really need it can activate it.

While at it, I've fixed a bug in `Signal::connect()` arising from a wrong use of `std::bind()`.

This closes #1475 and #1175.