### PR TITLE
Initialize bool argparse flags

### DIFF
--- a/src/metacommands.cpp
+++ b/src/metacommands.cpp
@@ -291,8 +291,8 @@ void MetaCommands::foreachCommand(CallOrComplete invoc)
 {
     RegexStr filterName = {};
     string ident;
-    bool unique;
-    bool recursive;
+    bool unique = false;
+    bool recursive = false;
     ObjectPointer object;
     ArgParse ap;
     ap.mandatory(ident).mandatory(object);


### PR DESCRIPTION
In PR #1589, the test `test_foreach_clients` failed because `bool unique` was not initialized.