### PR TITLE
CI: Allow old node version

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -137,6 +137,8 @@ jobs:
     runs-on: ubuntu-latest
     container: hlwm/ci:trusty
     needs: build-doc  # using the tarball
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Download source tarball
         uses: actions/download-artifact@v2


### PR DESCRIPTION
The `build-old-32bit` job failed because github has updated their base system but the job intentionally uses an old docker image:
```
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
```

The following suggestion might help for the time being: https://github.com/actions/checkout/issues/1590#issuecomment-2219382750