### PR TITLE
tests: Modernize tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py3
 skipsdist = true
 
 ###

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,9 @@ deps =
 
 ; Pass $PWD as it is when tox is invoked to pytest (used to find hlwm binaries)
 ; LSAN_OPTIONS is used for suppressing warnings about known memory leaks
-passenv = PWD LSAN_OPTIONS
+passenv =
+    PWD
+    LSAN_OPTIONS
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
- Use newline separated `passenv` values to [make things run with tox 4](https://tox.wiki/en/latest/upgrading.html#changed-ini-rules) (contrary to commas, newlines are backwards compatible with tox 3)
- Use `py3` without specifying a minor version, as the testsuite should work with ~any supported Python version, and it makes it easier to run it locally.