### PR TITLE
Depend on hlwm doc json for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,15 @@ $(BUILDDIR):
 clean:
 	rm -r $(BUILDDIR)/
 
+$(BUILDDIR)/doc/hlwm-doc.json:
+	make -C $(BUILDDIR)/doc doc_json
+
 .PHONY: smoke-test
-smoke-test: all
+smoke-test: all $(BUILDDIR)/doc/hlwm-doc.json
 	$(MAKE) tox EXTRA_TOX_ARGS="-m 'not exclude_from_coverage'"
 
 .PHONY: long-test
-long-test: all
+long-test: all $(BUILDDIR)/doc/hlwm-doc.json
 	$(MAKE) tox EXTRA_TOX_ARGS="-m 'exclude_from_coverage'"
 
 .PHONY: test


### PR DESCRIPTION
The documentation tests depend on an existing `hlwm-docs.json`, so create that before running the test suite.