### PR TITLE
python: Use pathlib instead of os.path

### DIFF
--- a/ci/diff-json-doc.py
+++ b/ci/diff-json-doc.py
@@ -3,6 +3,7 @@
 import re
 import subprocess
 import os
+import pathlib
 import sys
 import argparse
 import json
@@ -20,8 +21,8 @@ class GitDir:
         tmp_dir = self.dirpath
         full_cmd = [
             'git',
-            '--git-dir=' + os.path.join(tmp_dir, '.git'),
-            '--work-tree=' + tmp_dir
+            f'--git-dir={tmp_dir / ".git"}',
+            f'--work-tree={tmp_dir}',
         ] + list(cmd)
         print(':: ' + ' '.join(full_cmd), file=sys.stderr)
         return subprocess.run(full_cmd, check=check)
@@ -116,15 +117,17 @@ def main():
     else:
         comment_target = args.post_comment
 
-    git_root = run_pipe_stdout(['git', 'rev-parse', '--show-toplevel']).rstrip()
+    git_root = pathlib.Path(
+        run_pipe_stdout(["git", "rev-parse", "--show-toplevel"]).rstrip()
+    )
     if args.no_tmp_dir:
         # use this repository for checking different revisions
         tmp_dir = git_root
     else:
-        tmp_dir = os.path.join(git_root, '.hlwm-tmp-diff-json')
+        tmp_dir = git_root / '.hlwm-tmp-diff-json'
     git_tmp = GitDir(tmp_dir)
 
-    if not os.path.isdir(tmp_dir):
+    if not tmp_dir.is_dir():
         subprocess.call(['git', 'clone', git_root, tmp_dir])
 
     # fetch all pull request heads

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
 import sys
 import re
 import ast
 import json
+import pathlib
 
 
 def findfiles(sourcedir, regex_object):
     """find all files in the given 'sourcedir' whose
     filename matches 'regex_object'
     """
-    for root, _, files in os.walk(sourcedir):
-        for file in sorted(files):
-            if regex_object.match(file):
-                yield os.path.join(root, file)
+    for path in sorted(sourcedir.iterdir()):
+        if regex_object.match(str(path)):
+            yield path
 
 
 class TokenRe:
