### PR TITLE
Add entries for extra mouse buttons

### DIFF
--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -29,11 +29,19 @@ vector<pair<string, unsigned int>> MouseCombo::name2button =
     { "Button3",  Button3 },
     { "Button4",  Button4 },
     { "Button5",  Button5 },
+    { "Button6",  6 }, // X.h doesn't have Button6+ but
+    { "Button7",  7 }, // they're literally just const int
+    { "Button8",  8 }, // so that shouldn't stop us from
+    { "Button9",  9 }, // supporting common buttons
     { "B1",       Button1 },
     { "B2",       Button2 },
     { "B3",       Button3 },
     { "B4",       Button4 },
     { "B5",       Button5 },
+    { "B6",       6 },
+    { "B7",       7 },
+    { "B8",       8 },
+    { "B9",       9 },
 };
 
 template<>


### PR DESCRIPTION
lol hi, me again.

So I wanted to bind the extra two buttons (typically used as Forward/Back) as such;

```
herbstclient mousebind Mod4-Button1             move
herbstclient mousebind Mod4-Button2             zoom
herbstclient mousebind Mod4-Button3             resize
herbstclient mousebind Mod4-Button8             call set_attr clients.focus.minimized true
herbstclient mousebind Mod4-Button9             call set_attr clients.focus.floating toggle
```

No dice -- no Button8/Button9. Nothing above button5.

Consumer mice with back/forward buttons are ultra-common, but also tilt-wheel and double-wheel mice exist.

Original hlwm code uses defines specified from X.h -- X.h only goes to 5, but it's literally just a static integer as a define;

```
/* button names. Used as arguments to GrabButton and as detail in ButtonPress
   and ButtonRelease events.  Not to be confused with button masks above.
   Note that 0 is already defined above as "AnyButton".  */

#define Button1			1
#define Button2			2
#define Button3			3
#define Button4			4
#define Button5			5
```

Change adds static integers (exactly the same as if X.h had `#define`d them) for buttons thru 9. My mouse doesn't expose 6/7 but searching confirms other users have them.

It's literally eight lines in `src/mouse.cpp` because it's two integer mappings each, for four buttons. No other supporting code required. No documentation change required. (Maybe a convenience note about using `xinput list` to find your input and `xinput test #` to see which numbers each button maps to?)

I skimmed relevant references and I couldn't find anything which employed a check or evaluation against the entries of a name2button.

FWIW I'm running a local branch of this plus my mouse_follows_monitor_focus merged, and it all works as expected.

Potential impacts; No real way to check if users' device posess the button, but no real impetus not to expose them.