### PR TITLE
Add masterstack layout

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ doxygen-html/
 # ignore various other IDE config dirs
 .vscode/
 .idea/
+
+.direnv

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -394,6 +394,18 @@ class ObjectInformation:
             self.user_name = cpp_token
 
         def set_default_value(self, cpp_token):
+            def split_args(tokens):
+                chunks = []
+                current = []
+                for tok in tokens + [',']:
+                    if tok == ',':
+                        if current:
+                            chunks.append(current)
+                        current = []
+                    else:
+                        current.append(tok)
+                return chunks
+
             if TokenGroup.IsTokenGroup(cpp_token):
                 # drop surrounding '{' ... '}' if its an initializer list
                 if len(cpp_token.enclosed_tokens) == 0:
@@ -408,6 +420,12 @@ class ObjectInformation:
                 # assume that the next token in the list 'cpp_token' is a
                 # token group
                 cpp_token = cpp_token[4].enclosed_tokens[0]
+            if cpp_token[1:4] == [':', ':', 'approxFrac']:
+                approx_args = split_args(cpp_token[4].enclosed_tokens)
+                if len(approx_args) == 2:
+                    numerator = int(''.join(approx_args[0]))
+                    denominator = int(''.join(approx_args[1]))
+                    cpp_token = str(numerator / denominator)
             if len(cpp_token) == 4 and cpp_token[1:3] == [':', ':']:
                 # if the token is: EnumClass::value
                 cpp_token = cpp_token[3]

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -68,6 +68,8 @@ exactly one of the following conditions:
         * 'horizontal' - clients are placed next to each other
         * 'max' - all clients are maximized in this frame
         * 'grid' - clients are arranged in an almost quadratic grid
+        * 'masterstack' - the first client gets a larger master area and all
+          remaining clients are stacked in the remaining area
 
     . Frame is split into subframes: +
         It is split into exactly two *subframes* in a configurable 'fraction'

--- a/doc/herbstluftwm.txt
+++ b/doc/herbstluftwm.txt
@@ -848,6 +848,13 @@ fullscreen [*on*|*off*|*toggle*]::
     Sets or toggles the fullscreen state of the focused client. If no argument
     is given, fullscreen mode is toggled.
 
+maximize [*on*|*off*|*toggle*]::
+    Sets or toggles the maximized state of the focused client. A maximized
+    client covers the entire usable area of its monitor, similar to
+    +fullscreen+, but panels stay visible and the client keeps its window
+    border. The maximized and fullscreen states are mutually exclusive. If no
+    argument is given, maximized mode is toggled.
+
 pseudotile [*on*|*off*|*toggle*]::
     Sets or toggles the pseudotile state of the focused client. If a client is
     pseudotiled, then in tiling mode the client is only moved but not resized -

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  description = "Development shell for herbstluftwm";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs systems (system:
+          f {
+            inherit system;
+            pkgs = import nixpkgs { inherit system; };
+          });
+    in {
+      devShells = forAllSystems ({ pkgs, ... }:
+        let
+          pythonEnv = pkgs.python3.withPackages (ps: with ps; [
+            ewmh
+            pip
+            pytest
+            pytest-xdist
+            tox
+            xlib
+          ]);
+        in {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              asciidoc
+              cmake
+              expat
+              fontconfig
+              freetype
+              gdb
+              gnumake
+              libx11
+              libxcb
+              libxdmcp
+              libxext
+              libxfixes
+              libxft
+              libxinerama
+              libxrandr
+              libxrender
+              libxslt
+              pkg-config
+              procps
+              pythonEnv
+              xdotool
+              xorg-server
+              xsetroot
+              xterm
+            ];
+
+            shellHook = ''
+              export FONTCONFIG_FILE="${pkgs.fontconfig.out}/etc/fonts/fonts.conf"
+              export FONTCONFIG_PATH="${pkgs.fontconfig.out}/etc/fonts"
+              export PYTHONPATH="$PWD/python${PYTHONPATH:+:$PYTHONPATH}"
+              export XDG_CACHE_HOME="$PWD/.cache"
+              mkdir -p "$XDG_CACHE_HOME"
+            '';
+          };
+        });
+    };
+}

--- a/share/autostart-auto-sidepane-test
+++ b/share/autostart-auto-sidepane-test
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+hc() {
+    herbstclient "$@"
+}
+
+hc emit_hook reload
+hc keyunbind --all
+hc mouseunbind --all
+hc unrule -F
+
+xsetroot -solid '#20242b'
+
+Mod=Mod1
+
+hc rename default com || true
+hc add misc
+
+hc keybind $Mod-Shift-q quit
+hc keybind $Mod-Shift-r reload
+hc keybind $Mod-1 use com
+hc keybind $Mod-2 use misc
+hc keybind $Mod-Left focus left
+hc keybind $Mod-Down focus down
+hc keybind $Mod-Up focus up
+hc keybind $Mod-Right focus right
+hc keybind $Mod-Shift-Left shift left
+hc keybind $Mod-Shift-Down shift down
+hc keybind $Mod-Shift-Up shift up
+hc keybind $Mod-Shift-Right shift right
+hc keybind $Mod-s floating toggle
+hc keybind $Mod-space cycle_layout +1
+
+# test spawns
+hc keybind $Mod-Return spawn xterm -class main_app -title main-app -geometry 90x28
+hc keybind $Mod-Shift-Return spawn xterm -class side_app -title side-app -geometry 90x28
+hc keybind $Mod-f spawn xterm -class float_app -title floating-app -geometry 90x28
+hc keybind $Mod-m spawn xterm -class misc_app -title misc-app -geometry 90x28
+
+hc set frame_gap 8
+hc set window_gap 0
+hc set frame_border_width 2
+hc set smart_frame_surroundings on
+hc set smart_window_surroundings off
+hc set frame_border_active_color '#7aa2f7'
+hc set frame_border_normal_color '#3b4252'
+hc set frame_bg_active_color '#7aa2f733'
+hc set frame_bg_normal_color '#00000000'
+hc set frame_transparent_width 0
+hc set frame_bg_transparent on
+
+hc attr theme.tiling.reset 1
+hc attr theme.floating.reset 1
+hc attr theme.title_height 18
+hc attr theme.title_when always
+hc attr theme.active.color '#7aa2f7'
+hc attr theme.normal.color '#3b4252'
+hc attr theme.urgent.color '#bf616a'
+hc attr theme.title_color '#e5e9f0'
+hc attr theme.normal.title_color '#d8dee9'
+hc attr theme.active.title_color '#ffffff'
+
+# Enable the new mode only on the communication tag.
+hc set_attr tags.by-name.com.auto_sidepane on
+
+# Main apps stay in the primary pane.
+hc rule class=main_app tag=com main_client=on focus=on switchtag=on
+
+# Side apps go to the auto-managed pane on the right.
+hc rule class=side_app focus=on
+
+# Floating test case: should not participate in sidepane placement.
+hc rule class=float_app floating=on
+
+# Misc apps go to the second tag for comparison.
+hc rule class=misc_app tag=misc focus=on switchtag=on
+
+# Keep usual popup/dialog behavior.
+hc rule windowtype~'_NET_WM_WINDOW_TYPE_(DIALOG|UTILITY|SPLASH)' floating=on
+hc rule windowtype='_NET_WM_WINDOW_TYPE_DIALOG' focus=on
+hc rule windowtype~'_NET_WM_WINDOW_TYPE_(NOTIFICATION|DOCK|DESKTOP)' manage=off
+hc rule fixedsize floating=on
+
+hc set tree_style '╾│ ├└╼─┐'
+hc unlock

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -41,6 +41,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , floating_(this,  "floating", false)
     , main_client_(this, "main_client", false)
     , fullscreen_(this,  "fullscreen", false)