@@ -803,7 +802,7 @@ class TokTreeInfoExtrator:
 def main():
     parser = argparse.ArgumentParser(description='extract hlwm doc from the source code')
     parser.add_argument('--sourcedir', default='./src/',
-                        help='directory containing the source files')
+                        help='directory containing the source files', type=pathlib.Path)
     parser.add_argument('--fileregex', default=r'.*\.(h|cpp)$',
                         help='consider files whose name matches this regex')
     parser.add_argument('--tokenize-single-file',

--- a/doc/patch-manpage-xml.py
+++ b/doc/patch-manpage-xml.py
@@ -7,7 +7,7 @@ in docbook xml format using literal2emph.xsl
 
 import sys
 import subprocess
-import os
+import pathlib
 
 # the filename of the docbook xml is probably the first
 # command line argument that is not a flag
@@ -19,13 +19,13 @@ for arg in sys.argv[1:]:
 
 xsltproc = 'xsltproc'
 
-doc_directory = os.path.dirname(__file__)
+doc_directory = pathlib.Path(__file__).parent
 
 cmd = [
     xsltproc,
     '--output',
     filename,
-    os.path.join(doc_directory, 'literal2emph.xsl'),
+    doc_directory / 'literal2emph.xsl',
     filename
 ]
 

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -1,13 +1,12 @@
 import json
 import pytest
 import conftest
-import os
 import re
 
 
 @pytest.fixture()
 def json_doc():
-    json_filepath = os.path.join(conftest.BINDIR, 'doc/hlwm-doc.json')
+    json_filepath = conftest.BINDIR / "doc" / "hlwm-doc.json"
     with open(json_filepath, 'r') as fh:
         doc = json.loads(fh.read())
     return doc

--- a/tests/test_herbstclient.py
+++ b/tests/test_herbstclient.py
@@ -7,10 +7,10 @@ import sys
 import struct
 import contextlib
 from herbstluftwm import Herbstluftwm
-from conftest import PROCESS_SHUTDOWN_TIME, HcIdle
+from conftest import BINDIR, PROCESS_SHUTDOWN_TIME, HcIdle
 from Xlib import X, Xatom
 
-HC_PATH = os.path.join(os.path.abspath(os.environ['PWD']), 'herbstclient')
+HC_PATH = BINDIR / 'herbstclient'
 
 
 @pytest.mark.parametrize('argument', ['version', '--idle'])

--- a/tests/test_herbstluftwm.py
+++ b/tests/test_herbstluftwm.py
@@ -1,14 +1,12 @@
 import re
-import os
 import pytest
 import subprocess
 from conftest import BINDIR, PROCESS_SHUTDOWN_TIME, HlwmBridge
 import conftest
-import os.path
 from Xlib import X, Xatom
 
 
-HLWM_PATH = os.path.join(BINDIR, 'herbstluftwm')
+HLWM_PATH = BINDIR / 'herbstluftwm'
 
 
 def test_reload(hlwm_process, hlwm):
@@ -64,13 +62,13 @@ def test_wmexec_failure(hlwm, hlwm_process, args, errormsg):
 
 
 @pytest.mark.parametrize("with_client", [True, False])
-def test_wmexec_to_other(hlwm_process, xvfb, tmpdir, with_client):
+def test_wmexec_to_other(hlwm_process, xvfb, tmp_path, with_client):
     hlwm = HlwmBridge(xvfb.display, hlwm_process)
     if with_client:
         hlwm.create_client()
 
-    file_path = tmpdir / 'witness.txt'
-    assert not os.path.isfile(file_path)
+    file_path = tmp_path / 'witness.txt'
+    assert not file_path.is_file()
     p = hlwm.unchecked_call(['wmexec', 'touch', file_path],
                             read_hlwm_output=False)
     assert p.returncode == 0
@@ -78,7 +76,7 @@ def test_wmexec_to_other(hlwm_process, xvfb, tmpdir, with_client):
     # the hlwm process execs to 'touch' which then terminates on its own.
     hlwm_process.proc.wait()
 
-    os.path.isfile(file_path)
+    assert file_path.is_file()
 
 
 def test_herbstluftwm_already_running(hlwm):
@@ -118,7 +116,7 @@ def test_herbstluftwm_replace(hlwm_spawner, xvfb):
 
 
 def test_herbstluftwm_help_flags():
-    hlwm = os.path.join(BINDIR, 'herbstluftwm')
+    hlwm = BINDIR / 'herbstluftwm'
     for cmd in [[hlwm, '-h'], [hlwm, '--help']]:
         proc = subprocess.run(cmd,
                               stdout=subprocess.PIPE,
@@ -131,7 +129,7 @@ def test_herbstluftwm_help_flags():
 
 
 def test_herbstluftwm_unrecognized_option():
-    hlwm = os.path.join(BINDIR, 'herbstluftwm')
+    hlwm = BINDIR / 'herbstluftwm'
     proc = subprocess.run([hlwm, '--foobar'],
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE,
@@ -143,7 +141,7 @@ def test_herbstluftwm_unrecognized_option():
 
 
 def test_herbstluftwm_version_flags():
-    hlwm = os.path.join(BINDIR, 'herbstluftwm')
+    hlwm = BINDIR / 'herbstluftwm'
     for cmd in [[hlwm, '-v'], [hlwm, '--version']]:
         proc = subprocess.run(cmd,
                               stdout=subprocess.PIPE,

--- a/tests/test_python_binds.py
+++ b/tests/test_python_binds.py
@@ -1,17 +1,17 @@
 import pytest
-import os.path
 import subprocess
 import sys
 import os
 import conftest
+import pathlib
 from herbstluftwm.types import Rectangle
 
 
 def test_example(hlwm):
     # test the example.py shipped with the bindings
-    example_py = os.path.join(os.path.dirname(__file__), '..', 'python', 'example.py')
+    example_py = pathlib.Path(__file__).parents[1] / 'python' / 'example.py'
     # make 'herbstclient' binary available in the PATH
-    os.environ['PATH'] = conftest.BINDIR + ':' + os.environ['PATH']
+    os.environ['PATH'] = str(conftest.BINDIR) + os.pathsep + os.environ['PATH']
     assert subprocess.call([sys.executable, example_py]) == 0
 
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -14,8 +14,8 @@ def test_spawn_command_not_exist(hlwm, hlwm_process):
         .expect_stderr('No such file')
 
 
-def test_spawn_command_no_permission(hlwm, tmpdir, hlwm_process):
-    dirname = str(tmpdir)
+def test_spawn_command_no_permission(hlwm, tmp_path, hlwm_process):
+    dirname = str(tmp_path)
     hlwm.call_xfail(['spawn', dirname]) \
         .expect_stderr(dirname) \
         .expect_stderr('Permission denied')


### PR DESCRIPTION
Use [pathlib](https://docs.python.org/3/library/pathlib.html) instead of `os.path`, which exposes file paths as objects, similar to what `tmpdir` does.

Also replace `tmpdir` by the [more modern `tmp_path`](https://docs.pytest.org/en/stable/how-to/tmp_path.html) which uses the pathlib API instead of the (somewhat pytest specific) `py.path.local` one.

Got a bit bigger than I thought - let me know if you'd rather not have the churn or only have the `tmpdir` -> `tmp_path` part, no hard feelings in that case.