### PR TITLE
Mouse follows focus

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -363,9 +363,9 @@ Settings::Settings()
                 "when having pseudotiled windows in the max layout) "
                 "then an extra click is required to change the focus.");
     mouse_follows_focus.setDoc(
-		"If set and the focus is changed by a means other than the mouse"
-		" the mouse will be warped to the center of the area. Also known"
-		" as mouse warping");
+		"If set and the focus changed to a window that does not"
+		"contain the mouse, the mouse will be moved to the"
+		"center of the window. Also known as mouse warping.");
 
     focus_stealing_prevention.setDoc(
                 "If set, only pagers and taskbars are allowed to change "

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -101,6 +101,7 @@ Settings::Settings()
         &default_direction_external_only,
         &default_frame_layout,
         &focus_follows_mouse,
+	&mouse_follows_focus,
         &focus_stealing_prevention,
         &swap_monitors_to_get_tag,
         &raise_on_focus,
@@ -361,6 +362,10 @@ Settings::Settings()
                 "If another window is hidden by the focus change (e.g. "
                 "when having pseudotiled windows in the max layout) "
                 "then an extra click is required to change the focus.");
+    mouse_follows_focus.setDoc(
+		"If set and the focus is changed by a means other than the mouse"
+		" the mouse will be warped to the center of the area. Also known"
+		" as mouse warping");
 
     focus_stealing_prevention.setDoc(
                 "If set, only pagers and taskbars are allowed to change "

--- a/src/settings.h
+++ b/src/settings.h
@@ -89,7 +89,7 @@ public:
     Attribute_<bool>          default_direction_external_only = {"default_direction_external_only", false};
     Attribute_<LayoutAlgorithm> default_frame_layout = {"default_frame_layout", LayoutAlgorithm::vertical};
     Attribute_<bool>          focus_follows_mouse = {"focus_follows_mouse", false};
-    Attribute_<bool>          mouse_follows_focus = {"mouse_follows_focus", true};
+    Attribute_<bool>          mouse_follows_focus = {"mouse_follows_focus", false};
     Attribute_<bool>          focus_stealing_prevention = {"focus_stealing_prevention", true};
     Attribute_<bool>          swap_monitors_to_get_tag = {"swap_monitors_to_get_tag", true};
     Attribute_<bool>          raise_on_focus = {"raise_on_focus", false};

--- a/src/settings.h
+++ b/src/settings.h
@@ -89,6 +89,7 @@ public:
     Attribute_<bool>          default_direction_external_only = {"default_direction_external_only", false};
     Attribute_<LayoutAlgorithm> default_frame_layout = {"default_frame_layout", LayoutAlgorithm::vertical};
     Attribute_<bool>          focus_follows_mouse = {"focus_follows_mouse", false};
+    Attribute_<bool>          mouse_follows_focus = {"mouse_follows_focus", true};
     Attribute_<bool>          focus_stealing_prevention = {"focus_stealing_prevention", true};
     Attribute_<bool>          swap_monitors_to_get_tag = {"swap_monitors_to_get_tag", true};
     Attribute_<bool>          raise_on_focus = {"raise_on_focus", false};

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -729,14 +729,39 @@ void XMainLoop::focusedClientChanges(Client* newFocus)
         root_->ewmh_.updateActiveWindow(newFocus->window_);
         root_->mouse->grab_client_buttons(newFocus, true);
         root_->keys()->ensureKeyMask(newFocus);
-    } else { // if no client is focused
-        Ewmh::get().clearInputFocus();
-        if (lastFocus_) {
-            root_->ewmh_.updateActiveWindow(None);
 
-            // Enable all keys in the root window
-            root_->keys()->clearActiveKeyMask();
-        }
+	// mouse_follows_focus checks if the mouse is already in the focused window, if not,
+	// move pointer to the center of the window
+	if (root_->settings->mouse_follows_focus) {
+	  Window mousein_root;
+	  Window mousein_child;
+	  int root_x, root_y, child_x, child_y;
+	  unsigned int dummy_uint;
+	  XQueryPointer(g_display, newFocus->window_, &mousein_root, &mousein_child, &root_x, &root_y, &child_x, &child_y, &dummy_uint);
+	  // check if mouse is in window
+	  Rectangle border = newFocus->dec->last_inner();
+	  std::cout << border << std::endl;
+	  if (root_x < border.x  || root_x > border.width + border.x ||
+	      root_y < border.y || root_y > border.height + border.y) {
+	  XWarpPointer(g_display, None, newFocus->window_, 0, 0, 0, 0,
+		       newFocus->last_size_.width/2, newFocus->last_size_.height/2);
+	  std::cout << "Changing!" << std::endl;
+	  }
+	}
+    } else { // if no client is focused
+      Ewmh::get().clearInputFocus();
+      if (lastFocus_) {
+        root_->ewmh_.updateActiveWindow(None);
+
+        // Enable all keys in the root window
+        root_->keys()->clearActiveKeyMask();
+
+	// warp mouse to focus in center of frame
+	if (root_->settings->mouse_follows_focus) {
+	  Rectangle frame_rect = get_current_monitor()->tag->frame->focusedFrame()->lastRect();
+	  XWarpPointer(g_display, None, g_root, 0, 0, 0, 0, frame_rect.x + (frame_rect.width / 2), frame_rect.y + (frame_rect.height /2));
+	}
+      }
     }
     lastFocus_ = newFocus;
 }

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -736,16 +736,14 @@ void XMainLoop::focusedClientChanges(Client* newFocus)
 	  Window mousein_root;
 	  Window mousein_child;
 	  int root_x, root_y, child_x, child_y;
-	  unsigned int dummy_uint;
-	  XQueryPointer(g_display, newFocus->window_, &mousein_root, &mousein_child, &root_x, &root_y, &child_x, &child_y, &dummy_uint);
+	  unsigned int throwaway_uint;
+	  XQueryPointer(g_display, newFocus->window_, &mousein_root, &mousein_child, &root_x, &root_y, &child_x, &child_y, &throwaway_uint);
 	  // check if mouse is in window
 	  Rectangle border = newFocus->dec->last_inner();
-	  std::cout << border << std::endl;
 	  if (root_x < border.x  || root_x > border.width + border.x ||
 	      root_y < border.y || root_y > border.height + border.y) {
 	  XWarpPointer(g_display, None, newFocus->window_, 0, 0, 0, 0,
 		       newFocus->last_size_.width/2, newFocus->last_size_.height/2);
-	  std::cout << "Changing!" << std::endl;
 	  }
 	}
     } else { // if no client is focused


### PR DESCRIPTION
This PR adds a mouse_follows_focus option, which makes the mouse teleport to the center of a window when focus is moved to it if the mouse is not already in the window. This ensures the mouse is always close to where the user is working.

This is my first time doing any programming related to X11 so it may be a little rough around the edges.