### PR TITLE
Fix crash in debug_css

### DIFF
--- a/src/css.cpp
+++ b/src/css.cpp
@@ -252,8 +252,9 @@ DummyTree::Ptr Converter<DummyTree::Ptr>::parse(const string& source) {
 template<>
 string Converter<DummyTree::Ptr>::str(DummyTree::Ptr payload) {
     stringstream output;
-
-    payload->print(output);
+    if (payload) {
+        payload->print(output);
+    }
     return output.str();
 }
 
@@ -375,7 +376,7 @@ void debugCssCommand(CallOrComplete invoc)
 {
     string cssSource;
     bool print = false, printTree = false;
-    DummyTree::Ptr tree;
+    DummyTree::Ptr tree = {};
     string cssSelectorStr;
     bool treeIndexPresent = false;
     vector<int> treeIndex = {};
@@ -412,6 +413,10 @@ void debugCssCommand(CallOrComplete invoc)
                 file.print(output.output());
             }
             if (printTree) {
+                if (!tree) {
+                    output.error() << "printing requires a tree";
+                    return 1;
+                }
                 output << Converter<DummyTree::Ptr>::str(tree) << endl;
             }
             if (client) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,7 +164,7 @@ class HlwmBridge(herbstluftwm.Herbstluftwm):
 
         return winid, proc
 
-    def complete(self, cmd, partial=False, position=None, evaluate_escapes=False):
+    def complete(self, cmd, partial=False, position=None, evaluate_escapes=False, checked_call=True):
         """
         Return a sorted list of all completions for the next argument for the
         given command, if position=None. If position is given, then the
@@ -176,11 +176,18 @@ class HlwmBridge(herbstluftwm.Herbstluftwm):
         Set 'evaluate_escapes' if the escape sequences of completion items
         should be evaluated. If this is set, one cannot distinguish between
         partial and full completion results anymore.
+
+        If 'checked_call' is activated, then the exit code of the completion
+        command is checked to be zero.
         """
         args = self._parse_command(cmd)
         if position is None:
             position = len(args)
-        proc = self.call(['complete_shell', position] + args)
+        completion_command = ['complete_shell', position] + args
+        if checked_call:
+            proc = self.call(completion_command)
+        else:
+            proc = self.unchecked_call(completion_command)
         items = []
         for i in proc.stdout.splitlines(False):
             if partial:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -201,6 +201,28 @@ def test_completable_commands(hlwm, request, run_destructives):
             "Running " + ' '.join(command)
 
 
+@pytest.mark.exclude_from_coverage(
+    reason='This test does not verify functionality but only whether the \
+    commands can be called at all.')
+def test_every_arg_for_every_command(hlwm):
+    hlwm.open_persistent_pipe()
+
+    commands = []
+    # for cmdname in hlwm.call(['complete', '0']).stdout.splitlines():
+    for cmdname in ['debug_css']:
+        if cmdname not in ['wmexec', 'quit']:
+            for arg in hlwm.complete([cmdname], partial=True, checked_call=False):
+                if arg.endswith(' '):
+                    arg = arg[:-1]  # drop trailing ' '
+                commands.append([cmdname, arg])
+
+    assert ['debug_css', '--print-tree'] in commands
+    assert ['debug_css', '--print-css'] in commands
+
+    for cmd in commands:
+        hlwm.unchecked_call(cmd)
+
+
 def test_inputless_commands(hlwm):
     global commands_without_input
     hlwm.open_persistent_pipe()

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -460,3 +460,9 @@ def test_toplevel_css_classes_toplevel_client(hlwm):
         for r, expected in regexes.items():
             assert bool(re.search(r, output)) is expected, \
                 f'Checking that regex "{r}" is {expected}'
+
+
+def test_debug_css_basic_flags_dont_crash(hlwm):
+    hlwm.call_xfail(['debug_css', '--print-tree']) \
+        .expect_stderr('requires a tree')
+    assert hlwm.call(['debug_css', '--print-css']).stdout == ''


### PR DESCRIPTION
This fixes a crash of a nullptr dereference in debug_css if it is called with --print-tree but without a tree.