### PR TITLE
Keep the stacking order of sticky clients when switching tags

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,11 @@ Current git version
     unmapped (e.g. minimized) client changes. Previously, the next unmap by
     the application itself (e.g. hiding to the system tray) was ignored and
     the window stayed managed although it was not shown anymore.
+  * Fix the stacking order of sticky clients: switching the tag (or
+    swapping the tags of two monitors) moved the sticky clients to the new
+    tag one by one, each on top, so their relative stacking order was
+    replaced by the order of the tag's client list and a covered sticky
+    window could end up on top of the focused one.
 
 Release 0.9.6 on 2026-04-03
 ---------------------------

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -389,8 +389,43 @@ void all_monitors_apply_layout() {
     }
 }
 
+/**
+ * @brief Reorder the given clients by their position in the stack of the
+ * given tag, from bottom to top. Clients that are not in the stack (which
+ * should not happen) are kept in their given order at the top.
+ */
+static void sort_clients_by_stack(vector<Client*> &clients, HSTag* tag) {
+    vector<Client*> top_to_bottom;
+    // the stack lists the layers from top to bottom and the slices
+    // within each layer from top to bottom; a slice is stacked at its
+    // highest layer, i.e. where it is encountered first.
+    for (int layer = 0; layer < LAYER_COUNT; layer++) {
+        for (Slice* slice : tag->stack->layers_[layer]) {
+            for (Client* client : clients) {
+                if (client->slice == slice
+                    && std::find(top_to_bottom.begin(), top_to_bottom.end(), client)
+                       == top_to_bottom.end())
+                {
+                    top_to_bottom.push_back(client);
+                }
+            }
+        }
+    }
+    for (Client* client : clients) {
+        if (std::find(top_to_bottom.begin(), top_to_bottom.end(), client)
+            == top_to_bottom.end())
+        {
+            top_to_bottom.insert(top_to_bottom.begin(), client);
+        }
+    }
+    clients.assign(top_to_bottom.rbegin(), top_to_bottom.rend());
+}
+
 void move_clients_to_tag(vector<Client*> &clients, HSTag* from_tag, HSTag* to_tag) {
     Client* focused = from_tag->focusedClient();
+    // every client is inserted on top of the stack of to_tag, so moving
+    // them from bottom to top preserves their relative stacking order.
+    sort_clients_by_stack(clients, from_tag);
     for (auto client : clients) {
         assert(client->tag() == from_tag);
         from_tag->removeClient(client);

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 import random
 from conftest import PROCESS_SHUTDOWN_TIME
 from herbstluftwm.types import Rectangle
@@ -768,3 +769,36 @@ def test_sticky_swap_tags(hlwm):
 
     hlwm.call(f"focus_monitor {monitor2}")
     assert hlwm.attr.tags.focus.focused_client.winid() == client2
+
+
+def helper_client_stack(hlwm):
+    """the winids of the clients in the 'stack' output, top to bottom"""
+    winids = re.findall(r'Client (0x[0-9a-f]+)', hlwm.call('stack').stdout)
+    unique = []
+    for w in winids:
+        if w not in unique:
+            unique.append(w)
+    return unique
+
+
+@pytest.mark.parametrize('floating', ['tag', 'client'])
+def test_sticky_switch_tag_keeps_stacking_order(hlwm, floating):
+    hlwm.call('add othertag')
+    if floating == 'tag':
+        hlwm.call('floating on')
+        hlwm.call('attr tags.by-name.othertag.floating true')
+    clients = hlwm.create_clients(3)
+    for c in clients:
+        hlwm.attr.clients[c].sticky = True
+        if floating == 'client':
+            hlwm.attr.clients[c].floating = True
+    # stack the middle client on top: order top to bottom = 1, 2, 0
+    hlwm.call(['raise', clients[1]])
+    expected = [clients[1], clients[2], clients[0]]
+    assert helper_client_stack(hlwm) == expected
+
+    hlwm.call('use othertag')
+    assert helper_client_stack(hlwm) == expected
+
+    hlwm.call('use default')
+    assert helper_client_stack(hlwm) == expected


### PR DESCRIPTION
## Bug

With two or more sticky clients that overlap (floating clients, or a floating tag), every tag switch changes which one is on top: after `use othertag` the sticky clients are stacked in the order of the tag's client list (last one on top), regardless of what their stacking order was before.
Focus is unaffected, so the focused sticky window can end up covered by another sticky window (keyboard input goes to a window that is not visible)

note: the same happens on the tag-swap path (`swap_monitors_to_get_tag`).

## Mechanism

1. `monitor_set_tag` collects the sticky clients of the old tag with `get_sticky_clients` (client-list order: frame clients, then `floating_clients_`)
2. `move_clients_to_tag` moves them one by one:
	1. `removeClientSlice` on the old tag
	2. `insertClientSlice` on the new one.

note: `Stack::insertSlice` inserts the slice on top of each of its layers (`PlainStack::insert` with `insertOnTop = true`), so the last client in the list ends up on top.

## Fix

1. `move_clients_to_tag` first orders the clients bottom-to-top by their position in the old tag's stack (the rule `Stack::extractWindows` uses):
	1. layers top-to-bottom
	2. slices top-to-bottom
	3. first occurrence (the slice's highest layer)
2. move them in that order; the inserts on top reproduce the original order.

note:
- focus handling is unchanged.
- both `monitor_set_tag paths` (plain switch and swap_monitors_to_get_tag) are fixed (both go through `move_clients_to_tag`)

## Testing

- Adds `test_sticky_switch_tag_keeps_stacking_order` (parametrized: floating tag / floating clients on a tiling tag), which fails on master and passes with the fix

note: tiled sticky clients are not part of the test: the layout re-raises them (`needsRaise`), which is correct.

### Repro on 0.9.6 / master

```
herbstclient add othertag
herbstclient floating on
herbstclient attr tags.by-name.othertag.floating true
# open three clients A, B, C (in that order), then:
for c in $A $B $C; do herbstclient attr clients.$c.sticky true; done
herbstclient raise $B
herbstclient stack        # Floating-Layer: B, C, A (top to bottom)
herbstclient use othertag
herbstclient stack        # Floating-Layer: C, B, A on master — B, C, A with the fix
```
