### PR TITLE
Only redraw on new size hints if geometry changes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,8 @@ Current git version
     window surroundings when there is only one window and one frame in a tag,
     'one_window' and 'off' mirror the old behaviour with regards to 'true' and
     'false'.
+  * Bug fix: Only redraw after new WM_NORMAL_HINTS if it would affect the
+    clients geometry.
 
 Release 0.9.5 on 2022-07-30
 ---------------------------

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -658,12 +658,17 @@ void XMainLoop::propertynotify(XPropertyEvent* ev) {
                 client->readWmHints(forceNotUrgent);
             } else if (ev->atom == XA_WM_NORMAL_HINTS) {
                 client->updatesizehints();
-                Rectangle geom = client->float_size_;
-                client->applysizehints(&geom.width, &geom.height, true);
-                client->float_size_ = geom;
-                Monitor* m = find_monitor_with_tag(client->tag());
-                if (m) {
-                    m->applyLayout();
+                Rectangle geom = client->content_geometry_();
+                // check if the new size hints would affect the current
+                // size of the client:
+                client->applysizehints(&geom.width, &geom.height, false);
+                bool sizeChanged = client->content_geometry_ != geom;
+                if (sizeChanged) {
+                    // only redraw if the client's content geometry would be affected:
+                    Monitor* m = find_monitor_with_tag(client->tag());
+                    if (m) {
+                        m->applyLayout();
+                    }
                 }
             } else if (ev->atom == XA_WM_NAME ||
                        ev->atom == root_->ewmh_.netatom(NetWmName)) {


### PR DESCRIPTION
If a client changes its size hints via the property WM_NORMAL_HINTS, then we should only redraw the client if the new hints would change the size of the client.

This fixes bug #1629 in which pavucontrol endlessly sending new WM_NORMAL_HINTS property notify events, causing hlwm to redraw for no reason but causing even more property notify events.