### PR TITLE
Re-enable using double hyphens before rule options

### DIFF
--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -32,6 +32,7 @@ int RuleManager::parseRule(Input input, Output output, Rule& rule, bool& prepend
 
     for (auto argIter = input.begin(); argIter != input.end(); argIter++) {
         auto arg = *argIter;
+        arg = stripDoubleHyphens(arg);
 
         // Whether this argument is negated (only applies to conditions)
         bool negated = false;
@@ -53,6 +54,7 @@ int RuleManager::parseRule(Input input, Output output, Rule& rule, bool& prepend
             // Skip forward to next argument, but remember that it is negated:
             negated = true;
             arg = *(++argIter);
+            arg = stripDoubleHyphens(arg);
         }
 
         if (arg == "fixedsize") {
@@ -204,11 +206,14 @@ size_t RuleManager::removeRules(string label) {
     return countAfter - countBefore;
 }
 
-std::tuple<string, char, string> RuleManager::tokenizeArg(string arg) {
+std::string RuleManager::stripDoubleHyphens(string arg) {
     if (arg.substr(0, 2) == "--") {
         arg.erase(0, 2);
     }
+    return arg;
+}
 
+std::tuple<string, char, string> RuleManager::tokenizeArg(string arg) {
     auto operPos = arg.find_first_of("~=");
     if (operPos == string::npos) {
         throw std::invalid_argument("No operator in given arg: " + arg);

--- a/src/rulemanager.cpp
+++ b/src/rulemanager.cpp
@@ -206,7 +206,7 @@ size_t RuleManager::removeRules(string label) {
     return countAfter - countBefore;
 }
 
-std::string RuleManager::stripDoubleHyphens(string arg) {
+string RuleManager::stripDoubleHyphens(string arg) {
     if (arg.substr(0, 2) == "--") {
         arg.erase(0, 2);
     }

--- a/src/rulemanager.h
+++ b/src/rulemanager.h
@@ -18,7 +18,7 @@ public:
 
 private:
     size_t removeRules(std::string label);
-	static std::string stripDoubleHyphens(std::string arg);
+    static std::string stripDoubleHyphens(std::string arg);
     static std::tuple<std::string, char, std::string> tokenizeArg(std::string arg);
 
     //! Ever-incrementing index for labeling new rules

--- a/src/rulemanager.h
+++ b/src/rulemanager.h
@@ -18,6 +18,7 @@ public:
 
 private:
     size_t removeRules(std::string label);
+	static std::string stripDoubleHyphens(std::string arg);
     static std::tuple<std::string, char, std::string> tokenizeArg(std::string arg);
 
     //! Ever-incrementing index for labeling new rules

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -51,10 +51,12 @@ def test_add_simple_rule(hlwm):
 
 
 def test_add_simple_rule_with_dashes(hlwm):
-    hlwm.call('rule --class=Foo --tag=bar')
+    for negation in ['not', '--not', '!', '--!']:
+        hlwm.call('unrule --all')
+        hlwm.call(f'rule {negation} --class=Foo --tag=bar')
 
-    rules = hlwm.call('list_rules')
-    assert rules.stdout == 'label=0\tclass=Foo\ttag=bar\t\n'
+        rules = hlwm.call('list_rules')
+        assert rules.stdout == 'label=0\tnot\tclass=Foo\ttag=bar\t\n'
 
 
 def test_add_many_labeled_rules(hlwm):
@@ -166,6 +168,15 @@ def test_remove_nonexistent_rule(hlwm):
 
 def test_singleuse_rule_disappears_after_matching(hlwm):
     hlwm.call('rule once hook=dummy_hook')
+    assert hlwm.call('list_rules').stdout != ''
+
+    hlwm.create_client()
+
+    assert hlwm.call('list_rules').stdout == ''
+
+    # and the same with --once
+    hlwm.call('rule --once --hook=dummy_hook')
+    assert hlwm.call('list_rules').stdout != ''
 
     hlwm.create_client()
 


### PR DESCRIPTION
Previously, double hyphens were stripped in the tokenizeArg function which is only called after checking if the argument is "prepend", "once", "printlabel", "not", "!", or "fixedwidth". This failed to match on "--once", "--prepend", etc..., so the argument is eventually passed to tokenizeArg. But tokenizeArg expects all of its arguments to contain a = or ~ (everything else was supposed to be handled already). This resulted in an error.

Now, the stripping of hyphens is done at the beginning of rule parsing, and after manually moving the loop pointer for "not" and "!".

This closes #1487