### PR TITLE
Restore non-transparent frame by removing mask

### DIFF
--- a/src/framedecoration.cpp
+++ b/src/framedecoration.cpp
@@ -131,7 +131,7 @@ void FrameDecoration::render(const FrameDecorationData& data, bool isFocused) {
         window_cut_rect_holes(xcon, window, rect.width, rect.height, holes);
         window_transparent = true;
     } else if (window_transparent) {
-        window_make_intransparent(xcon, window, rect.width, rect.height);
+        window_make_intransparent(xcon, window);
         window_transparent = false;
     }
     if (isFocused) {

--- a/src/x11-utils.cpp
+++ b/src/x11-utils.cpp
@@ -45,26 +45,9 @@ void window_cut_rect_holes(XConnection& X, Window win, int width, int height,
     XFreePixmap(d, p);
 }
 
-void window_make_intransparent(XConnection& X, Window win, int width, int height) {
-    // inspired by the xhole.c example
-    // http://www.answers.com/topic/xhole-c
+void window_make_intransparent(XConnection& X, Window win) {
     Display* d = X.display();
-    GC gp;
-    int bw = 100; // add a large border, just to be sure the border is visible
-    width += 2*bw;
-    height += 2*bw;
-
-    /* create the pixmap that specifies the shape */
-    Pixmap p = XCreatePixmap(d, win, width, height, 1);
-    gp = XCreateGC(d, p, 0, nullptr);
-    XSetForeground(d, gp, WhitePixel(d, X.screen()));
-    XFillRectangle(d, p, gp, 0, 0, width, height);
-    /* set the pixmap as the new window mask;
-    the pixmap is slightly larger than the window to allow for the window
-    border and title bar (as added by the window manager) to be visible */
-    XShapeCombineMask(d, win, ShapeBounding, -bw, -bw, p, ShapeSet);
-    XFreeGC(d, gp);
-    XFreePixmap(d, p);
+    XShapeCombineMask(d, win, ShapeBounding, 0, 0, None, ShapeSet);
 }
 
 

--- a/src/x11-utils.h
+++ b/src/x11-utils.h
@@ -12,8 +12,7 @@ void window_cut_rect_holes(XConnection& X,
                            Window win, int width, int height,
                            const std::vector<Rectangle>& holes);
 // fill the hole again, i.e. remove all masks
-void window_make_intransparent(XConnection& X,
-                               Window win, int width, int height);
+void window_make_intransparent(XConnection& X, Window win);
 
 Point2D get_cursor_position();
 


### PR DESCRIPTION
This fixes incorrect rendering of resized, once-transparent focused frames with `frame_bg_transparent off`.

`window_make_intransparent` only took into account the _current_ size. Properly removing the mask allows for later resizing.
Fixes #1576.