### PR TITLE
Add if_multiple_empty option to show_frame_decorations

### DIFF
--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -157,6 +157,9 @@ void FrameDecoration::updateVisibility(const FrameDecorationData& data, bool isF
     case ShowFrameDecorations::if_empty:
         show = !data.hasClients;
         break;
+    case ShowFrameDecorations::if_multiple_empty:
+        show = !data.hasClients && !isRootFrame;
+        break;
     case ShowFrameDecorations::focused:
         show = data.hasClients || isFocused;
         break;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -36,6 +36,7 @@ Finite<ShowFrameDecorations>::ValueList Finite<ShowFrameDecorations>::values = V
     { ShowFrameDecorations::if_multiple, "if_multiple" },
     { ShowFrameDecorations::nonempty, "nonempty" },
     { ShowFrameDecorations::if_empty, "if_empty" },
+    { ShowFrameDecorations::if_multiple_empty, "if_multiple_empty" },
     { ShowFrameDecorations::none, "none" },
 };
 
@@ -283,6 +284,7 @@ Settings::Settings()
                 "- \'nonempty\' shows decorations of frames that have client windows, \n"
                 "- \'if_multiple\' shows decorations on the tags with at least two frames, \n"
                 "- \'if_empty\' shows decorations of frames that have no client windows, \n"
+                "- \'if_multiple_empty\' shows decorations of frames that have no client windows on tags with at least two frames, \n"
                 "- \'focused\' shows the decoration of focused and nonempty frames, \n"
                 "- \'focused_if_multiple\' shows decorations of focused and non-empty frames on tags with at least two frames."
                 );

--- a/src/settings.h
+++ b/src/settings.h
@@ -30,6 +30,7 @@ enum class ShowFrameDecorations {
     focused_if_multiple,
     focused,
     if_empty,
+    if_multiple_empty,
     if_multiple,
     all,
 };

--- a/tests/test_frame_decorations.py
+++ b/tests/test_frame_decorations.py
@@ -10,6 +10,7 @@ def test_show_frame_decorations_one_frame(hlwm, x11, running_clients, running_cl
         'nonempty': 1 if running_clients_num > 0 else 0,
         'if_multiple': 1 if running_clients_num > 0 else 0,
         'if_empty': 0 if running_clients_num > 0 else 1,
+        'if_multiple_empty': 0,
         'none': 0,
     }
     for v in hlwm.complete(['set', 'show_frame_decorations']):
@@ -31,6 +32,7 @@ def test_show_frame_decorations_focus(hlwm, x11):
         'nonempty': 1,
         'if_multiple': 2,
         'if_empty': 1,
+        'if_multiple_empty': 1,
         'none': 0,
     }
     for v in hlwm.complete(['set', 'show_frame_decorations']):


### PR DESCRIPTION
This adds an `if_multiple_empty` choice for `show_frame_decorations`. It works like `if_empty` to show a placeholder for childless frames, but it hides that placeholder on empty tags that only have a root frame. A similar behavior could only be achieved before with `show_frame_decorations` set to `if_empty` and `smart_frame_surroundings` on.