### PR TITLE
Fix unmap counting when 'decorated' changes on an unmapped client

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,14 @@ herbstluftwm NEWS -- History of user-visible changes
 See the link:MIGRATION[] file for changes that introduced incompatibility to
 older versions.
 
+Current git version
+-------------------
+
+  * Fix the counting of unmap events when the 'decorated' attribute of an
+    unmapped (e.g. minimized) client changes. Previously, the next unmap by
+    the application itself (e.g. hiding to the system tray) was ignored and
+    the window stayed managed although it was not shown anymore.
+
 Release 0.9.6 on 2026-04-03
 ---------------------------
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -694,8 +694,12 @@ void Client::fixParentWindow(bool decorated)
         }
         XReparentWindow(X_.display(), window_, dec->decorationWindow(), 40, 40);
     }
-    // the unmap triggers an unmap notify for the window itself
-    ignore_unmaps_++;
+    // XReparentWindow() temporarily unmaps the window and thus triggers an
+    // unmap notify for the window itself, but only if the window is currently
+    // mapped
+    if (visible_()) {
+        ignore_unmaps_++;
+    }
     needsRelayout.emit(this->tag());
 }
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -587,6 +587,45 @@ def test_decorated_change_while_minimized(hlwm, x11):
         assert_decoration_state_correct(hlwm, x11, winid)
 
 
+@pytest.mark.parametrize("hide_by", ["visible", "minimized", "hidden_tag"])
+def test_decorated_change_on_unmapped_client_then_self_unmap(hlwm, x11, hide_by):
+    """
+    Changing 'decorated' on an unmapped client must not increment the
+    counter of unmap events to ignore, because XReparentWindow() only
+    generates an UnmapNotify for a mapped window. Otherwise, a later unmap
+    by the application itself (e.g. hiding to the tray) would be ignored
+    and hlwm would keep managing an unmapped window. The "visible" case
+    checks that the counter is still incremented for a mapped window.
+    """
+    handle, winid = x11.create_client()
+    hlwm.attr.theme.border_width = 11
+    client_obj = hlwm.attr.clients[winid]
+    if hide_by == "minimized":
+        client_obj.minimized = True
+    elif hide_by == "hidden_tag":
+        hlwm.call('add othertag')
+        hlwm.call(['move', 'othertag'])
+    assert client_obj.visible() is (hide_by == "visible")
+
+    # toggle decorations
+    client_obj.decorated = False
+    client_obj.decorated = True
+
+    # make the client visible again
+    if hide_by == "minimized":
+        client_obj.minimized = False
+    elif hide_by == "hidden_tag":
+        hlwm.call(['bring', winid])
+    assert client_obj.visible() is True
+    assert_decoration_state_correct(hlwm, x11, winid)
+
+    # the application withdraws its window
+    handle.unmap()
+    x11.sync_with_hlwm()
+
+    assert winid not in hlwm.list_children('clients')
+
+
 def test_decorated_off_floating_geometry_correct(hlwm):
     winid, _ = hlwm.create_client()
     hlwm.attr.theme.border_width = 8


### PR DESCRIPTION
## Bug

An application that withdraws its own window (Electron apps hiding to the system tray, or any `XWithdrawWindow`) stays managed by hlwm as a visible client if the `decorated` attribute was ever changed while the client was unmapped (minimized, or on a tag that is not shown).

The window is gone from the screen, `clients.<id>.visible` still says `true`, `WM_STATE` stays `NormalState`, and the application's next `MapRequest` only clears `minimized` (`XMainLoop::maprequest`) and never maps the window, so the application can never show its window again.

## Mechanism

1. hlwm counts the unmaps it causes itself in `Client::ignore_unmaps_`; `ClientManager::unmap_notify` only unmanages a client on `UnmapNotify` when the counter is zero.
2. `Client::fixParentWindow` (the `decorated` attribute's change handler, added in #1374) reparents the client window and then does `ignore_unmaps_++` unconditionally.

However, `XReparentWindow` only generates an `UnmapNotify` for a *mapped* window (Xlib manual: "If the window is mapped, XReparentWindow automatically performs an UnmapWindow request on it"), so every `decorated` change on an unmapped client leaks one count, and the next genuine `UnmapNotify` from the application is swallowed.

The sibling increment in `Client::set_visible(false)` is correctly paired with its own `XUnmapWindow`; only `fixParentWindow` is unbalanced.

## Fix

Guard the increment with `visible_()` (the same predicate the `decorated` branch already uses to decide whether to map the decoration window)

Note: I also
- added a regression test (parametrized over minimized / hidden tag) 
- Updated NEWS

## Repro on 0.9.6 / master (`H` = a client on the shown tag, `W` its X id)

```
herbstclient add Fun
herbstclient apply_tmp_rule $H tag=Fun          # hidden tag: unmapped
herbstclient attr clients.$H.decorated true
herbstclient attr clients.$H.decorated false    # two leaked counts
herbstclient bring $H                           # mapped again
xdotool windowunmap --sync $W                   # app hides itself
herbstclient list_clients                       # still lists $H (bug)
xdotool windowmap --sync $W                     # window stays IsUnMapped (bug)
```

Without the two `decorated` changes the self-unmap unmanages the client at once.

## Related

- #1374 introduced `decorated` and `fixParentWindow`.
- #1537 (rules setting `decorated` at manage time) would make it easier to hit this, since a rule can set `decorated` on a client that is placed on a hidden tag.
