### PR TITLE
CI: remove old 32 bit job

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -286,6 +286,6 @@ jobs:
         run: |
           builddir=$BUILD ci/mktar.sh
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: herbstluftwm*.tar.gz

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -132,64 +132,64 @@ jobs:
         run: |
           ci/build.py --iwyu
 
-  build-old-32bit:
-    name: Build for 32bit with ancient GCC on Ubuntu 14.04
-    runs-on: ubuntu-latest
-    container: hlwm/ci:trusty
-    needs: build-doc  # using the tarball
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-    steps:
-      - name: Download source tarball
-        uses: actions/download-artifact@v2
-        # we do not specify a name, hence all artifacts are downloaded
-
-      - uses: actions/cache@v1
-        name: Cache ~/.ccache
-        with:
-          path: ~/.ccache
-          key: ccache-gcc-ancient-${{ github.run_number }}
-          restore-keys: |
-            ccache-gcc-ancient-
-
-      - name: Extract tarball
-        run: |
-          tar xvf artifact/herbstluftwm*.tar.gz
-
-      - name: Sanity check tarball content
-        run: |
-          cd herbstluftwm-*/doc/
-          echo Checking that generated file have at least 10 lines
-          test "$(wc -l hlwm-objects-gen.txt|cut -d' ' -f1)" -gt 10 || exit 1
-          test "$(wc -l hlwm-doc.json|cut -d' ' -f1)" -gt 10 || exit 1
-
-      - name: Build
-        env:
-          CC: gcc-4.8
-          CXX: g++-4.8
-          CXXFLAGS: -m32
-          CFLAGS: -m32
-        run: |
-          cd herbstluftwm-*/
-          find ~/.ccache | wc -l
-          ccache -z --max-size=500M
-          # ccache too old for --show-config
-          mkdir build
-          cd build
-          cmake -GNinja -DENABLE_CCACHE=YES ..
-          ninja -v -k10
-          ccache -s
-          find ~/.ccache | wc -l
-
-      - name: Install
-        env:
-          DESTDIR: ${{ github.workspace }}/install-herbstluftwm/
-        run: |
-          cd herbstluftwm-*/build/
-          mkdir -v -p $DESTDIR
-          ninja -v install
-          # check that the man page has been installed:
-          find $DESTDIR -name 'herbstluftwm.1' -printf '%P\n' | grep . # grep for the right exit-status
+  # build-old-32bit:
+  #   name: Build for 32bit with ancient GCC on Ubuntu 14.04
+  #   runs-on: ubuntu-latest
+  #   container: hlwm/ci:trusty
+  #   needs: build-doc  # using the tarball
+  #   env:
+  #     ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+  #   steps:
+  #     - name: Download source tarball
+  #       uses: actions/download-artifact@v2
+  #       # we do not specify a name, hence all artifacts are downloaded
+  
+  #     - uses: actions/cache@v1
+  #       name: Cache ~/.ccache
+  #       with:
+  #         path: ~/.ccache
+  #         key: ccache-gcc-ancient-${{ github.run_number }}
+  #         restore-keys: |
+  #           ccache-gcc-ancient-
+  
+  #     - name: Extract tarball
+  #       run: |
+  #         tar xvf artifact/herbstluftwm*.tar.gz
+  
+  #     - name: Sanity check tarball content
+  #       run: |
+  #         cd herbstluftwm-*/doc/
+  #         echo Checking that generated file have at least 10 lines
+  #         test "$(wc -l hlwm-objects-gen.txt|cut -d' ' -f1)" -gt 10 || exit 1
+  #         test "$(wc -l hlwm-doc.json|cut -d' ' -f1)" -gt 10 || exit 1
+  
+  #     - name: Build
+  #       env:
+  #         CC: gcc-4.8
+  #         CXX: g++-4.8
+  #         CXXFLAGS: -m32
+  #         CFLAGS: -m32
+  #       run: |
+  #         cd herbstluftwm-*/
+  #         find ~/.ccache | wc -l
+  #         ccache -z --max-size=500M
+  #         # ccache too old for --show-config
+  #         mkdir build
+  #         cd build
+  #         cmake -GNinja -DENABLE_CCACHE=YES ..
+  #         ninja -v -k10
+  #         ccache -s
+  #         find ~/.ccache | wc -l
+  
+  #     - name: Install
+  #       env:
+  #         DESTDIR: ${{ github.workspace }}/install-herbstluftwm/
+  #       run: |
+  #         cd herbstluftwm-*/build/
+  #         mkdir -v -p $DESTDIR
+  #         ninja -v install
+  #         # check that the man page has been installed:
+  #         find $DESTDIR -name 'herbstluftwm.1' -printf '%P\n' | grep . # grep for the right exit-status
 
   diff-objects:
     name: Diff object tree

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -251,7 +251,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: install asciidoc
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends asciidoc xsltproc docbook-xsl
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends asciidoc xsltproc docbook-xsl imagemagick librsvg2-bin
       - name: restrict cmake to doc
         run: |
           cat > CMakeLists.txt <<EOF

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -132,65 +132,6 @@ jobs:
         run: |
           ci/build.py --iwyu
 
