### PR TITLE
Stick to old python-xlib in CI until bugfix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,15 +24,14 @@ skipsdist = true
 # repository anyway)
 commands =
     pip install ./python/
-    # pin python-xlib to version 0.31 until the issue
-    # https://github.com/python-xlib/python-xlib/pull/242
-    # is fixed.
-    pip install --force-reinstall -v "python-xlib==0.31"
     {envpython} -m pytest {posargs}
 deps =
     ewmh
     pytest-xdist
-    python-xlib
+    # pin python-xlib to version 0.31 until the issue
+    # https://github.com/python-xlib/python-xlib/pull/242
+    # is fixed.
+    python-xlib==0.31
     ./python/
 
 ; Pass $PWD as it is when tox is invoked to pytest (used to find hlwm binaries)

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,10 @@ skipsdist = true
 # repository anyway)
 commands =
     pip install ./python/
+    # pin python-xlib to version 0.31 until the issue
+    # https://github.com/python-xlib/python-xlib/pull/242
+    # is fixed.
+    pip install --force-reinstall -v "python-xlib==0.31"
     {envpython} -m pytest {posargs}
 deps =
     ewmh


### PR DESCRIPTION
In python-xlib 0.32, the bug https://github.com/python-xlib/python-xlib/pull/242 was introduced which caused `test_floatplacement_smart_create_many` to fail deterministically. There already is a pull request in `python-xlib` with a fix, but it is not merged yet. So for the time being, let's simply use the old python-xlib version.