+    , maximized_(this,  "maximized", false)
     , sticky_(this,  "sticky", false)
     , minimized_(this,  "minimized", false)
     , floating_effectively_(this,  "floating_effectively", false)
@@ -78,6 +79,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     ewmhnotify_.setWritable();
     ewmhrequests_.setWritable();
     fullscreen_.setWritable();
+    maximized_.setWritable();
     sticky_.setWritable();
     pseudotile_.setWritable();
     sizehints_floating_.setWritable();
@@ -87,6 +89,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     for (auto i : {&fullscreen_, &pseudotile_, &sizehints_floating_, &sizehints_tiling_}) {
         i->changed().connect(this, &Client::requestRedraw);
     }
+    maximized_.changed().connect(this, &Client::requestRedraw);
 
     keyMask_.changed().connect([this] {
             if (Root::get()->clients()->focus() == this) {
@@ -99,8 +102,19 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
             }
             });
     fullscreen_.changed().connect([this] {
+        if (fullscreen_()) {
+            // fullscreen and maximized are mutually exclusive
+            maximized_ = false;
+        }
         updateEwmhState();
         hook_emit({"fullscreen", fullscreen_() ? "on" : "off", WindowID(window_).str()});
+    });
+    maximized_.changed().connect([this] {
+        if (maximized_()) {
+            // fullscreen and maximized are mutually exclusive
+            fullscreen_ = false;
+        }
+        hook_emit({"maximized", maximized_() ? "on" : "off", WindowID(window_).str()});
     });
     minimized_.changed().connect([this]() {
         static long long minimizedTick = 0;
@@ -138,6 +152,11 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     fullscreen_.setDoc(
                 "whether this client covers all other "
                 "windows and panels on its monitor.");
+    maximized_.setDoc(
+                "whether this client covers the entire usable area of "
+                "its monitor (like 'fullscreen', but panels stay visible "
+                "and the window keeps its border). Mutually exclusive "
+                "with 'fullscreen'.");
     sticky_.setDoc(
                 "whether this client is pinned to the monitor. "
                 "This means that the client stays on its monitor, even when "
@@ -299,6 +318,16 @@ void Client::resize_fullscreen(Rectangle monitor_rect, bool isFocused) {
     decParams->urgent_ = urgent_();
     dec->setParameters(*decParams);
     dec->resize_outline(monitor_rect);
+}
+
+void Client::resize_maximized(Rectangle usable_area, bool isFocused) {
+    // like fullscreen, but the window keeps a normal decoration and is laid
+    // out within the monitor's usable area, so panels stay visible.
+    *decParams = DecorationParameters();
+    decParams->focused_ = isFocused;
+    decParams->urgent_ = urgent_();
+    dec->setParameters(*decParams);
+    dec->resize_outline(usable_area);
 }
 
 void Client::raise() {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -39,6 +39,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     , visible_(this, "visible", visible_already)
     , urgent_(this, "urgent", false)
     , floating_(this,  "floating", false)
+    , main_client_(this, "main_client", false)
     , fullscreen_(this,  "fullscreen", false)
     , sticky_(this,  "sticky", false)
     , minimized_(this,  "minimized", false)
@@ -71,6 +72,7 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
     window_id_str = WindowID(window).str();
     decorated_.setWritable();
     floating_.setWritable();
+    main_client_.setWritable();
     keyMask_.setWritable();
     keysInactive_.setWritable();
     ewmhnotify_.setWritable();
@@ -145,6 +147,9 @@ Client::Client(Window window, bool visible_already, ClientManager& cm)
                 "iconified).");
     floating_.setDoc("whether this client is set as a (single-window) floating client. "
                      "If set, the client is floated above the tiled clients.");
+    main_client_.setDoc(
+                "whether this client should be treated as a main application "
+                "for tag-local placement rules.");
     floating_effectively_.setDoc(
                 "whether this client is in the floating state currently. "
                 "This is the case if the client\'s tag is set to floating mode or "
@@ -783,4 +788,3 @@ string Client::tagName() {
 Window Client::decorationWindow() {
     return dec->decorationWindow();
 }
-

--- a/src/client.h
+++ b/src/client.h
@@ -71,6 +71,7 @@ public:
     Attribute_<bool> floating_;
     Attribute_<bool> main_client_;
     Attribute_<bool> fullscreen_;
+    Attribute_<bool> maximized_;
     Attribute_<bool> sticky_;
     Attribute_<bool> minimized_;
     Attribute_<bool> floating_effectively_;
@@ -115,6 +116,7 @@ public:
     void resize_tiling(Rectangle rect, bool isFocused, bool minimalDecoration, std::vector<Client*> tabs);
     void resize_floating(Monitor* m, bool isFocused);
     void resize_fullscreen(Rectangle m, bool isFocused);
+    void resize_maximized(Rectangle usable_area, bool isFocused);
     bool is_client_floated();
     void set_urgent(bool state);
     void readWmHints(bool forceNotUrgent = false);

--- a/src/client.h
+++ b/src/client.h
@@ -69,6 +69,7 @@ public:
     Attribute_<bool> urgent_;
     bool x11urgent_ = false;
     Attribute_<bool> floating_;
+    Attribute_<bool> main_client_;
     Attribute_<bool> fullscreen_;
     Attribute_<bool> sticky_;
     Attribute_<bool> minimized_;

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -558,13 +558,17 @@ void ClientManager::applyTmpRuleCompletion(Completion& complete)
 void ClientManager::focusedClientChanges(Client* newFocus)
 {
     // When the focus moves to another client on the same tag, the previously
-    // focused client leaves fullscreen. Switching to a different tag keeps the
-    // fullscreen state, so a fullscreen window can be left untouched while
-    // peeking at another tag.
+    // focused client leaves fullscreen/maximized. Switching to a different tag
+    // keeps the state, so such a window can be left untouched while peeking at
+    // another tag.
     if (lastFocus_ && newFocus && lastFocus_ != newFocus
-        && lastFocus_->fullscreen_()
         && lastFocus_->tag() == newFocus->tag()) {
-        lastFocus_->fullscreen_ = false;
+        if (lastFocus_->fullscreen_()) {
+            lastFocus_->fullscreen_ = false;
+        }
+        if (lastFocus_->maximized_()) {
+            lastFocus_->maximized_ = false;
+        }
     }
     if (newFocus) {
         hook_emit({"focus_changed", newFocus->window_id_str(), newFocus->title_()});
@@ -653,6 +657,11 @@ int ClientManager::fullscreen_cmd(Input input, Output output)
     return clientSetAttribute("fullscreen", input, output);
 }
 
+int ClientManager::maximize_cmd(Input input, Output output)
+{
+    return clientSetAttribute("maximized", input, output);
+}
+
 void ClientManager::pseudotile_complete(Completion& complete)
 {
     fullscreen_complete(complete);
@@ -668,4 +677,9 @@ void ClientManager::fullscreen_complete(Completion& complete)
     } else {
         complete.none();
     }
+}
+
+void ClientManager::maximize_complete(Completion& complete)
+{
+    fullscreen_complete(complete);
 }

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -180,6 +180,9 @@ void ClientManager::setDragged(Client* client) {
 
 void ClientManager::remove(Window window)
 {
+    if (lastFocus_ == clients_[window]) {
+        lastFocus_ = nullptr;
+    }
     removeChild(*clients_[window]->window_id_str);
     clients_.erase(window);
 }
@@ -554,10 +557,22 @@ void ClientManager::applyTmpRuleCompletion(Completion& complete)
  */
 void ClientManager::focusedClientChanges(Client* newFocus)
 {
+    // When the focus moves to another client on the same tag, the previously
+    // focused client leaves fullscreen. Switching to a different tag keeps the
+    // fullscreen state, so a fullscreen window can be left untouched while
+    // peeking at another tag.
+    if (lastFocus_ && newFocus && lastFocus_ != newFocus
+        && lastFocus_->fullscreen_()
+        && lastFocus_->tag() == newFocus->tag()) {
+        lastFocus_->fullscreen_ = false;
+    }
     if (newFocus) {
         hook_emit({"focus_changed", newFocus->window_id_str(), newFocus->title_()});
     } else {
         hook_emit({"focus_changed", "0x0", ""});
+    }
+    if (newFocus) {
+        lastFocus_ = newFocus;
     }
 }
 

--- a/src/clientmanager.cpp
+++ b/src/clientmanager.cpp
@@ -251,6 +251,9 @@ Client* ClientManager::manage_client(Window win, bool visible_already, bool forc
     client->slice = Slice::makeClientSlice(client);
     client->tag()->insertClientSlice(client);
     // insert window to the tag
+    if (changes.tree_index.empty()) {
+        changes.tree_index = client->tag()->autoSidepaneInsertIndex(client);
+    }
     client->tag()->insertClient(client, changes.tree_index, changes.focus);
 
     tag_set_flags_dirty();
@@ -343,6 +346,9 @@ void ClientManager::setSimpleClientAttributes(Client* client, const ClientChange
 {
     if (changes.floating.has_value()) {
         client->floating_ = changes.floating.value();
+    }
+    if (changes.mainClient.has_value()) {
+        client->main_client_ = changes.mainClient.value();
     }
     if (changes.pseudotile.has_value()) {
         client->pseudotile_ = changes.pseudotile.value();
@@ -648,4 +654,3 @@ void ClientManager::fullscreen_complete(Completion& complete)
         complete.none();
     }
 }
-

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -57,8 +57,10 @@ public:
 
     int pseudotile_cmd(Input input, Output output);
     int fullscreen_cmd(Input input, Output output);
+    int maximize_cmd(Input input, Output output);
     void pseudotile_complete(Completion& complete);
     void fullscreen_complete(Completion& complete);
+    void maximize_complete(Completion& complete);
 
     // adds a new client to list of managed client windows
     Client* manage_client(Window win, bool visible_already, bool force_unmanage,

--- a/src/clientmanager.h
+++ b/src/clientmanager.h
@@ -80,6 +80,7 @@ protected:
     Settings* settings;
     Ewmh* ewmh;
     XConnection* X_;
+    Client* lastFocus_ = nullptr; //! the previously focused client, for disabling fullscreen on focus change
     std::unordered_map<Window, Client*> clients_;
     friend class Client;
 };

--- a/src/fixprecdec.h
+++ b/src/fixprecdec.h
@@ -27,6 +27,14 @@ public:
         return value_ > other.value_;
     }
 
+    bool operator==(FixPrecDec other) {
+        return value_ == other.value_;
+    }
+
+    bool operator!=(FixPrecDec other) {
+        return value_ != other.value_;
+    }
+
     static FixPrecDec fromInteger(int integer) {
         return integer * unit_;
     }

--- a/src/framedata.cpp
+++ b/src/framedata.cpp
@@ -16,6 +16,7 @@ template<> Finite<LayoutAlgorithm>::ValueList Finite<LayoutAlgorithm>::values = 
     { LayoutAlgorithm::horizontal, "horizontal" },
     { LayoutAlgorithm::max, "max" },
     { LayoutAlgorithm::grid, "grid" },
+    { LayoutAlgorithm::masterstack, "masterstack" },
   }
 };
 

--- a/src/framedata.h
+++ b/src/framedata.h
@@ -40,6 +40,7 @@ enum class LayoutAlgorithm {
     horizontal,
     max,
     grid,
+    masterstack
 };
 
 template <>

--- a/src/frametree.cpp
+++ b/src/frametree.cpp
@@ -977,7 +977,8 @@ void FrameTree::splitFrame(string frameIndex, SplitModeName mode, FixPrecDec fra
             m.align = align_auto;
         } else if (layout == LayoutAlgorithm::grid && windowcount == 2) {
             m.align = SplitAlign::horizontal;
-        } else if (layout == LayoutAlgorithm::horizontal) {
+        } else if (layout == LayoutAlgorithm::horizontal
+            || layout == LayoutAlgorithm::masterstack) {
             m.align = SplitAlign::horizontal;
         } else {
             m.align = SplitAlign::vertical;
@@ -985,7 +986,8 @@ void FrameTree::splitFrame(string frameIndex, SplitModeName mode, FixPrecDec fra
         size_t count1 = windowcount;
         size_t nc1 = (count1 + 1) / 2;      // new count for the first frame
         if ((layout == LayoutAlgorithm::horizontal
-            || layout == LayoutAlgorithm::vertical)
+            || layout == LayoutAlgorithm::vertical
+            || layout == LayoutAlgorithm::masterstack)
             && !userDefinedFraction && count1 > 1) {
             fraction.value_ = (nc1 * fraction.unit_) / count1;
         }
@@ -1065,4 +1067,3 @@ void FrameTree::dumpLayoutCompletion(Completion& complete) {
         complete.none();
     }
 }
-

--- a/src/layoutalgoimpl.cpp
+++ b/src/layoutalgoimpl.cpp
@@ -252,6 +252,74 @@ public:
 };
 
 
+class LayoutMasterStack : public LayoutAlgoImpl {
+public:
+    LayoutMasterStack (Params p) : LayoutAlgoImpl(p) {}
+public:
+    virtual TilingResult compute(Rectangle rect) override {
+        TilingResult res;
+        const vector<Client*>& clients = frame_.clientsConst();
+        if (clients.empty()) {
+            return res;
+        } else if (clients.size() == 1) {
+            res.add(clients[0], TilingStep(rect));
+            return res;
+        }
+
+        Client* main = clients[0];
+        auto masterOnLeft = settings_->masterstack_master_position() == MasterStackPosition::left;
+        auto masterRatio = settings_->masterstack_master_ratio();
+        auto r = rect; // current rectangle
+        r.width = (rect.width * masterRatio.value_) / masterRatio.unit_;
+        if (!masterOnLeft) {
+            r.x = rect.x + rect.width - r.width;
+        }
+        res.add(main, TilingStep(r));
+
+        int rows = clients.size()-1;
+
+        auto cur = rect; // current rectangle
+        cur.x = masterOnLeft ? (r.x + r.width) : rect.x;
+        cur.width = rect.width-r.width; // remaining width
+        cur.height = rect.height / rows;
+        for (int row = 0; row < rows; row++) {
+            if (row == rows-1) {
+                // fill small pixel gap below last row
+                cur.height += rect.height % rows;
+            }
+            res.add(clients[row+1], TilingStep(cur));
+            cur.y += cur.height;
+        }
+        return res;
+    }
+
+    virtual int neighbour(Direction direction, DirectionLevel depth, int startIndex) override {
+        size_t count = frame_.clientsConst().size();
+        auto masterOnLeft = settings_->masterstack_master_position() == MasterStackPosition::left;
+
+        if (count > 1) {
+            if (startIndex == 0) {
+                // we are main window
+                if ((masterOnLeft && direction == Direction::Right)
+                    || (!masterOnLeft && direction == Direction::Left)) {
+                    // top window
+                    return 1;
+                }
+            } else if ((masterOnLeft && direction == Direction::Left)
+                || (!masterOnLeft && direction == Direction::Right)) {
+                return 0;
+            } else if (startIndex > 1 && direction == Direction::Up) {
+                return startIndex - 1;
+            } else if (direction == Direction::Down) {
+                return startIndex + 1;
+            }
+        }
+
+        return -1;
+    }
+};
+
+
 unique_ptr<LayoutAlgoImpl> LayoutAlgoImpl::createInstance(const FrameLeaf& frame, LayoutAlgorithm algoName)
 {
     Params p = {frame, algoName};
@@ -264,6 +332,8 @@ unique_ptr<LayoutAlgoImpl> LayoutAlgoImpl::createInstance(const FrameLeaf& frame
         return make_unique<LayoutGrid>(p);
     case LayoutAlgorithm::max:
         return make_unique<LayoutMax>(p);
+    case LayoutAlgorithm::masterstack:
+        return make_unique<LayoutMasterStack>(p);
     }
     // this can never be reached...
     return {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,6 +152,8 @@ unique_ptr<CommandTable> commands(shared_ptr<Root> root) {
                                    &TagManager::floatingComplete }},
         {"fullscreen",     {clients, &ClientManager::fullscreen_cmd,
                                      &ClientManager::fullscreen_complete}},
+        {"maximize",       {clients, &ClientManager::maximize_cmd,
+                                     &ClientManager::maximize_complete}},
         {"pseudotile",     {clients, &ClientManager::pseudotile_cmd,
                                      &ClientManager::pseudotile_complete}},
         {"tag_status",     {global_cmds, &GlobalCommands::tagStatusCommand}},

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -190,8 +190,8 @@ void Monitor::applyLayout() {
     }
     // preprocessing
     for (auto& p : res.data) {
-        if (p.first->fullscreen_() || p.second.floated) {
-            // do not hide fullscreen windows
+        if (p.first->fullscreen_() || p.first->maximized_() || p.second.floated) {
+            // do not hide fullscreen/maximized windows
             p.second.visible = true;
         }
         if (settings->hide_covered_windows) {
@@ -210,6 +210,11 @@ void Monitor::applyLayout() {
             tag->stack->sliceAddLayer(c->slice, LAYER_FULLSCREEN);
         } else {
             tag->stack->sliceRemoveLayer(c->slice, LAYER_FULLSCREEN);
+        }
+        if (c->maximized_()) {
+            tag->stack->sliceAddLayer(c->slice, LAYER_MAXIMIZED);
+        } else {
+            tag->stack->sliceRemoveLayer(c->slice, LAYER_MAXIMIZED);
         }
         // special raise rules for tiled clients:
         if (!p.second.floated) {
@@ -231,10 +236,11 @@ void Monitor::applyLayout() {
     tag->stack->clearLayer(LAYER_FOCUS);
     if (res.focus) {
         // activate the focus layer if requested by the setting
-        // or if there is a fullscreen client potentially covering
-        // the focused client.
+        // or if there is a fullscreen or maximized client potentially
+        // covering the focused client.
         if ((isFocused && g_settings->raise_on_focus_temporarily())
-            || tag->stack->isLayerEmpty(LAYER_FULLSCREEN) == false)
+            || tag->stack->isLayerEmpty(LAYER_FULLSCREEN) == false
+            || tag->stack->isLayerEmpty(LAYER_MAXIMIZED) == false)
         {
             tag->stack->sliceAddLayer(res.focus->slice, LAYER_FOCUS);
         }
@@ -246,6 +252,8 @@ void Monitor::applyLayout() {
         bool clientFocused = isFocused && res.focus == c;
         if (c->fullscreen_()) {
             c->resize_fullscreen(rect, clientFocused);
+        } else if (c->maximized_()) {
+            c->resize_maximized(getFloatingArea(), clientFocused);
         } else if (p.second.floated) {
             c->resize_floating(this, clientFocused);
         } else {
@@ -256,6 +264,8 @@ void Monitor::applyLayout() {
     for (auto& c : tag->floating_clients_) {
         if (c->fullscreen_()) {
             c->resize_fullscreen(rect, res.focus == c && isFocused);
+        } else if (c->maximized_()) {
+            c->resize_maximized(getFloatingArea(), res.focus == c && isFocused);
         } else {
             c->resize_floating(this, res.focus == c && isFocused);
         }

--- a/src/rules.cpp
+++ b/src/rules.cpp
@@ -71,6 +71,7 @@ const std::map<string, function<Consequence::Applier(const string&)>> Consequenc
     { "switchtag",      setMember(&ClientChanges::switchtag) },
     { "manage",         setMember(&ClientChanges::manage) },
     { "floating",       setOptionalMember(&ClientChanges::floating) },
+    { "main_client",    setOptionalMember(&ClientChanges::mainClient) },
     { "floating_geometry", parseFloatingGeometry },
     { "pseudotile",     setOptionalMember(&ClientChanges::pseudotile) },
     { "fullscreen",     setOptionalMember(&ClientChanges::fullscreen) },

--- a/src/rules.h
+++ b/src/rules.h
@@ -103,6 +103,7 @@ public:
     std::experimental::optional<RegexStr> keysInactive; // Which keymask rule should be applied for this client
 
     std::experimental::optional<bool> floating;
+    std::experimental::optional<bool> mainClient;
     std::experimental::optional<Rectangle> floatingGeometry;
     std::experimental::optional<bool> pseudotile;
     std::experimental::optional<bool> ewmhRequests;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -52,6 +52,12 @@ Finite<ShowFrameDecorations>::ValueList Finite<ShowFrameDecorations>::values = V
     { ShowFrameDecorations::none, "none" },
 };
 
+template<>
+Finite<MasterStackPosition>::ValueList Finite<MasterStackPosition>::values = ValueListPlain {
+    { MasterStackPosition::left, "left" },
+    { MasterStackPosition::right, "right" },
+};
+
 
 Settings* g_settings = nullptr; // the global settings object
 
@@ -108,6 +114,8 @@ Settings::Settings()
         &raise_on_focus_temporarily,
         &raise_on_click,
         &gapless_grid,
+        &masterstack_master_position,
+        &masterstack_master_ratio,
         &tabbed_max,
         &hide_covered_windows,
         &smart_frame_surroundings,
@@ -155,6 +163,16 @@ Settings::Settings()
          &raise_on_focus_temporarily}) {
         i->changed().connect(&all_monitors_apply_layout);
     }
+    masterstack_master_position.changed().connect(&all_monitors_apply_layout);
+    masterstack_master_ratio.changed().connect(&all_monitors_apply_layout);
+    masterstack_master_ratio.setValidator([] (FixPrecDec new_value) {
+        auto maxFrac = FixPrecDec::fromInteger(1) - FRAME_MIN_FRACTION;
+        if (new_value < FRAME_MIN_FRACTION || new_value > maxFrac) {
+            return string("masterstack_master_ratio must be between ")
+                + FRAME_MIN_FRACTION.str() + " and " + maxFrac.str();
+        }
+        return string();
+    });
     show_frame_decorations.changed().connect(&all_monitors_apply_layout);
     smart_frame_surroundings.changed().connect(&all_monitors_apply_layout);
     smart_window_surroundings.changed().connect(&all_monitors_apply_layout);
@@ -329,6 +347,18 @@ Settings::Settings()
                 "client always fills the gap within this frame. If unset, "
                 "then the last client has the same size as all other clients "
                 "in this frame.");
+    masterstack_master_position.setDoc(
+                "Controls on which side the master area is placed in the "
+                "'masterstack' layout. If set to 'left', then the first client "
+                "is shown on the left and the stack is shown on the right. "
+                "If set to 'right', the arrangement is mirrored. The default "
+                "value is 'left'."
+                );
+    masterstack_master_ratio.setDoc(
+                "Controls the size of the master area in the 'masterstack' "
+                "layout. The value must be between '0.1' and '0.9'. The "
+                "default value is '0.6'."
+                );
 
     hide_covered_windows.setDoc(
                 "If activated, windows are explicitly hidden when they are "

--- a/src/settings.h
+++ b/src/settings.h
@@ -51,6 +51,16 @@ struct is_finite<ShowFrameDecorations> : std::true_type {};
 template<> Finite<ShowFrameDecorations>::ValueList Finite<ShowFrameDecorations>::values;
 template<> inline Type Attribute_<ShowFrameDecorations>::staticType() { return Type::NAMES; }
 
+enum class MasterStackPosition {
+    left,
+    right,
+};
+
+template <>
+struct is_finite<MasterStackPosition> : std::true_type {};
+template<> Finite<MasterStackPosition>::ValueList Finite<MasterStackPosition>::values;
+template<> inline Type Attribute_<MasterStackPosition>::staticType() { return Type::NAMES; }
+
 
 class Settings : public Object {
 public:
@@ -96,6 +106,8 @@ public:
     Attribute_<bool>          raise_on_focus_temporarily = {"raise_on_focus_temporarily", false};
     Attribute_<bool>          raise_on_click = {"raise_on_click", true};
     Attribute_<bool>          gapless_grid = {"gapless_grid", true};
+    Attribute_<MasterStackPosition> masterstack_master_position = {"masterstack_master_position", MasterStackPosition::left};
+    Attribute_<FixPrecDec>    masterstack_master_ratio = {"masterstack_master_ratio", FixPrecDec::approxFrac(3, 5)};
     Attribute_<bool>          tabbed_max = {"tabbed_max", true};
     Attribute_<bool>          hide_covered_windows = {"hide_covered_windows", false};
     Attribute_<SmartFrameSurroundings> smart_frame_surroundings = {"smart_frame_surroundings", SmartFrameSurroundings::off};

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -17,6 +17,7 @@ const std::array<const char*, LAYER_COUNT>g_layer_names =
     ArrayInitializer<const char*, LAYER_COUNT>({
      { LAYER_FOCUS       , "Focus-Layer"                },
      { LAYER_FULLSCREEN  , "Fullscreen-Layer"           },
+     { LAYER_MAXIMIZED   , "Maximized-Layer"            },
      { LAYER_FLOATING    , "Floating-Layer"             },
      { LAYER_NORMAL      , "Tiling-Layer"               },
      { LAYER_FRAMES      , "Frame Layer"                },

--- a/src/stack.h
+++ b/src/stack.h
@@ -13,6 +13,7 @@ enum HSLayer {
     /* layers on each tag, from top to bottom */
     LAYER_FOCUS,
     LAYER_FULLSCREEN,
+    LAYER_MAXIMIZED,
     LAYER_FLOATING,
     LAYER_NORMAL,
     LAYER_FRAMES,

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -36,6 +36,9 @@ HSTag::HSTag(string name_, TagManager* tags, Settings* settings)
     , index(this, "index", 0, &HSTag::isValidTagIndex)
     , visible(this, "visible", false)
     , floating(this, "floating", false, [](bool){return "";})
+    , auto_sidepane(this, "auto_sidepane", false)
+    , auto_sidepane_layout(this, "auto_sidepane_layout", LayoutAlgorithm::vertical)
+    , auto_sidepane_fraction(this, "auto_sidepane_fraction", FixPrecDec::approxFrac(3, 5))
     , floating_focused(this, "floating_focused", false, [](bool){return "";})
     , name(this, "name", name_,
         [tags](string newName) { return tags->isValidTagName(newName); })
@@ -73,12 +76,21 @@ HSTag::HSTag(string name_, TagManager* tags, Settings* settings)
     floating_focused.setValidator([this](bool v) {
         return this->floatingLayerCanBeFocused(v);
     });
+    auto_sidepane.setWritable();
+    auto_sidepane_layout.setWritable();
+    auto_sidepane_fraction.setWritable();
     atEnd.setWritable();
 
     name.setDoc("name of the tag (must be non-empty)");
     index.setDoc("index of this tag (the first index is 0)");
     visible.setDoc("if this tag is shown on some monitor");
     floating.setDoc("if the entire tag is set to floating mode");
+    auto_sidepane.setDoc("if enabled, non-floating non-main clients are inserted "
+                         "into an automatically managed side pane on this tag");
+    auto_sidepane_layout.setDoc("the layout algorithm used within the auto-managed "
+                                "side pane");
+    auto_sidepane_fraction.setDoc("the fraction of the tag width assigned to the "
+                                  "main pane when the auto-managed side pane is created");
     floating_focused.setDoc("if the floating layer is focused"
                             " (otherwise the tiling layer is)");
     frame_count.setDoc("the number of frames on this tag");
@@ -159,6 +171,7 @@ void HSTag::applyClientState(Client* client)
     if (!hasVisibleFloatingClients()) {
         floating_focused = false;
     }
+    autoSidepaneCleanup();
     client->floating_effectively_ = floating() || client->floating_();
     bool client_becomes_visible = !client->minimized_() && this->visible();
     if (client_becomes_visible) {
@@ -194,6 +207,7 @@ bool HSTag::removeClient(Client* client) {
         }
     });
     if (frame->root_->removeClient(client)) {
+        autoSidepaneCleanup();
         return true;
     }
     auto it = std::find(floating_clients_.begin(), floating_clients_.end(), client);
@@ -207,6 +221,7 @@ bool HSTag::removeClient(Client* client) {
         // focus back the tiling
         floating_focused = false;
     }
+    autoSidepaneCleanup();
     return true;
 }
 
@@ -305,6 +320,64 @@ void HSTag::insertClient(Client* client, string frameIndex, bool focus)
         target->insertClient(client, focus);
     }
     client->floating_effectively_ = floating() || client->floating_();
+}
+
+shared_ptr<FrameSplit> HSTag::autoSidepaneRootSplit()
+{
+    if (!auto_sidepane()) {
+        return {};
+    }
+    auto split = frame->root_->isSplit();
+    if (!split || split->getAlign() != SplitAlign::horizontal) {
+        return {};
+    }
+    if (!split->firstChild()->isLeaf() || !split->secondChild()->isLeaf()) {
+        return {};
+    }
+    return split;
+}
+
+string HSTag::autoSidepaneInsertIndex(Client* client)
+{
+    if (!auto_sidepane() || client->floating_()) {
+        return {};
+    }
+    if (client->main_client_()) {
+        return autoSidepaneRootSplit() ? "0" : "";
+    }
+    if (autoSidepaneRootSplit()) {
+        return "1";
+    }
+    auto rootLeaf = frame->root_->isLeaf();
+    if (!rootLeaf) {
+        return {};
+    }
+    if (!rootLeaf->split(SplitAlign::horizontal, auto_sidepane_fraction(), 0)) {
+        return {};
+    }
+    auto split = autoSidepaneRootSplit();
+    if (!split) {
+        return {};
+    }
+    auto sideLeaf = split->secondChild()->isLeaf();
+    if (sideLeaf) {
+        sideLeaf->setLayout(auto_sidepane_layout());
+    }
+    split->setSelection(1);
+    return "1";
+}
+
+void HSTag::autoSidepaneCleanup()
+{
+    auto split = autoSidepaneRootSplit();
+    if (!split) {
+        return;
+    }
+    auto sideLeaf = split->secondChild()->isLeaf();
+    if (!sideLeaf || sideLeaf->clientCount() != 0) {
+        return;
+    }
+    frame->replaceNode(split, split->firstChild());
 }
 
 void HSTag::insertClientSlice(Client* client)
@@ -411,6 +484,7 @@ int HSTag::shiftInDir(Direction direction, DirectionLevel depth, Output output)
     } else {
         success = frame->shiftInDirection(direction, depth);
         if (success) {
+            autoSidepaneCleanup();
             needsRelayout_.emit();
         }
     }
@@ -749,4 +823,3 @@ int HSTag::closeAndRemoveCommand() {
     }
     return 0;
 }
-

--- a/src/tag.h
+++ b/src/tag.h
@@ -6,6 +6,8 @@
 
 #include "attribute_.h"
 #include "child.h"
+#include "fixprecdec.h"
+#include "framedata.h"
 #include "object.h"
 #include "signal.h"
 
@@ -21,6 +23,7 @@ enum class DirectionLevel;
 class Client;
 class Completion;
 class FrameLeaf;
+class FrameSplit;
 class FrameTree;
 class Settings;
 class Stack;
@@ -34,6 +37,9 @@ public:
     Attribute_<unsigned long> index;
     Attribute_<bool>         visible;
     Attribute_<bool>         floating;
+    Attribute_<bool>         auto_sidepane;
+    Attribute_<LayoutAlgorithm> auto_sidepane_layout;
+    Attribute_<FixPrecDec>   auto_sidepane_fraction;
     Attribute_<bool>         floating_focused; // if a floating client is focused
     Attribute_<std::string>  name;   // name of this tag
     Attribute_<bool>         atEnd;
@@ -68,6 +74,8 @@ public:
     void insertClientSlice(Client* client);
     //! remove the client's slice from this tag's stack
     void removeClientSlice(Client* client);
+    std::string autoSidepaneInsertIndex(Client* client);
+    void autoSidepaneCleanup();
 
     void focusInDirCommand(CallOrComplete invoc);
     int focusInDir(Direction direction, DirectionLevel depth, Output output);
@@ -88,6 +96,7 @@ private:
     std::string isValidTagIndex(unsigned long newIndex);
     std::string floatingLayerCanBeFocused(bool floatingFocused);
     void onGlobalFloatingChange(bool newState);
+    std::shared_ptr<FrameSplit> autoSidepaneRootSplit();
     void fixFocusIndex();
     //! get the number of clients on this tag
     int computeClientCount();
@@ -108,4 +117,3 @@ void tag_update_flags();
 void tag_set_flags_dirty();
 
 #endif
-

--- a/src/tagmanager.cpp
+++ b/src/tagmanager.cpp
@@ -321,6 +321,9 @@ void TagManager::moveClient(Client* client, HSTag* target, string frameIndex, bo
         // nothing to do
         return;
     }
+    if (frameIndex.empty()) {
+        frameIndex = target->autoSidepaneInsertIndex(client);
+    }
     Monitor* monitor_target = find_monitor_with_tag(target);
     tag_source->removeClient(client);
     // insert window into target
@@ -330,6 +333,8 @@ void TagManager::moveClient(Client* client, HSTag* target, string frameIndex, bo
         client->setTag(target);
         client->tag()->insertClientSlice(client);
     }
+    tag_source->autoSidepaneCleanup();
+    target->autoSidepaneCleanup();
 
     // refresh things, hide things, layout it, and then show it if needed
     if (monitor_source && !monitor_target) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,13 @@ BINDIR = pathlib.Path(os.environ['PWD'])  # use workdir
 
 # List of environment variables copied during hlwm process creation:
 # * LSAN_OPTIONS: needed to suppress warnings about known memory leaks
-COPY_ENV_WHITELIST = ['LSAN_OPTIONS']
+COPY_ENV_WHITELIST = [
+    'FONTCONFIG_FILE',
+    'FONTCONFIG_PATH',
+    'LSAN_OPTIONS',
+    'PATH',
+    'XDG_CACHE_HOME',
+]
 
 # time in seconds to wait for a process to shut down
 PROCESS_SHUTDOWN_TIME = 30

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -36,6 +36,50 @@ def test_alter_fullscreen(hlwm):
     assert hlwm.get_attr('clients.focus.fullscreen') == 'false'
 
 
+def test_fullscreen_disabled_when_focusing_other_client_same_tag(hlwm):
+    first, _ = hlwm.create_client()
+    second, _ = hlwm.create_client()
+    hlwm.call(['jumpto', first])
+    hlwm.attr.clients[first].fullscreen = True
+    assert hlwm.attr.clients[first].fullscreen() is True
+
+    # focusing another client on the same tag disables fullscreen on the
+    # previously focused client
+    hlwm.call(['jumpto', second])
+    assert hlwm.attr.clients.focus.winid() == second
+    assert hlwm.attr.clients[first].fullscreen() is False
+
+
+def test_fullscreen_not_restored_when_refocusing(hlwm):
+    first, _ = hlwm.create_client()
+    second, _ = hlwm.create_client()
+    hlwm.call(['jumpto', first])
+    hlwm.attr.clients[first].fullscreen = True
+
+    hlwm.call(['jumpto', second])
+    assert hlwm.attr.clients[first].fullscreen() is False
+
+    # refocusing the previously fullscreen client does not restore fullscreen
+    hlwm.call(['jumpto', first])
+    assert hlwm.attr.clients[first].fullscreen() is False
+
+
+def test_fullscreen_kept_when_switching_tag(hlwm):
+    hlwm.call('add othertag')
+    winid, _ = hlwm.create_client()
+    hlwm.attr.clients[winid].fullscreen = True
+    assert hlwm.attr.clients[winid].fullscreen() is True
+
+    # switching to another tag keeps the fullscreen state (peeking)
+    hlwm.call('use othertag')
+    assert hlwm.attr.clients[winid].fullscreen() is True
+
+    # and switching back keeps it, too
+    hlwm.call('use_index 0')
+    assert hlwm.attr.clients.focus.winid() == winid
+    assert hlwm.attr.clients[winid].fullscreen() is True
+
+
 @pytest.mark.parametrize("command", ["fullscreen", "pseudotile"])
 def test_fullscreen_pseudotile_invalid_arg(hlwm, command):
     hlwm.create_client()

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -80,6 +80,50 @@ def test_fullscreen_kept_when_switching_tag(hlwm):
     assert hlwm.attr.clients[winid].fullscreen() is True
 
 
+def test_maximized_disabled_when_focusing_other_client_same_tag(hlwm):
+    first, _ = hlwm.create_client()
+    second, _ = hlwm.create_client()
+    hlwm.call(['jumpto', first])
+    hlwm.attr.clients[first].maximized = True
+    assert hlwm.attr.clients[first].maximized() is True
+
+    # focusing another client on the same tag disables maximized on the
+    # previously focused client
+    hlwm.call(['jumpto', second])
+    assert hlwm.attr.clients.focus.winid() == second
+    assert hlwm.attr.clients[first].maximized() is False
+
+
+def test_maximized_not_restored_when_refocusing(hlwm):
+    first, _ = hlwm.create_client()
+    second, _ = hlwm.create_client()
+    hlwm.call(['jumpto', first])
+    hlwm.attr.clients[first].maximized = True
+
+    hlwm.call(['jumpto', second])
+    assert hlwm.attr.clients[first].maximized() is False
+
+    # refocusing the previously maximized client does not restore maximized
+    hlwm.call(['jumpto', first])
+    assert hlwm.attr.clients[first].maximized() is False
+
+
+def test_maximized_kept_when_switching_tag(hlwm):
+    hlwm.call('add othertag')
+    winid, _ = hlwm.create_client()
+    hlwm.attr.clients[winid].maximized = True
+    assert hlwm.attr.clients[winid].maximized() is True
+
+    # switching to another tag keeps the maximized state (peeking)
+    hlwm.call('use othertag')
+    assert hlwm.attr.clients[winid].maximized() is True
+
+    # and switching back keeps it, too
+    hlwm.call('use_index 0')
+    assert hlwm.attr.clients.focus.winid() == winid
+    assert hlwm.attr.clients[winid].maximized() is True
+
+
 @pytest.mark.parametrize("command", ["fullscreen", "pseudotile"])
 def test_fullscreen_pseudotile_invalid_arg(hlwm, command):
     hlwm.create_client()
@@ -89,6 +133,59 @@ def test_fullscreen_pseudotile_invalid_arg(hlwm, command):
 
 def test_fullscreen_completion(hlwm):
     assert hlwm.complete("fullscreen") == 'false off on toggle true'.split(' ')
+
+
+def test_maximize_command_and_attr(hlwm):
+    hlwm.create_client()
+    positives = ('true', 'on', '1')
+    negatives = ('false', 'off', '0')
+    for on, off in zip(positives, negatives):
+        hlwm.call(['maximize', on])
+        assert hlwm.get_attr('clients.focus.maximized') == 'true'
+        hlwm.call(['maximize', off])
+        assert hlwm.get_attr('clients.focus.maximized') == 'false'
+    hlwm.call('maximize toggle')
+    assert hlwm.get_attr('clients.focus.maximized') == 'true'
+    hlwm.call('maximize toggle')
+    assert hlwm.get_attr('clients.focus.maximized') == 'false'
+
+
+def test_maximize_completion(hlwm):
+    assert hlwm.complete("maximize") == 'false off on toggle true'.split(' ')
+
+
+def test_maximize_invalid_arg(hlwm):
+    hlwm.create_client()
+    hlwm.call_xfail(['maximize', 'novalue']) \
+        .expect_stderr('illegal argument "novalue"')
+
+
+def test_maximize_and_fullscreen_mutually_exclusive(hlwm):
+    hlwm.create_client()
+    hlwm.attr.clients.focus.fullscreen = True
+    hlwm.attr.clients.focus.maximized = True
+    # enabling maximized clears fullscreen
+    assert hlwm.attr.clients.focus.fullscreen() is False
+    assert hlwm.attr.clients.focus.maximized() is True
+
+    # and the other way around
+    hlwm.attr.clients.focus.fullscreen = True
+    assert hlwm.attr.clients.focus.maximized() is False
+    assert hlwm.attr.clients.focus.fullscreen() is True
+
+
+def test_maximize_fills_usable_area_keeping_panel_space(hlwm):
+    # reserve space at the top of the monitor like a panel would
+    hlwm.call('pad 0 30')
+    mx, my, mw, mh = (int(v) for v in hlwm.call('monitor_rect 0').stdout.split())
+
+    winid, _ = hlwm.create_client()
+    hlwm.attr.clients[winid].maximized = True
+
+    # the maximized window covers the usable area (monitor minus the panel
+    # reservation), so the reserved panel space stays free
+    assert hlwm.attr.clients[winid].decoration_geometry() \
+        == Rectangle(mx, my + 30, mw, mh - 30)
 
 
 def test_close_without_clients(hlwm):
@@ -341,6 +438,7 @@ def test_fullscreen_pseudotile_command(hlwm, command):
     'ewmhnotify',
     'ewmhrequests',
     'fullscreen',
+    'maximized',
     'pseudotile',
     'sizehints_floating',
     'sizehints_tiling',

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -114,6 +114,7 @@ def types_and_shorthands():
         'ShowFrameDecorations': 'n',
         'SplitAlign': 'n',
         'LayoutAlgorithm': 'n',
+        'MasterStackPosition': 'n',
         'TagSelectionStrategy': 'n',
         'TextAlign': 'n',
         'TitleWhen': 'n',

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -84,6 +84,138 @@ def test_single_frame_layout_three(hlwm):
     verify_frame_objects_via_dump(hlwm)
 
 
+def test_auto_sidepane_places_non_main_clients_in_sidepane(hlwm, x11):
+    hlwm.attr.tags.focus.auto_sidepane = 'on'
+    hlwm.call('rule once class=main_app main_client=on')
+
+    _, main = x11.create_client(wm_class=('main_app', 'main_app'))
+    _, side = x11.create_client(wm_class=('aux_app', 'aux_app'))
+
+    expected_layout = normalize_layout_string(f"""\
+    (split horizontal:0.6:1
+      (clients vertical:0 {main})
+      (clients vertical:0 {side}))
+    """)
+    assert hlwm.call('dump').stdout == expected_layout
+
+
+def test_auto_sidepane_stacks_multiple_side_clients(hlwm, x11):
+    hlwm.attr.tags.focus.auto_sidepane = 'on'
+    hlwm.call('rule once class=main_app main_client=on')
+
+    _, main = x11.create_client(wm_class=('main_app', 'main_app'))
+    _, side1 = x11.create_client(wm_class=('aux_app_1', 'aux_app_1'))
+    _, side2 = x11.create_client(wm_class=('aux_app_2', 'aux_app_2'))
+
+    expected_layout = normalize_layout_string(f"""\
+    (split horizontal:0.6:1
+      (clients vertical:0 {main})
+      (clients vertical:0 {side1} {side2}))
+    """)
+    assert hlwm.call('dump').stdout == expected_layout
+
+
+def test_auto_sidepane_ignores_rule_floating_clients(hlwm, x11):
+    hlwm.attr.tags.focus.auto_sidepane = 'on'
+    hlwm.call('rule once class=main_app main_client=on')
+    hlwm.call('rule once class=floater floating=on')
+
+    _, main = x11.create_client(wm_class=('main_app', 'main_app'))
+    _, floater = x11.create_client(wm_class=('floater', 'floater'))
+
+    assert hlwm.call('dump').stdout == f'(clients vertical:0 {main})'
+    assert hlwm.get_attr(f'clients.{floater}.floating') == hlwm.bool(True)
+
+
+def test_auto_sidepane_ignores_dialog_windows(hlwm, x11):
+    hlwm.attr.tags.focus.auto_sidepane = 'on'
+    hlwm.call('rule once class=main_app main_client=on')
+
+    _, main = x11.create_client(wm_class=('main_app', 'main_app'))
+    _, dialog = x11.create_client(
+        wm_class=('dialog', 'dialog'),
+        window_type='_NET_WM_WINDOW_TYPE_DIALOG',
+    )
+
+    assert hlwm.call('dump').stdout == f'(clients vertical:0 {main})'
+    assert hlwm.get_attr(f'clients.{dialog}.floating') == hlwm.bool(True)
+
+
+def test_auto_sidepane_cleanup_after_last_side_client_is_closed(hlwm, x11):
+    hlwm.attr.tags.focus.auto_sidepane = 'on'
+    hlwm.call('rule once class=main_app main_client=on')
+
+    _, main = x11.create_client(wm_class=('main_app', 'main_app'))
+    side_window, side = x11.create_client(wm_class=('aux_app', 'aux_app'))
+
+    side_window.unmap()
+    side_window.destroy()
+    x11.sync_with_hlwm()
+
+    assert hlwm.call('dump').stdout == f'(clients vertical:0 {main})'
+
+
+def test_auto_sidepane_obeys_layout_and_fraction_settings(hlwm, x11):
+    hlwm.attr.tags.focus.auto_sidepane = 'on'
+    hlwm.attr.tags.focus.auto_sidepane_layout = 'max'
+    hlwm.attr.tags.focus.auto_sidepane_fraction = '0.7'
+    hlwm.call('rule once class=main_app main_client=on')
+
+    _, main = x11.create_client(wm_class=('main_app', 'main_app'))
+    _, side = x11.create_client(wm_class=('aux_app', 'aux_app'))
+
+    expected_layout = normalize_layout_string(f"""\
+    (split horizontal:0.7:1
+      (clients vertical:0 {main})
+      (clients max:0 {side}))
+    """)
+    assert hlwm.call('dump').stdout == expected_layout
+
+
+def test_move_client_to_auto_sidepane_tag_goes_to_sidepane(hlwm, x11):
+    target_tag = hlwm.get_attr('tags.focus.name')
+    hlwm.call('add othertag')
+    hlwm.attr.tags.focus.auto_sidepane = 'on'
+
+    hlwm.call('rule once class=main_app main_client=on')
+    _, main = x11.create_client(wm_class=('main_app', 'main_app'))
+    hlwm.call('use othertag')
+    _, moved = x11.create_client(wm_class=('aux_app', 'aux_app'))
+
+    hlwm.call('jumpto ' + moved)
+    hlwm.call('move ' + target_tag)
+
+    expected_layout = normalize_layout_string(f"""\
+    (split horizontal:0.6:1
+      (clients vertical:0 {main})
+      (clients vertical:0 {moved}))
+    """)
+    assert hlwm.call('use ' + target_tag).returncode == 0
+    assert hlwm.call('dump').stdout == expected_layout
+
+
+def test_move_main_client_to_auto_sidepane_tag_stays_in_main_pane(hlwm, x11):
+    target_tag = hlwm.get_attr('tags.focus.name')
+    hlwm.call('add othertag')
+    hlwm.attr.tags.focus.auto_sidepane = 'on'
+
+    hlwm.call('rule once class=main_app main_client=on')
+    _, main1 = x11.create_client(wm_class=('main_app', 'main_app'))
+
+    hlwm.call('use othertag')
+    hlwm.call('rule once class=main_app2 main_client=on')
+    _, main2 = x11.create_client(wm_class=('main_app2', 'main_app2'))
+
+    hlwm.call('jumpto ' + main2)
+    hlwm.call('move ' + target_tag)
+
+    expected_layout = normalize_layout_string(f"""\
+    (clients vertical:1 {main1} {main2})
+    """)
+    assert hlwm.call('use ' + target_tag).returncode == 0
+    assert hlwm.call('dump').stdout == expected_layout
+
+
 @pytest.mark.parametrize("running_clients_num", [2, 3])
 def test_explode(hlwm, running_clients, running_clients_num):
     assert running_clients_num >= 2, "explode behaves as auto for one client"

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -112,6 +112,21 @@ def test_explode_second_client(hlwm):
     verify_frame_objects_via_dump(hlwm)
 
 
+def test_explode_masterstack_keeps_horizontal_split(hlwm):
+    winids = hlwm.create_clients(2)
+    hlwm.attr.tags.focus.tiling.root.algorithm = 'masterstack'
+
+    hlwm.call('split explode')
+
+    expected_layout = normalize_layout_string(f"""\
+    (split horizontal:0.5:0
+    (clients masterstack:0 {winids[0]})
+    (clients masterstack:0 {winids[1]}))
+    """)
+    assert hlwm.call('dump').stdout == expected_layout
+    verify_frame_objects_via_dump(hlwm)
+
+
 @pytest.mark.parametrize("running_clients_num", [4])
 @pytest.mark.parametrize("focus_idx", range(0, 4))
 def test_explode_preserves_focus(hlwm, running_clients, running_clients_num, focus_idx):
@@ -1948,6 +1963,43 @@ def test_frame_leaf_algorithm_change(hlwm, x11):
     assert geom1_before.height < geom1_now.height
     assert geom1_now.width == geom2_now.width
     assert geom1_now.height == geom2_now.height
+
+
+def test_masterstack_master_ratio_changes_widths(hlwm, x11):
+    win1, _ = x11.create_client()
+    win2, _ = x11.create_client()
+    hlwm.call('set_layout masterstack')
+
+    x11.sync_with_hlwm()
+    geom1_before = win1.get_geometry()
+    geom2_before = win2.get_geometry()
+
+    hlwm.attr.settings.masterstack_master_ratio = '0.7'
+
+    x11.sync_with_hlwm()
+    geom1_after = win1.get_geometry()
+    geom2_after = win2.get_geometry()
+
+    assert geom1_after.width > geom1_before.width
+    assert geom2_after.width < geom2_before.width
+
+
+def test_masterstack_master_position_mirrors_layout(hlwm, x11):
+    win1, _ = x11.create_client()
+    win2, _ = x11.create_client()
+    hlwm.call('set_layout masterstack')
+
+    x11.sync_with_hlwm()
+    geom1_left = x11.get_absolute_geometry(win1)
+    geom2_left = x11.get_absolute_geometry(win2)
+    assert geom1_left.x < geom2_left.x
+
+    hlwm.attr.settings.masterstack_master_position = 'right'
+
+    x11.sync_with_hlwm()
+    geom1_right = x11.get_absolute_geometry(win1)
+    geom2_right = x11.get_absolute_geometry(win2)
+    assert geom1_right.x > geom2_right.x
 
 
 def test_frame_content_geometry_attribute(hlwm):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -25,6 +25,7 @@ consequences = [
     'manage',
     'index',
     'floating',
+    'main_client',
     'floating_geometry',
     'pseudotile',
     'sticky',
@@ -392,7 +393,7 @@ def create_client(hlwm, rule_mode: RuleMode, rule):
 
 @pytest.mark.parametrize(
     'name',
-    ['floating', 'pseudotile', 'fullscreen', 'ewmhrequests', 'ewmhnotify', 'fullscreen', 'sticky'])
+    ['floating', 'main_client', 'pseudotile', 'fullscreen', 'ewmhrequests', 'ewmhnotify', 'fullscreen', 'sticky'])
 @pytest.mark.parametrize('value', [True, False])
 @pytest.mark.parametrize('rule_mode', RuleMode.values)
 def test_bool_consequence_with_corresponding_attribute(hlwm, name, value, rule_mode):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -227,6 +227,7 @@ def test_stack_tree(hlwm):
     - Monitor 1 ("monitor2") with tag "tag2"
       - Focus-Layer
       - Fullscreen-Layer
+      - Maximized-Layer
       - Floating-Layer
       - Tiling-Layer
         - Client <windowid> "bash"
@@ -236,6 +237,7 @@ def test_stack_tree(hlwm):
     - Monitor 0 with tag "default"
       - Focus-Layer
       - Fullscreen-Layer
+      - Maximized-Layer
       - Floating-Layer
       - Tiling-Layer
         - Client <windowid> "bash"
@@ -259,6 +261,7 @@ def test_stack_tree_desktop_windows(hlwm, x11):
     - Monitor 0 with tag "default"
       - Focus-Layer
       - Fullscreen-Layer
+      - Maximized-Layer
       - Floating-Layer
       - Tiling-Layer
       - Frame Layer

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,11 @@ deps =
 ; Pass $PWD as it is when tox is invoked to pytest (used to find hlwm binaries)
 ; LSAN_OPTIONS is used for suppressing warnings about known memory leaks
 passenv =
+    FONTCONFIG_FILE
+    FONTCONFIG_PATH
     PWD
     LSAN_OPTIONS
+    XDG_CACHE_HOME
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
This PR adds the master stack layout as discussed in #1003.

TODOs:
- add docs
- check todo in code
- maybe add options for:
  - position of master node (left, right), currently its always right
  - which node should be focused in the stack when going right from master, currently the bottom node is focused
  - split ratio (currently its 0.6)