### PR TITLE
Explicitly list pull request target branch in CI specification

### DIFF
--- a/.github/workflows/hlwm.yml
+++ b/.github/workflows/hlwm.yml
@@ -13,6 +13,8 @@ on:
     paths-ignore:
     - '.mergify.yml'
   pull_request:
+    branches:
+    - master
     paths-ignore:
     - '.mergify.yml'
 


### PR DESCRIPTION
In pull requests by external contributors (e.g. #1633), the github actions
workflow is not triggered. When comparing our workflow yml file to that of e.g.
agda-categories, the only noticable difference is that they explicitly list
`branches` in the `pull_request` section.
The present change is an attempt to fix the CI issue.
