### PR TITLE
systemd.service and sd_notify() integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,27 @@ set(FISHCOMPLETIONDIR ${DATADIR}/fish/vendor_completions.d
 set(BASHCOMPLETIONDIR ${DATADIR}/bash-completion/completions
     CACHE PATH "Install path for bash completions file")
 
+option(WITH_SYSTEMD "Enable systemd sd_notify integration" OFF)
+
+if(WITH_SYSTEMD)
+    pkg_check_modules(SYSTEMD REQUIRED libsystemd)
+    add_compile_definitions(HAVE_SYSTEMD)
+    include_directories(${SYSTEMD_INCLUDE_DIRS})
+    link_libraries(${SYSTEMD_LIBRARIES})
+
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=systemduserunitdir systemd
+                    OUTPUT_VARIABLE SYSTEMD_USER_UNIT_DIR_DEFAULT
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT SYSTEMD_USER_UNIT_DIR_DEFAULT)
+        set(SYSTEMD_USER_UNIT_DIR_DEFAULT "lib/systemd/user")
+    endif()
+
+    set(SYSTEMD_USER_UNIT_DIR "${SYSTEMD_USER_UNIT_DIR_DEFAULT}"
+        CACHE PATH "Install path for systemd user unit")
+
+    install(FILES share/herbstluftwm.service DESTINATION ${SYSTEMD_USER_UNIT_DIR})
+endif()
+
 ## do the actual work
 add_subdirectory(ipc-client)
 add_subdirectory(src)

--- a/INSTALL
+++ b/INSTALL
@@ -13,6 +13,8 @@ Build dependencies:
     - asciidoc (only when building from git, not when building from tarball)
     - a posix system with _POSIX_TIMERS and _POSIX_MONOTONIC_CLOCK or a system
       with a current mach kernel
+    - optionally: pkg-config and systemd development files for systemd
+      sd_notify integration
 
 Runtime dependencies:
 
@@ -67,6 +69,17 @@ If you are building from a source tarball or do not want to build the
 documentation, you can disable WITH_DOCUMENTATION during cmake:
 
     cmake -DWITH_DOCUMENTATION=NO ..
+
+If you want to build with systemd sd_notify integration, enable it
+using WITH_SYSTEMD:
+
+    cmake -DWITH_SYSTEMD=ON ..
+
+By default, the systemd user unit is installed to the directory provided by
+pkg-config (falling back to lib/systemd/user). You can override this using
+SYSTEMD_USER_UNIT_DIR:
+
+    cmake -DWITH_SYSTEMD=ON -DSYSTEMD_USER_UNIT_DIR=/custom/path ..
 
 To use the software locally, create your own autostart file:
 

--- a/share/herbstluftwm.service
+++ b/share/herbstluftwm.service
@@ -8,3 +8,4 @@ After=graphical-session-pre.target
 ExecStart=herbstluftwm
 ExecReload=herbstluftwm reload
 Restart=on-failure
+Type=notify

--- a/share/herbstluftwm.service
+++ b/share/herbstluftwm.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=A manual tiling window manager for X11
+Documentation=man:herbstluftwm(1)
+PartOf=graphical-session.target
+After=graphical-session-pre.target
+
+[Service]
+ExecStart=herbstluftwm
+ExecReload=herbstluftwm reload
+Restart=on-failure

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,10 @@
 #include "xconnection.h"
 #include "xmainloop.h"
 
+#ifdef HAVE_SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 using std::endl;
 using std::make_shared;
 using std::pair;
@@ -444,6 +448,11 @@ int main(int argc, char* argv[]) {
     }
     mainloop.childExited.connect(root->autostart(), &Autostart::childExited);
     root->autostart()->reloadCmd();
+
+#ifdef HAVE_SYSTEMD
+    // Signal systemd that herbstluftwm has finished initializing
+    sd_notify(0, "READY=1\n");
+#endif
 
     // main loop
     mainloop.run();


### PR DESCRIPTION
I am modernizing my herbstluftwm + gnome-flashback setup. Recent GNOME versions have overhauled session management. GNOME has deprecated its legacy internal session manager and now delegates session component initialization to `systemd --user`.

Because of this, herbstluftwm needs to be started a systemd user unit, that can be later selected by the gnome-flashback-herbstluftwm session (not part of this PR). Therefore, it seems sensible for herbstluftwm to ship a `herbstluftwm.service`. This is done in the first commit. The second commit adds `sd_notify()` integration, which is not strictly necessary, but nice to have. Feel free to pick neither, the first, or all commits in this PR.