### PR TITLE
Add herbstclient option --hook-ready-text to indicate hc --idle connection

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@ herbstluftwm NEWS -- History of user-visible changes
 See the link:MIGRATION[] file for changes that introduced incompatibility to
 older versions.
 
+Current git version
+-------------------
+  * New herbstclient option *--hook-ready-text* (to indicate established
+    connection of the *--idle* mode)
+
 Release 0.9.6 on 2026-04-03
 ---------------------------
 

--- a/doc/herbstclient.txt
+++ b/doc/herbstclient.txt
@@ -51,6 +51,10 @@ OPTIONS
     Let *--wait* exit after 'COUNT' hooks were received and printed. The default
     'COUNT' is 1.
 
+*--hook-ready-text* 'TEXT'::
+   Print a the specified 'TEXT' as soon as *--idle*/*--wait* has connected to
+   herbstluftwm (so it only has effect when listening to hooks).
+
 *-q*, *--quiet*::
     Do not print error messages if herbstclient cannot connect to the running
     herbstluftwm instance.

--- a/ipc-client/main.c
+++ b/ipc-client/main.c
@@ -27,6 +27,9 @@ static bool g_quiet = false;
 static regex_t* g_hook_regex = NULL;
 static int g_hook_regex_count = 0;
 static int g_hook_count = 1; // count of hooks to wait for, 0 means: forever
+static int g_hook_indicate_bootup = 0; // print a message after having connected to the hlwm window
+
+#define HOOK_BOOTUP_MESSAGE "hook_connected"
 
 static void quit_herbstclient(int signal) {
     // TODO: better solution to quit x connection more softly?
@@ -92,6 +95,9 @@ void print_help(char* command, FILE* file) {
             "connect to the running herbstluftwm instance.\n"
         "\t--binary-pipe: run multiple commands via a binary interface"
             "on the standard channels.\n"
+        "\t--indicate-connected: Print a (synthetic) line \'" HOOK_BOOTUP_MESSAGE "\' "
+            "as soon as --idle/--wait have connected to herbstluftwm (only has effect "
+            "when listening to hooks\n"
         "\t-v, --version: Print the herbstclient version. To get the "
             "herbstluftwm version, use 'herbstclient version'.\n"
         "\t-h, --help: Print this help."
@@ -124,7 +130,22 @@ int main_hook(int argc, char* argv[]) {
     signal(SIGINT,  quit_herbstclient);
     signal(SIGQUIT, quit_herbstclient);
     int exit_code = 0;
-    while (1) {
+    // explicitly connect to hlwm's hook window
+    if (!hc_hook_window_connect(con)) {
+        fprintf(stderr, "Cannot listen for hooks\n");
+        exit_code = EXIT_FAILURE;
+    }
+    if (g_hook_indicate_bootup) {
+        printf("%s", HOOK_BOOTUP_MESSAGE);
+        if (g_null_char_as_delim) {
+            putchar(0);
+        } else {
+            printf("\n");
+        }
+        fflush(stdout);
+    }
+    // repeat while there has been no error
+    while (exit_code == 0) {
         bool print_signal = true;
         int hook_argc;
         char** hook_argv;
@@ -283,6 +304,7 @@ int main(int argc, char* argv[]) {
         {"count", 1, 0, 'c'},
         {"idle", 0, 0, 'i'},
         {"quiet", 0, 0, 'q'},
+        {"indicate-connected", 0, &g_hook_indicate_bootup, 1},
         {"version", 0, 0, 'v'},
         {"help", 0, 0, 'h'},
         {0, 0, 0, 0}

--- a/ipc-client/main.c
+++ b/ipc-client/main.c
@@ -27,9 +27,9 @@ static bool g_quiet = false;
 static regex_t* g_hook_regex = NULL;
 static int g_hook_regex_count = 0;
 static int g_hook_count = 1; // count of hooks to wait for, 0 means: forever
-static int g_hook_indicate_bootup = 0; // print a message after having connected to the hlwm window
 
-#define HOOK_BOOTUP_MESSAGE "hook_connected"
+#define HOOK_BOOTUP_MESSAGE_OPT 1000
+static char* g_hook_bootup_message = 0; // print this message after having connected to the hlwm window
 
 static void quit_herbstclient(int signal) {
     // TODO: better solution to quit x connection more softly?
@@ -95,9 +95,9 @@ void print_help(char* command, FILE* file) {
             "connect to the running herbstluftwm instance.\n"
         "\t--binary-pipe: run multiple commands via a binary interface"
             "on the standard channels.\n"
-        "\t--indicate-connected: Print a (synthetic) line \'" HOOK_BOOTUP_MESSAGE "\' "
-            "as soon as --idle/--wait have connected to herbstluftwm (only has effect "
-            "when listening to hooks\n"
+        "\t--hook-ready-text=TEXT: Print a the specified TEXT "
+            "as soon as --idle/--wait has connected to herbstluftwm (only has effect "
+            "when listening to hooks)\n"
         "\t-v, --version: Print the herbstclient version. To get the "
             "herbstluftwm version, use 'herbstclient version'.\n"
         "\t-h, --help: Print this help."
@@ -135,8 +135,8 @@ int main_hook(int argc, char* argv[]) {
         fprintf(stderr, "Cannot listen for hooks\n");
         exit_code = EXIT_FAILURE;
     }
-    if (g_hook_indicate_bootup) {
-        printf("%s", HOOK_BOOTUP_MESSAGE);
+    if (g_hook_bootup_message) {
+        printf("%s", g_hook_bootup_message);
         if (g_null_char_as_delim) {
             putchar(0);
         } else {
@@ -304,7 +304,7 @@ int main(int argc, char* argv[]) {
         {"count", 1, 0, 'c'},
         {"idle", 0, 0, 'i'},
         {"quiet", 0, 0, 'q'},
-        {"indicate-connected", 0, &g_hook_indicate_bootup, 1},
+        {"hook-ready-text", 1, 0, HOOK_BOOTUP_MESSAGE_OPT},
         {"version", 0, 0, 'v'},
         {"help", 0, 0, 'h'},
         {0, 0, 0, 0}
@@ -317,8 +317,13 @@ int main(int argc, char* argv[]) {
             break;
         }
         switch (c) {
+            case HOOK_BOOTUP_MESSAGE_OPT:
+                // optarg should (hopefully) point to a suffix within
+                // one of the entries of argv
+                g_hook_bootup_message = optarg;
+                break;
             case 0:
-                /* ignore recognized long option */
+                /* ignore any other recognized long option */
                 break;
             case 'i':
                 g_hook_count = 0;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -548,31 +548,18 @@ class HcIdle:
         """
         self.hlwm = hlwm
         self.separator = b'\n'
-        command = [hlwm.HC_PATH, '--idle']
+        command = [hlwm.HC_PATH, '--hook-ready-text=hc_idle_bootup', '--idle']
         if zero_separated:
-            command = [hlwm.HC_PATH, '-0', '--idle']
+            command = [hlwm.HC_PATH, '--hook-ready-text=hc_idle_bootup', '-0', '--idle']
             self.separator = b'\x00'
         self.proc = subprocess.Popen(command,
                                      stdout=subprocess.PIPE,
                                      bufsize=0)
-        # we don't know how fast self.proc connects to hlwm.
-        # So we keep sending messages via hlwm util we receive some
-        number_sent = 0
-        while [] == select.select([self.proc.stdout], [], [], 0.1)[0]:
-            # while there hasn't been a message received, send something
-            number_sent += 1
-            self.hlwm.call(['emit_hook', 'hc_idle_bootup', number_sent])
-        # now that we know that self.proc is connected, we need to consume
-        # its output up to the last message we have sent
-        assert number_sent > 0
-        number_received = 0
-        while number_received < number_sent:
-            line = self.read_hook()
-            assert line[0] == 'hc_idle_bootup'
-            number_received = int(line[1])
+        bootup = self.read_hook()
+        assert bootup[0] == 'hc_idle_bootup'
 
     def read_hook(self):
-        """read exactly one hook. This blocks if there is on herbstclient's stdout none."""
+        """read exactly one hook. This blocks until there is one on herbstclient's stdout."""
         line_bytes = b''
         while True:
             b = self.proc.stdout.read(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import Xlib
 import ewmh
 import os
 import re
-import select
 import selectors
 import shlex
 import shutil

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,12 +55,15 @@ class HlwmBridge(herbstluftwm.Herbstluftwm):
         self.env = extend_env_with_whitelist(self.env)
         self.hlwm_process = hlwm_process
         self.hc_idle = subprocess.Popen(
-            [self.HC_PATH, '--idle', 'rule', 'here_is_.*'],
+            [self.HC_PATH, '--indicate-connected', '--idle', 'rule', 'here_is_.*'],
             bufsize=1,  # line buffered
             universal_newlines=True,
             env=self.env,
             stdout=subprocess.PIPE
         )
+        # wait for hc --idle to connect to hlwm's hook window
+        bootup_message = self.hc_idle.stdout.readline()
+        assert bootup_message.rstrip() == "hook_connected"
         # a dictionary mapping wmclasses to window ids as reported
         # by self.hc_idle
         self.wmclass2winid = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ class HlwmBridge(herbstluftwm.Herbstluftwm):
         self.env = extend_env_with_whitelist(self.env)
         self.hlwm_process = hlwm_process
         self.hc_idle = subprocess.Popen(
-            [self.HC_PATH, '--indicate-connected', '--idle', 'rule', 'here_is_.*'],
+            [self.HC_PATH, '--hook-ready-text=IDLE_IS_READY', '--idle', 'rule', 'here_is_.*'],
             bufsize=1,  # line buffered
             universal_newlines=True,
             env=self.env,
@@ -63,7 +63,7 @@ class HlwmBridge(herbstluftwm.Herbstluftwm):
         )
         # wait for hc --idle to connect to hlwm's hook window
         bootup_message = self.hc_idle.stdout.readline()
-        assert bootup_message.rstrip() == "hook_connected"
+        assert bootup_message.rstrip() == "IDLE_IS_READY"
         # a dictionary mapping wmclasses to window ids as reported
         # by self.hc_idle
         self.wmclass2winid = {}


### PR DESCRIPTION
The new option lets herbstclient print a user-supplied text once herbstclient is listening to hooks.

* This avoids a race condition in HlwmBridge (and generally almost every script that is listening to hooks) by letting herbstclient print a bootup message as soon as it has connected to hlwm's hook window.
* The race conditions was already solved in the `HcIdle` class, but the new option simplifies the bootup routine considerably.
