### PR TITLE
Update CI environment to latest Ubuntu LTS

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build and test on current ubuntu
     # Set the type of machine to run on
     runs-on: ubuntu-latest
-    container: hlwm/ci:focal
+    container: hlwm/ci:jammy
     env:
       HLWM_BUILDDIR: build
       CCACHE_LOGFILE: /github/home/ccache.log
@@ -37,21 +37,21 @@ jobs:
         name: Cache ~/.ccache
         with:
           path: ~/.ccache
-          key: focal-gcc-ccache-${{ github.run_number }}
+          key: jammy-gcc-ccache-${{ github.run_number }}
           # since the every new gha run gets a new key, we need to search
           # for existing cache entries more sloppily:
           restore-keys: |
-            focal-gcc-ccache-
+            jammy-gcc-ccache-
 
       - uses: actions/cache@v1
         name: Cache .tox-cache
         with:
           path: .tox-cache
-          key: focal-tox
+          key: jammy-tox
 
       - name: CMake
         run: |
-          ci/build.py --cmake --cxx=g++-9 --cc=gcc-9 --build-type=Debug --ccache=$HOME/.ccache
+          ci/build.py --cmake --cxx=g++-11 --cc=gcc-11 --build-type=Debug --ccache=$HOME/.ccache
 
       - name: Compile
         run: |
@@ -82,7 +82,7 @@ jobs:
   build-clang:
     name: Build with Clang, run linters and static analyzers
     runs-on: ubuntu-latest
-    container: hlwm/ci:focal
+    container: hlwm/ci:jammy
     env:
       HLWM_BUILDDIR: build
       CCACHE_LOGFILE: /github/home/ccache.log
@@ -94,15 +94,15 @@ jobs:
         name: Cache ~/.ccache
         with:
           path: ~/.ccache
-          key: focal-clang-ccache-${{ github.run_number }}
+          key: jammy-clang-ccache-${{ github.run_number }}
           restore-keys: |
-            focal-clang-ccache-
+            jammy-clang-ccache-
 
       - uses: actions/cache@v1
         name: Cache .tox-cache
         with:
           path: .tox-cache
-          key: focal-tox # same name as in build-test-current
+          key: jammy-tox # same name as in build-test-current
 
       - name: Check usage of std-prefix
         run: |

--- a/ci/Dockerfile.ci-jammy
+++ b/ci/Dockerfile.ci-jammy
@@ -1,13 +1,13 @@
-FROM ubuntu:focal-20200423
+FROM ubuntu:jammy-20230605
 
 # Build deps
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     ccache \
-    clang-10 \
-    clang-tidy-10 \
+    clang-14 \
+    clang-tidy-14 \
     curl \
     cmake \
-    g++-9 \
+    g++-11 \
     git \
     iwyu \
     lcov \
@@ -20,7 +20,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libxfixes-dev \
     ninja-build \
     pkg-config \
-    python3.8 \
+    python3.10 \
     tox \
     wget \
     x11-xserver-utils \

--- a/ci/Dockerfile.ci-trusty
+++ b/ci/Dockerfile.ci-trusty
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty-20190122
+FROM ubuntu:trusty-20191217
 
 # Add i386 so that we can build with -m32 to catch more portability errors:
 RUN dpkg --add-architecture i386

--- a/ci/clang-and-tidy.sh
+++ b/ci/clang-and-tidy.sh
@@ -27,9 +27,9 @@ set -o nounset
 # Perform the regular compiler invocation:
 progname=$(basename "$0")
 if [[ $progname == clang-* ]]; then
-    clang-10 "$@"
+    clang-14 "$@"
 elif [[ $progname == clang++-* ]]; then
-    clang++-10 "$@"
+    clang++-14 "$@"
 else
     echo >&2 "Error: Cannot handle program name: $progname"
     exit 1
@@ -75,7 +75,7 @@ clang_tidy_args="-header-filter=.* -extra-arg=-Wno-unknown-warning-option -p=${C
 
 # Run clang-tidy, but hide its output unless it fails (non-failing stdout
 # confuses ccache!)
-if ! out="$(clang-tidy-10 $clang_tidy_args "$sourcefile" 2>&1)"; then
+if ! out="$(clang-tidy-14 $clang_tidy_args "$sourcefile" 2>&1)"; then
     echo "$out"
     exit 1
 fi

--- a/ci/lsan-suppressions.txt
+++ b/ci/lsan-suppressions.txt
@@ -1,6 +1,3 @@
-# Xrandr is leaking...
-leak:libXrandr
-
 # libfontconfig too according to
 # https://chromium.googlesource.com/chromium/src/build/+/master/sanitizers/lsan_suppressions.cc#22
 # http://crbug.com/39050

--- a/src/cssname.h
+++ b/src/cssname.h
@@ -50,7 +50,6 @@ public:
         index_ = static_cast<size_t>(builtin);
     }
     CssName(const std::string& name);
-    CssName(const CssName& other) = default;
 
     bool isBinaryOperator() const;
     inline static bool isBuiltin(size_t index) {

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py310
 skipsdist = true
 
 ###


### PR DESCRIPTION
* Update to Jammy Jellyfish
* Fix hardcoded clang-* paths (we should make this base on a environment variable...)
* Also bumped the Trusty Docker base image (Trusty is almost 10 years)
* Newer clang version complained about a copy ctor in CSS code

Joint effort @dnnr