### PR TITLE
Add types to pull_request hook

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -13,6 +13,7 @@ on:
     paths-ignore:
     - '.mergify.yml'
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore:
     - '.mergify.yml'
 


### PR DESCRIPTION
The github actions workflow for #1633 and #1627 isn't triggered. This is an attempt to fix this.