### PR TITLE
Add #include <stdint.h> to fix building with gcc 15

### DIFF
--- a/src/xconnection.cpp
+++ b/src/xconnection.cpp
@@ -6,6 +6,7 @@
 #include <X11/Xutil.h>
 #include <X11/extensions/Xrender.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <unistd.h>
 #include <climits>
 #include <cstring>


### PR DESCRIPTION
With gcc 15, the C++ Standard Library no longer includes other headers that were internally used by the library. In herbstluftwm's case the missing header is `<stdint.h>`

Downstream Gentoo bug: https://bugs.gentoo.org/937529

Closes: #1612