### PR TITLE
Add missing doc for show_frame_decorations = all

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -284,7 +284,8 @@ Settings::Settings()
                 "- \'if_multiple\' shows decorations on the tags with at least two frames, \n"
                 "- \'if_empty\' shows decorations of frames that have no client windows, \n"
                 "- \'focused\' shows the decoration of focused and nonempty frames, \n"
-                "- \'focused_if_multiple\' shows decorations of focused and non-empty frames on tags with at least two frames."
+                "- \'focused_if_multiple\' shows decorations of focused and non-empty frames on tags with at least two frames.\n"
+                "- \'all\' shows all frame decorations."
                 );
 
     frame_active_opacity.setDoc(


### PR DESCRIPTION
This just adds the so-far missing documentation of the value 'all' of settings.show_frame_decorations.