-  # build-old-32bit:
-  #   name: Build for 32bit with ancient GCC on Ubuntu 14.04
-  #   runs-on: ubuntu-latest
-  #   container: hlwm/ci:trusty
-  #   needs: build-doc  # using the tarball
-  #   env:
-  #     ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-  #   steps:
-  #     - name: Download source tarball
-  #       uses: actions/download-artifact@v2
-  #       # we do not specify a name, hence all artifacts are downloaded
-  
-  #     - uses: actions/cache@v1
-  #       name: Cache ~/.ccache
-  #       with:
-  #         path: ~/.ccache
-  #         key: ccache-gcc-ancient-${{ github.run_number }}
-  #         restore-keys: |
-  #           ccache-gcc-ancient-
-  
-  #     - name: Extract tarball
-  #       run: |
-  #         tar xvf artifact/herbstluftwm*.tar.gz
-  
-  #     - name: Sanity check tarball content
-  #       run: |
-  #         cd herbstluftwm-*/doc/
-  #         echo Checking that generated file have at least 10 lines
-  #         test "$(wc -l hlwm-objects-gen.txt|cut -d' ' -f1)" -gt 10 || exit 1
-  #         test "$(wc -l hlwm-doc.json|cut -d' ' -f1)" -gt 10 || exit 1
-  
-  #     - name: Build
-  #       env:
-  #         CC: gcc-4.8
-  #         CXX: g++-4.8
-  #         CXXFLAGS: -m32
-  #         CFLAGS: -m32
-  #       run: |
-  #         cd herbstluftwm-*/
-  #         find ~/.ccache | wc -l
-  #         ccache -z --max-size=500M
-  #         # ccache too old for --show-config
-  #         mkdir build
-  #         cd build
-  #         cmake -GNinja -DENABLE_CCACHE=YES ..
-  #         ninja -v -k10
-  #         ccache -s
-  #         find ~/.ccache | wc -l
-  
-  #     - name: Install
-  #       env:
-  #         DESTDIR: ${{ github.workspace }}/install-herbstluftwm/
-  #       run: |
-  #         cd herbstluftwm-*/build/
-  #         mkdir -v -p $DESTDIR
-  #         ninja -v install
-  #         # check that the man page has been installed:
-  #         find $DESTDIR -name 'herbstluftwm.1' -printf '%P\n' | grep . # grep for the right exit-status
-
   diff-objects:
     name: Diff object tree
     runs-on: ubuntu-latest

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         name: Cache ~/.ccache
         with:
           path: ~/.ccache
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             focal-gcc-ccache-
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         name: Cache .tox-cache
         with:
           path: .tox-cache
@@ -90,7 +90,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         name: Cache ~/.ccache
         with:
           path: ~/.ccache
@@ -98,7 +98,7 @@ jobs:
           restore-keys: |
             focal-clang-ccache-
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         name: Cache .tox-cache
         with:
           path: .tox-cache

--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         name: Cache ~/.ccache
@@ -88,7 +88,7 @@ jobs:
       CCACHE_LOGFILE: /github/home/ccache.log
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         name: Cache ~/.ccache
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2  # fetch previous commits
 
@@ -249,7 +249,7 @@ jobs:
       BUILD: build-${{ github.run_number }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: install asciidoc
         run: sudo apt-get update && sudo apt-get install --no-install-recommends asciidoc xsltproc docbook-xsl
       - name: restrict cmake to doc


### PR DESCRIPTION
It does not seem to be possible to let github actions pass data into old docker containers. So let us disable the old 32 bit build for the time being.
Also, this commit updates the version of the github action modules and installs imagemagick and librsvg2-bin in the website job to make the CI pass again.