### PR TITLE
Make mergify compatible with up-to-date branch protection

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,20 @@
+merge_queue:
+  max_parallel_checks: 1
+
+# message from mergify (as of 2025-12-30):
+#
+#    The branch protection setting
+#       'Require branches to be up to date before merging'
+#    is not compatible with draft PR checks. To keep this branch
+#    protection enabled, update your Mergify configuration to enable
+#    in-place checks: set merge_queue.max_parallel_checks: 1,
+#    set every queue rule batch_size: 1, and avoid two-step CI
+#    (make merge_conditions identical to queue_conditions). Otherwise, disable
+#    this branch protection.
+
 queue_rules:
   - name: default
+    batch_size: 1
     queue_conditions:
       # conditions on a PR to be added to the merge queue
       - base=master
@@ -10,9 +25,13 @@ queue_rules:
       - label!=wip
     branch_protection_injection_mode: merge
     merge_conditions:
+      - base=master
       # Conditions to get out of the queue (= merged)
       - check-success=Build and test on current ubuntu
       - check-success=Build with Clang, run linters and static analyzers
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - label!=wip
     commit_message_template: |
       {{ title }} (#{{ number }})
 


### PR DESCRIPTION
This change attempts to make mergify compatible with our branch protection setting setting that pull requests are 'up to date' before merging. I want this setting because it adds the 'Update branch' button in pull requests that are not ahead of the current master branch.

I hope the present change to the mergify config achieves this because mergify showed this error message:

> The branch protection setting 'Require branches to be up to date
> before merging' is not compatible with draft PR checks. To keep this
> branch protection enabled, update your Mergify configuration to enable
> in-place checks: set merge_queue.max_parallel_checks: 1, set every queue
> rule batch_size: 1, and avoid two-step CI (make merge_conditions
> identical to queue_conditions). Otherwise, disable this branch
> protection.