### PR TITLE
Keep transient windows above the window they are transient for

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,9 +18,11 @@ Current git version
   * Keep transient windows (dialogs with a WM_TRANSIENT_FOR hint) above the
     window they belong to: raising a client now also raises its transient
     clients, and a client in the fullscreen layer or in the focus layer
-    (raise_on_focus_temporarily) takes its transient clients with it, so a
-    dialog is no longer covered by its own application after the application
-    window is raised, focused, clicked or made fullscreen.
+    (raise_on_focus_temporarily) takes its transient clients with it, and a
+    client that is set floating (or tiled again) enters the new layer below
+    its transients that are there, so a dialog is no longer covered by its
+    own application after the application window is raised, focused,
+    clicked, made fullscreen or set floating.
 
 Release 0.9.6 on 2026-04-03
 ---------------------------

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ Current git version
     unmapped (e.g. minimized) client changes. Previously, the next unmap by
     the application itself (e.g. hiding to the system tray) was ignored and
     the window stayed managed although it was not shown anymore.
+  * Put a floating client (the 'floating' attribute set) that is fullscreen
+    in the fullscreen layer, like a tiled fullscreen client. Previously it
+    was resized to the monitor but stayed in the floating layer, below any
+    floating window raised after it.
 
 Release 0.9.6 on 2026-04-03
 ---------------------------

--- a/NEWS
+++ b/NEWS
@@ -17,8 +17,10 @@ Current git version
     floating window raised after it.
   * Keep transient windows (dialogs with a WM_TRANSIENT_FOR hint) above the
     window they belong to: raising a client now also raises its transient
-    clients, so a dialog is no longer covered by its own application after
-    the application window is raised, focused or clicked.
+    clients, and a client in the fullscreen layer or in the focus layer
+    (raise_on_focus_temporarily) takes its transient clients with it, so a
+    dialog is no longer covered by its own application after the application
+    window is raised, focused, clicked or made fullscreen.
 
 Release 0.9.6 on 2026-04-03
 ---------------------------

--- a/NEWS
+++ b/NEWS
@@ -20,9 +20,11 @@ Current git version
     clients, and a client in the fullscreen layer or in the focus layer
     (raise_on_focus_temporarily) takes its transient clients with it, and a
     client that is set floating (or tiled again) enters the new layer below
-    its transients that are there, so a dialog is no longer covered by its
+    its transients that are there, and lowering a client also lowers the
+    client it is transient for, so a dialog is no longer covered by its
     own application after the application window is raised, focused,
-    clicked, made fullscreen or set floating.
+    clicked, made fullscreen or set floating, or after the dialog is
+    lowered.
 
 Release 0.9.6 on 2026-04-03
 ---------------------------

--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,10 @@ Current git version
     in the fullscreen layer, like a tiled fullscreen client. Previously it
     was resized to the monitor but stayed in the floating layer, below any
     floating window raised after it.
+  * Keep transient windows (dialogs with a WM_TRANSIENT_FOR hint) above the
+    window they belong to: raising a client now also raises its transient
+    clients, so a dialog is no longer covered by its own application after
+    the application window is raised, focused or clicked.
 
 Release 0.9.6 on 2026-04-03
 ---------------------------

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -335,6 +335,26 @@ void Client::collectWithTransients(vector<Client*>& result, std::set<Client*>& v
 }
 
 /**
+ * @brief put this client on top of the given layer of its tag's stack, and
+ * its transient windows above it. A transient that is already in the layer
+ * is re-inserted above the client; a transient that is not in the layer is
+ * inserted only if bringTransients is set (e.g. the fullscreen layer takes
+ * the dialogs of a fullscreen window with it, whereas the floating layer
+ * leaves a tiled dialog of a floated window where it is).
+ */
+void Client::raiseIntoLayer(HSLayer layer, bool bringTransients) {
+    for (Client* client : withTransients()) {
+        bool inLayer = client->slice->layers.count(layer) != 0;
+        if (client == this || inLayer || bringTransients) {
+            if (inLayer) {
+                tag()->stack->sliceRemoveLayer(client->slice, layer);
+            }
+            tag()->stack->sliceAddLayer(client->slice, layer);
+        }
+    }
+}
+
+/**
  * @brief raise this client and keep its transient windows above it: after
  * the client itself, every client on the same tag whose WM_TRANSIENT_FOR
  * names this client is raised as well (recursively), preserving their

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -302,6 +302,38 @@ void Client::updateTransientFor() {
     transientFor_ = X_.getTransientForHint(window_).value_or(None);
 }
 
+//! this client followed by the clients on its tag that are transient for
+//! it, recursively. The transients of a client are listed from the lowest to
+//! the topmost in the current stacking order, such that putting the clients
+//! on top of a layer one after the other in this order keeps every transient
+//! above the client it belongs to and keeps the relative order of the
+//! transients. A cycle in the WM_TRANSIENT_FOR hints is visited only once.
+vector<Client*> Client::withTransients() {
+    vector<Client*> result;
+    std::set<Client*> visited;
+    collectWithTransients(result, visited);
+    return result;
+}
+
+void Client::collectWithTransients(vector<Client*>& result, std::set<Client*>& visited) {
+    visited.insert(this);
+    result.push_back(this);
+    // collect the clients that are transient for this one, from top to
+    // bottom of the current stack of the tag.
+    vector<Client*> transients;
+    tag()->stack->extractWindows(true, [&](Window win) {
+        Client* client = manager.client(win);
+        if (client && client->transientFor_ == window_
+            && visited.count(client) == 0)
+        {
+            transients.push_back(client);
+        }
+    });
+    for (auto it = transients.rbegin(); it != transients.rend(); ++it) {
+        (*it)->collectWithTransients(result, visited);
+    }
+}
+
 /**
  * @brief raise this client and keep its transient windows above it: after
  * the client itself, every client on the same tag whose WM_TRANSIENT_FOR
@@ -310,28 +342,8 @@ void Client::updateTransientFor() {
  * it belongs to.
  */
 void Client::raise() {
-    std::set<Client*> raised;
-    raiseWithTransients(raised);
-}
-
-void Client::raiseWithTransients(std::set<Client*>& raised) {
-    raised.insert(this);
-    tag()->stack->raiseSlice(slice);
-    // collect the clients that are transient for this one, from top to
-    // bottom of the current stack of the tag.
-    vector<Client*> transients;
-    tag()->stack->extractWindows(true, [&](Window win) {
-        Client* client = manager.client(win);
-        if (client && client->transientFor_ == window_
-            && raised.count(client) == 0)
-        {
-            transients.push_back(client);
-        }
-    });
-    // raise the lowest transient first, such that the topmost one
-    // ends up on top again.
-    for (auto it = transients.rbegin(); it != transients.rend(); ++it) {
-        (*it)->raiseWithTransients(raised);
+    for (Client* client : withTransients()) {
+        tag()->stack->raiseSlice(client->slice);
     }
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -190,6 +190,7 @@ void Client::init_from_X() {
     update_title();
     readWmHints();
     updatesizehints();
+    updateTransientFor();
 }
 
 void Client::make_full_client() {
@@ -296,8 +297,42 @@ void Client::resize_fullscreen(Rectangle monitor_rect, bool isFocused) {
     dec->resize_outline(monitor_rect);
 }
 
+//! re-read the WM_TRANSIENT_FOR hint
+void Client::updateTransientFor() {
+    transientFor_ = X_.getTransientForHint(window_).value_or(None);
+}
+
+/**
+ * @brief raise this client and keep its transient windows above it: after
+ * the client itself, every client on the same tag whose WM_TRANSIENT_FOR
+ * names this client is raised as well (recursively), preserving their
+ * relative stacking order. So a dialog never ends up covered by the window
+ * it belongs to.
+ */
 void Client::raise() {
-    this->tag()->stack->raiseSlice(this->slice);
+    std::set<Client*> raised;
+    raiseWithTransients(raised);
+}
+
+void Client::raiseWithTransients(std::set<Client*>& raised) {
+    raised.insert(this);
+    tag()->stack->raiseSlice(slice);
+    // collect the clients that are transient for this one, from top to
+    // bottom of the current stack of the tag.
+    vector<Client*> transients;
+    tag()->stack->extractWindows(true, [&](Window win) {
+        Client* client = manager.client(win);
+        if (client && client->transientFor_ == window_
+            && raised.count(client) == 0)
+        {
+            transients.push_back(client);
+        }
+    });
+    // raise the lowest transient first, such that the topmost one
+    // ends up on top again.
+    for (auto it = transients.rbegin(); it != transients.rend(); ++it) {
+        (*it)->raiseWithTransients(raised);
+    }
 }
 
 void Client::lower()

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -367,9 +367,34 @@ void Client::raise() {
     }
 }
 
-void Client::lower()
-{
-    this->tag()->stack->lowerSlice(this->slice);
+//! the client on the same tag that this client is transient for, if any
+Client* Client::transientForClient() {
+    if (transientFor_ == None) {
+        return nullptr;
+    }
+    Client* parent = manager.client(transientFor_);
+    if (!parent || parent->tag() != tag()) {
+        return nullptr;
+    }
+    return parent;
+}
+
+/**
+ * @brief lower this client and keep it above the window it is transient
+ * for: after the client itself, the client it is transient for is lowered
+ * as well (recursively up the chain of WM_TRANSIENT_FOR hints on the same
+ * tag), such that every one of them ends up below the client that was
+ * lowered. The transients of the lowered client itself need no move, they
+ * stay above it. A cycle in the hints is visited only once.
+ */
+void Client::lower() {
+    std::set<Client*> visited;
+    Client* client = this;
+    while (client && visited.count(client) == 0) {
+        visited.insert(client);
+        tag()->stack->lowerSlice(client->slice);
+        client = client->transientForClient();
+    }
 }
 
 /**

--- a/src/client.h
+++ b/src/client.h
@@ -124,6 +124,7 @@ public:
     void update_title();
     void updateTransientFor();
     std::vector<Client*> withTransients();
+    Client* transientForClient();
     void raiseIntoLayer(HSLayer layer, bool bringTransients);
     void raise();
     void lower();

--- a/src/client.h
+++ b/src/client.h
@@ -13,6 +13,7 @@
 #include "object.h"
 #include "rectangle.h"
 #include "regexstr.h"
+#include "stack.h"
 #include "x11-types.h"
 
 class Decoration;
@@ -21,7 +22,6 @@ class ResizeAction;
 class DecTriple;
 class Ewmh;
 class FrameLeaf;
-class Slice;
 class HSTag;
 class Monitor;
 class Settings;
@@ -124,6 +124,7 @@ public:
     void update_title();
     void updateTransientFor();
     std::vector<Client*> withTransients();
+    void raiseIntoLayer(HSLayer layer, bool bringTransients);
     void raise();
     void lower();
 

--- a/src/client.h
+++ b/src/client.h
@@ -4,6 +4,7 @@
 #include <X11/X.h>
 #include <X11/Xlib.h>
 #include <set>
+#include <vector>
 
 #include "attribute_.h"
 #include "child.h"
@@ -122,6 +123,7 @@ public:
     void readWmHints(bool forceNotUrgent = false);
     void update_title();
     void updateTransientFor();
+    std::vector<Client*> withTransients();
     void raise();
     void lower();
 
@@ -140,7 +142,7 @@ public:
 
     void updateEwmhState();
 private:
-    void raiseWithTransients(std::set<Client*>& raised);
+    void collectWithTransients(std::vector<Client*>& result, std::set<Client*>& visited);
     void floatingGeometryChanged();
     void urgencyAttributeChanged(bool state);
     void fixParentWindow(bool decorated);

--- a/src/client.h
+++ b/src/client.h
@@ -3,6 +3,7 @@
 
 #include <X11/X.h>
 #include <X11/Xlib.h>
+#include <set>
 
 #include "attribute_.h"
 #include "child.h"
@@ -40,6 +41,8 @@ public:
     Attribute_<Rectangle> float_size_;     // floating size without the window border
     HSTag*      tag_ = {};
     Slice* slice = {};
+    //! the window named by WM_TRANSIENT_FOR, or None if there is no such hint
+    Window      transientFor_ = None;
     bool        ewmhfullscreen_ = false; // ewmh fullscreen state
     bool        neverfocus_ = false; // do not give the focus via XSetInputFocus
     Attribute_<bool> decorated_;
@@ -118,6 +121,7 @@ public:
     void set_urgent(bool state);
     void readWmHints(bool forceNotUrgent = false);
     void update_title();
+    void updateTransientFor();
     void raise();
     void lower();
 
@@ -136,6 +140,7 @@ public:
 
     void updateEwmhState();
 private:
+    void raiseWithTransients(std::set<Client*>& raised);
     void floatingGeometryChanged();
     void urgencyAttributeChanged(bool state);
     void fixParentWindow(bool decorated);

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -213,14 +213,12 @@ void Monitor::applyLayout() {
         if (!c->fullscreen_()) {
             return;
         }
-        // if the client enters the fullscreen layer now, then re-insert its
-        // transients that are already in the layer, such that they end up
-        // above the client again.
-        bool entersLayer = c->slice->layers.count(LAYER_FULLSCREEN) == 0;
+        if (c->slice->layers.count(LAYER_FULLSCREEN) == 0) {
+            // the client enters the fullscreen layer now: on top, and its
+            // transients above it (also those already in the layer)
+            c->raiseIntoLayer(LAYER_FULLSCREEN, true);
+        }
         for (Client* client : c->withTransients()) {
-            if (entersLayer) {
-                tag->stack->sliceRemoveLayer(client->slice, LAYER_FULLSCREEN);
-            }
             tag->stack->sliceAddLayer(client->slice, LAYER_FULLSCREEN);
             inFullscreenLayer.insert(client);
         }
@@ -258,9 +256,7 @@ void Monitor::applyLayout() {
             || tag->stack->isLayerEmpty(LAYER_FULLSCREEN) == false)
         {
             // the transients of the focused client come along, above it
-            for (Client* client : res.focus->withTransients()) {
-                tag->stack->sliceAddLayer(client->slice, LAYER_FOCUS);
-            }
+            res.focus->raiseIntoLayer(LAYER_FOCUS, true);
         }
     }
     restack();

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <cstring>
 #include <sstream>
+#include <set>
 #include <vector>
 
 #include "client.h"
@@ -204,12 +205,28 @@ void Monitor::applyLayout() {
         }
     }
     // 1. Update stack (TODO: why stack first?)
-    // the fullscreen layer holds the fullscreen clients, tiled or floated
-    // (res.data only contains the clients of the frame tree)
+    // The fullscreen layer holds the fullscreen clients (tiled or floated)
+    // and their transient clients (their dialogs), such that a dialog stays
+    // above its fullscreen window.
+    std::set<Client*> inFullscreenLayer;
     tag->foreachClient([&](Client* c) {
-        if (c->fullscreen_()) {
-            tag->stack->sliceAddLayer(c->slice, LAYER_FULLSCREEN);
-        } else {
+        if (!c->fullscreen_()) {
+            return;
+        }
+        // if the client enters the fullscreen layer now, then re-insert its
+        // transients that are already in the layer, such that they end up
+        // above the client again.
+        bool entersLayer = c->slice->layers.count(LAYER_FULLSCREEN) == 0;
+        for (Client* client : c->withTransients()) {
+            if (entersLayer) {
+                tag->stack->sliceRemoveLayer(client->slice, LAYER_FULLSCREEN);
+            }
+            tag->stack->sliceAddLayer(client->slice, LAYER_FULLSCREEN);
+            inFullscreenLayer.insert(client);
+        }
+    });
+    tag->foreachClient([&](Client* c) {
+        if (inFullscreenLayer.count(c) == 0) {
             tag->stack->sliceRemoveLayer(c->slice, LAYER_FULLSCREEN);
         }
     });
@@ -240,7 +257,10 @@ void Monitor::applyLayout() {
         if ((isFocused && g_settings->raise_on_focus_temporarily())
             || tag->stack->isLayerEmpty(LAYER_FULLSCREEN) == false)
         {
-            tag->stack->sliceAddLayer(res.focus->slice, LAYER_FOCUS);
+            // the transients of the focused client come along, above it
+            for (Client* client : res.focus->withTransients()) {
+                tag->stack->sliceAddLayer(client->slice, LAYER_FOCUS);
+            }
         }
     }
     restack();

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -204,13 +204,17 @@ void Monitor::applyLayout() {
         }
     }
     // 1. Update stack (TODO: why stack first?)
-    for (auto& p : res.data) {
-        Client* c = p.first;
+    // the fullscreen layer holds the fullscreen clients, tiled or floated
+    // (res.data only contains the clients of the frame tree)
+    tag->foreachClient([&](Client* c) {
         if (c->fullscreen_()) {
             tag->stack->sliceAddLayer(c->slice, LAYER_FULLSCREEN);
         } else {
             tag->stack->sliceRemoveLayer(c->slice, LAYER_FULLSCREEN);
         }
+    });
+    for (auto& p : res.data) {
+        Client* c = p.first;
         // special raise rules for tiled clients:
         if (!p.second.floated) {
             // this client is the globally focused client if this monitor

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -142,7 +142,9 @@ void HSTag::applyClientState(Client* client)
                 floating_clients_focus_ = floating_clients_.size() - 1;
             }
             stack->sliceRemoveLayer(client->slice, LAYER_NORMAL);
-            stack->sliceAddLayer(client->slice, LAYER_FLOATING);
+            // on top of the floating layer, below its transients that
+            // float already (a tiled transient stays where it is)
+            client->raiseIntoLayer(LAYER_FLOATING, false);
         }
     } else {
         // client wants to be tiled again
@@ -153,7 +155,8 @@ void HSTag::applyClientState(Client* client)
             if (!floating()) {
                 stack->sliceRemoveLayer(client->slice, LAYER_FLOATING);
             }
-            stack->sliceAddLayer(client->slice, LAYER_NORMAL);
+            // on top of the tiling layer, below its tiled transients
+            client->raiseIntoLayer(LAYER_NORMAL, false);
         }
     }
     if (!hasVisibleFloatingClients()) {

--- a/src/xmainloop.cpp
+++ b/src/xmainloop.cpp
@@ -684,6 +684,8 @@ void XMainLoop::propertynotify(XPropertyEvent* ev) {
             } else if (ev->atom == XA_WM_NAME ||
                        ev->atom == root_->ewmh_.netatom(NetWmName)) {
                 client->update_title();
+            } else if (ev->atom == XA_WM_TRANSIENT_FOR) {
+                client->updateTransientFor();
             } else if (ev->atom == XA_WM_CLASS && client) {
                 // according to the ICCCM specification, the WM_CLASS property may only
                 // be changed in the withdrawn state:
@@ -695,6 +697,10 @@ void XMainLoop::propertynotify(XPropertyEvent* ev) {
             }
         } else {
             root_->panels->propertyChanged(ev->window, ev->atom);
+        }
+    } else if (ev->state == PropertyDelete && client != nullptr) {
+        if (ev->atom == XA_WM_TRANSIENT_FOR) {
+            client->updateTransientFor();
         }
     }
 }

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -363,3 +363,21 @@ def test_fullscreen_above_unmanaged(hlwm, x11, mouse, decorated):
     # double check that disabling fullscreen lowers the window again:
     hlwm.attr.clients[fs_winid].fullscreen = False
     assert x11.get_window_under_cursor() == um
+
+
+def helper_get_layer_as_list(hlwm, layer):
+    """the clients in the given layer (e.g. 'Fullscreen-Layer') of the
+    stack, from top to bottom"""
+    stack_stdout = hlwm.call('stack').stdout
+    match = re.search(layer + r'(\n.*Client.*)*', stack_stdout, flags=re.MULTILINE)
+    return re.findall('Client (0x[0-9a-f]+)', match.group(0))
+
+
+def test_single_floated_fullscreen_client_in_fullscreen_layer(hlwm):
+    winid, _ = hlwm.create_client()
+    other, _ = hlwm.create_client()
+    hlwm.attr.clients[winid].floating = True
+    hlwm.attr.clients[winid].fullscreen = True
+    assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') == [winid]
+    hlwm.attr.clients[winid].fullscreen = False
+    assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') == []

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -381,3 +381,109 @@ def test_single_floated_fullscreen_client_in_fullscreen_layer(hlwm):
     assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') == [winid]
     hlwm.attr.clients[winid].fullscreen = False
     assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') == []
+
+
+@pytest.mark.parametrize('floating', [True, False])
+@pytest.mark.parametrize('raise_command', ['raise', 'jumpto'])
+def test_raise_keeps_transient_above_parent(hlwm, x11, floating, raise_command):
+    hlwm.call(['floating', hlwm.bool(floating)])
+    hlwm.call('set raise_on_focus true')
+    parent_win, parent = x11.create_client()
+    _, dialog = x11.create_client(transient_for=parent_win)
+    if not floating:
+        # the dialog floats by its transient hint; float the third client
+        # explicitly so that it can cover the dialog:
+        hlwm.call('rule once floating=on')
+    _, other = x11.create_client()
+    # focus 'other' first: a focused tiled parent is re-raised on every
+    # relayout, and so would be its dialog.
+    hlwm.call(['jumpto', other])
+    hlwm.call(['raise', other])
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [other, dialog, parent]
+    # the tiled parent stays below the floating layer:
+    expected = [dialog, parent, other] if floating else [dialog, other, parent]
+
+    hlwm.call([raise_command, parent])
+
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) == expected
+
+
+def test_raise_keeps_relative_order_of_transients(hlwm, x11):
+    hlwm.call('floating on')
+    parent_win, parent = x11.create_client()
+    _, dialog1 = x11.create_client(transient_for=parent_win)
+    _, dialog2 = x11.create_client(transient_for=parent_win)
+    _, other = x11.create_client()
+    hlwm.call(['raise', dialog1])
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [dialog1, other, dialog2, parent]
+
+    hlwm.call(['raise', parent])
+
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [dialog1, dialog2, parent, other]
+
+
+def test_raise_keeps_nested_transient_above_parent(hlwm, x11):
+    hlwm.call('floating on')
+    parent_win, parent = x11.create_client()
+    dialog_win, dialog = x11.create_client(transient_for=parent_win)
+    _, subdialog = x11.create_client(transient_for=dialog_win)
+    _, other = x11.create_client()
+
+    hlwm.call(['raise', parent])
+
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [subdialog, dialog, parent, other]
+
+
+def test_raise_transient_for_set_after_map(hlwm, x11):
+    hlwm.call('floating on')
+    parent_win, parent = x11.create_client()
+    dialog_win, dialog = x11.create_client()
+    _, other = x11.create_client()
+    dialog_win.set_wm_transient_for(parent_win)
+    x11.display.sync()
+
+    hlwm.call(['raise', parent])
+
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [dialog, parent, other]
+
+    # the client is no longer transient after the hint is removed:
+    dialog_win.delete_property(x11.display.intern_atom('WM_TRANSIENT_FOR'))
+    x11.display.sync()
+    hlwm.call(['raise', other])
+    hlwm.call(['raise', parent])
+
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [parent, other, dialog]
+
+
+def test_raise_transient_cycle_terminates(hlwm, x11):
+    hlwm.call('floating on')
+    win1, client1 = x11.create_client()
+    win2, client2 = x11.create_client(transient_for=win1)
+    win1.set_wm_transient_for(win2)
+    x11.display.sync()
+
+    hlwm.call(['raise', client1])
+
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [client2, client1]
+
+
+def test_raise_ignores_transient_on_other_tag(hlwm, x11):
+    hlwm.call('floating on')
+    hlwm.call('add othertag')
+    parent_win, parent = x11.create_client()
+    _, dialog = x11.create_client(transient_for=parent_win)
+    _, other = x11.create_client()
+    hlwm.call(['jumpto', dialog])
+    hlwm.call(['move', 'othertag'])
+    assert hlwm.get_attr(f'clients.{dialog}.tag') == 'othertag'
+
+    hlwm.call(['raise', parent])
+
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) == [parent, other]

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -565,3 +565,37 @@ def test_raise_on_focus_temporarily_takes_transient_into_focus_layer(hlwm, x11):
     hlwm.call(['jumpto', other_id])
     assert helper_get_layer_as_list(hlwm, 'Focus-Layer') == [other_id]
     assert helper_get_stack_as_list(hlwm) == [other_id, dialog_id, parent_id]
+
+
+def test_parent_set_floating_stays_below_transient(hlwm, x11):
+    # tiling tag: the dialog is floated by the transient_for hint, the
+    # parent is tiled
+    parent, parent_id = x11.create_client()
+    dialog, dialog_id = x11.create_client(transient_for=parent)
+    subdialog, subdialog_id = x11.create_client(transient_for=dialog)
+    other, other_id = x11.create_client()
+    hlwm.call(['jumpto', other_id])
+    assert helper_get_layer_as_list(hlwm, 'Floating-Layer') == [subdialog_id, dialog_id]
+
+    hlwm.attr.clients[parent_id].floating = True
+    assert helper_get_layer_as_list(hlwm, 'Floating-Layer') \
+        == [subdialog_id, dialog_id, parent_id]
+
+    hlwm.attr.clients[parent_id].floating = False
+    assert helper_get_layer_as_list(hlwm, 'Floating-Layer') == [subdialog_id, dialog_id]
+
+
+def test_parent_set_floating_leaves_tiled_transient(hlwm, x11):
+    hlwm.call('rule floating=off')
+    parent, parent_id = x11.create_client()
+    dialog, dialog_id = x11.create_client(transient_for=parent)
+    assert helper_get_layer_as_list(hlwm, 'Floating-Layer') == []
+
+    hlwm.attr.clients[parent_id].floating = True
+    assert helper_get_layer_as_list(hlwm, 'Floating-Layer') == [parent_id]
+    assert helper_get_layer_as_list(hlwm, 'Tiling-Layer') == [dialog_id]
+
+    # and back to tiling, below the dialog again
+    hlwm.attr.clients[parent_id].floating = False
+    assert helper_get_layer_as_list(hlwm, 'Floating-Layer') == []
+    assert helper_get_layer_as_list(hlwm, 'Tiling-Layer') == [dialog_id, parent_id]

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -489,6 +489,86 @@ def test_raise_ignores_transient_on_other_tag(hlwm, x11):
     assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) == [parent, other]
 
 
+def test_lower_transient_takes_parent_along(hlwm, x11):
+    hlwm.call('floating on')
+    parent_win, parent = x11.create_client()
+    _, dialog = x11.create_client(transient_for=parent_win)
+    _, other = x11.create_client()
+    hlwm.call(['raise', parent])
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [dialog, parent, other]
+
+    hlwm.call(['lower', dialog])
+
+    # the parent is lowered below its dialog
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [other, dialog, parent]
+
+
+def test_lower_nested_transient_takes_parents_along(hlwm, x11):
+    hlwm.call('floating on')
+    parent_win, parent = x11.create_client()
+    dialog_win, dialog = x11.create_client(transient_for=parent_win)
+    _, subdialog = x11.create_client(transient_for=dialog_win)
+    _, other = x11.create_client()
+    hlwm.call(['raise', parent])
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [subdialog, dialog, parent, other]
+
+    hlwm.call(['lower', subdialog])
+
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [other, subdialog, dialog, parent]
+
+
+def test_lower_parent_leaves_transient(hlwm, x11):
+    hlwm.call('floating on')
+    parent_win, parent = x11.create_client()
+    _, dialog = x11.create_client(transient_for=parent_win)
+    _, other = x11.create_client()
+    hlwm.call(['raise', parent])
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [dialog, parent, other]
+
+    hlwm.call(['lower', parent])
+
+    # the dialog is above its parent anyway, so only the parent moves
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [dialog, other, parent]
+
+
+def test_lower_transient_cycle_terminates(hlwm, x11):
+    hlwm.call('floating on')
+    win1, client1 = x11.create_client()
+    win2, client2 = x11.create_client(transient_for=win1)
+    win1.set_wm_transient_for(win2)
+    x11.display.sync()
+    _, other = x11.create_client()
+    hlwm.call(['raise', client2])
+
+    hlwm.call(['lower', client2])
+
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) \
+        == [other, client2, client1]
+
+
+def test_lower_ignores_parent_on_other_tag(hlwm, x11):
+    hlwm.call('floating on')
+    hlwm.call('add othertag')
+    parent_win, parent = x11.create_client()
+    _, dialog = x11.create_client(transient_for=parent_win)
+    _, other = x11.create_client()
+    hlwm.call(['jumpto', parent])
+    hlwm.call(['move', 'othertag'])
+    assert hlwm.get_attr(f'clients.{parent}.tag') == 'othertag'
+    hlwm.call(['raise', dialog])
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) == [dialog, other]
+
+    hlwm.call(['lower', dialog])
+
+    assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) == [other, dialog]
+
+
 def test_fullscreen_parent_takes_transient_into_fullscreen_layer(hlwm, x11):
     hlwm.call('floating on')
     hlwm.call('set raise_on_focus true')

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -487,3 +487,81 @@ def test_raise_ignores_transient_on_other_tag(hlwm, x11):
     hlwm.call(['raise', parent])
 
     assert helper_get_stack_as_list(hlwm, strip_focus_layer=True) == [parent, other]
+
+
+def test_fullscreen_parent_takes_transient_into_fullscreen_layer(hlwm, x11):
+    hlwm.call('floating on')
+    hlwm.call('set raise_on_focus true')
+    parent, parent_id = x11.create_client()
+    dialog, dialog_id = x11.create_client(transient_for=parent)
+    other, other_id = x11.create_client()
+    hlwm.call(['jumpto', other_id])
+    assert helper_get_stack_as_list(hlwm) == [other_id, dialog_id, parent_id]
+
+    hlwm.attr.clients[parent_id].fullscreen = True
+    assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') == [dialog_id, parent_id]
+    # the focused client is put in the focus layer above the fullscreen ones
+    assert helper_get_stack_as_list(hlwm) == [other_id, dialog_id, parent_id]
+
+    # raising the parent raises the dialog above it in every layer
+    hlwm.call(['raise', parent_id])
+    assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') == [dialog_id, parent_id]
+    assert helper_get_stack_as_list(hlwm) == [other_id, dialog_id, parent_id]
+
+    # the dialog leaves the fullscreen layer together with the parent
+    hlwm.attr.clients[parent_id].fullscreen = False
+    assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') == []
+    assert helper_get_stack_as_list(hlwm) == [dialog_id, parent_id, other_id]
+
+
+def test_focused_fullscreen_parent_takes_transient_into_focus_layer(hlwm, x11):
+    hlwm.call('floating on')
+    hlwm.call('set raise_on_focus true')
+    parent, parent_id = x11.create_client()
+    dialog, dialog_id = x11.create_client(transient_for=parent)
+    subdialog, subdialog_id = x11.create_client(transient_for=dialog)
+    other, other_id = x11.create_client()
+    hlwm.call(['jumpto', parent_id])
+    hlwm.attr.clients[parent_id].fullscreen = True
+    assert helper_get_layer_as_list(hlwm, 'Focus-Layer') \
+        == [subdialog_id, dialog_id, parent_id]
+    assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') \
+        == [subdialog_id, dialog_id, parent_id]
+    assert helper_get_stack_as_list(hlwm) \
+        == [subdialog_id, dialog_id, parent_id, other_id]
+
+
+def test_parent_entering_fullscreen_below_its_fullscreen_transient(hlwm, x11):
+    hlwm.call('floating on')
+    parent, parent_id = x11.create_client()
+    dialog, dialog_id = x11.create_client(transient_for=parent)
+    other, other_id = x11.create_client()
+    hlwm.call(['jumpto', other_id])
+
+    # a fullscreen dialog of a non-fullscreen parent is in the layer alone
+    hlwm.attr.clients[dialog_id].fullscreen = True
+    assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') == [dialog_id]
+
+    # the parent enters the layer below its dialog, not on top of it
+    hlwm.attr.clients[parent_id].fullscreen = True
+    assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') == [dialog_id, parent_id]
+
+    # the dialog stays in the layer on its own account
+    hlwm.attr.clients[parent_id].fullscreen = False
+    assert helper_get_layer_as_list(hlwm, 'Fullscreen-Layer') == [dialog_id]
+
+
+def test_raise_on_focus_temporarily_takes_transient_into_focus_layer(hlwm, x11):
+    hlwm.call('floating on')
+    hlwm.call('set raise_on_focus_temporarily true')
+    parent, parent_id = x11.create_client()
+    dialog, dialog_id = x11.create_client(transient_for=parent)
+    other, other_id = x11.create_client()
+
+    hlwm.call(['jumpto', parent_id])
+    assert helper_get_layer_as_list(hlwm, 'Focus-Layer') == [dialog_id, parent_id]
+    assert helper_get_stack_as_list(hlwm) == [dialog_id, parent_id, other_id]
+
+    hlwm.call(['jumpto', other_id])
+    assert helper_get_layer_as_list(hlwm, 'Focus-Layer') == [other_id]
+    assert helper_get_stack_as_list(hlwm) == [other_id, dialog_id, parent_id]


### PR DESCRIPTION
This PR makes hlwm enforce the EWMH stacking rule for transient windows at every place where the stacking order of a window changes

Sorry this PR description is a bit long (even though the code itself is not that long) because although the code change isn't that big, it impacts end-user behavior in a few different ways I wanted to lay out so the impact of these changes is more clear (and it doesn't really make sense to have these as separate PR, since you need all of them bundled to have coherent behavior)

## Bug

For a window with a `WM_TRANSIENT_FOR` hint, it's possible for the main window to permanently hide its own dialog (which is doubly bad in the case the modal dialog disables the parent window until the dialog is handled)

More specifically, this happens when the parent window is:
1. the target of a `raise` command (`raise_on_click`, `raise_on_focus`, or re-raising caused by a re-layout)
2. moved into the fullscreen layer (`fullscreen` on)
3. moved into the focus layer (`raise_on_focus_temporarily`, or the focused client whenever a fullscreen client exists on the tag)
5. moved into the floating layer or back into the tiling layer (`floating` attribute set or cleared)

## Background

Recall:
1. `Client::raise()` is `Stack::raiseSlice` of the client's own slice.
2. `Client::lower()` is `Stack::lowerSlice` of the client's own slice
3. `Monitor::applyLayout` moves only the client's own slice into the fullscreen / focus layer on every re-layout 
5. `HSTag::applyClientState` (the `floating` attribute) moves only the client's own slice into the floating or the tiling layer

The `WM_TRANSIENT_FOR` hint is read once (and only once) in `ClientManager::applyDefaultRules` (since #725) to float the window, and then never checked again

## Why the window manager

There are two different sources that force this to be a window manager concern:
1. X's EWMH says "Windows that are transient for another window should be kept above this window." ([source](https://specifications.freedesktop.org/wm/latest-single/#STACKINGORDER))
2. [ICCCM](https://tronche.com/gui/x/icccm/sec-4.html) 4.1.2.6: a transient window is "a pop-up on behalf of" the named window, so a dialog behind that window has failed at its purpose (and a modal one leaves the application unusable)

The base for this PR follows the sketch in #1527, except that the `Window` is stored rather than a `Client*` (so that a parent that is managed later, or unmanaged first, needs no bookkeeping)

## Fix

This fix is split into multiple commits (each containing tests):

#### [b2cecbd](https://github.com/herbstluftwm/herbstluftwm/commit/b2cecbdbacc15fa3f497f463f44822b87e71fec6): fix fullscreened float handling

Although strictly speaking a separate issue, this PR also makes a that a floating window that is fullscreen is now stacked in the fullscreen layer (like a tiled one) both because
1. it's a related type of issue
2. it's needed for the proper fix of the main issue to work (since dialogs are auto-floated by #725 and so would otherwise be invisible to that loop)

More specifically, we now compute the layer over all clients of the tag (`HSTag::foreachClient`)

#### [52e53f8](https://github.com/herbstluftwm/herbstluftwm/commit/52e53f84716f5939262df3bf36ebae627fadf6b1): fix `raise` handling

raising a window now also raises its dialogs, so a raise (click, focus, re-layout) can no longer put a window on top of its own dialog

Concretely,
1. `Client` remembers the hint (`transientFor_`, read at manage time and on `PropertyNotify` of `WM_TRANSIENT_FOR`, including its deletion)
3. `Client::raise()` has the new behavior:
	1. raises its own slice
	2. raises every client on the same tag whose hint names it, recursively (lowest transient first so the transients keep their relative order)

Note:
1. Transients on another tag are left alone.
2. Every existing raise path goes through `Client::raise()` (so fortunately no need to change callers)

#### [bf2f3ee](https://github.com/herbstluftwm/herbstluftwm/commit/bf2f3eef234876567fb93996ab22f14ee6b450c7): : fix fullscreen and focus layer handling

Apply the same fix in two other places where hlwm reorders the stack:
1. a window entering the fullscreen layer
2. a window entering the focus layer

Concretely,
1. Make the new `raise()` behavior also changed with `Monitor::applyLayout` (by moving it into `Client::withTransients()`)
2. Make `Monitor::applyLayout` fills the fullscreen layer and the focus layer in that order
3. A client entering the fullscreen layer below a transient that is already there (a fullscreen dialog) re-inserts the transient above itself

#### [eb806e2](https://github.com/herbstluftwm/herbstluftwm/commit/eb806e2e): fix `floating` attribute handling

Apply the same fix in one other places where hlwm reorders the stack: setting floating on a parent inserts it on top of the floating layer, above its already-floating dialog (and clearing it does the same in the tiling layer)

Fix: a window that is set floating (or tiled again) now enters the new layer below its dialogs that are already there

Concretely,
1. `Client::raiseIntoLayer()` puts a client on top of a layer with its transients above it (a transient already in the layer is re-inserted above the client, a transient not in the layer is brought along only when asked for)
2. The fullscreen and focus layers bring the transients along; the floating and tiling layers don't (a tiled dialog of a floated window stays tiled)

#### [867ec99](https://github.com/herbstluftwm/herbstluftwm/commit/867ec996807b0c14802867a105d4c5599bf98970): fix `lower` handling

lowering a dialog now also lowers the window it belongs to, so a `lower` can no longer put a dialog below its own window

Concretely,
1. `Client::lower()` lowers its own slice, then the client it is transient for (recursively up the `WM_TRANSIENT_FOR` chain on the same tag), each to the bottom
2. lowering a window that has dialogs needs no extra move (its dialogs are above it already, and stay there)

## Design decisions

### Which windows to raise

Note: when it comes to raising parents vs dialogs, EWMH constrains one case only ("Windows that are transient for another window should be kept above this window", [source](https://specifications.freedesktop.org/wm/latest-single/#STACKINGORDER)), and raising a dialog alone never violates it.

However, bringing the parent up too is a policy WMs disagree on:
1. mutter always raises the root ancestor ([`meta_window_raise`](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/core/window.c), reason given: "it's weird to see windows from other apps stacked between a child and parent window of the currently active app")
2. openbox only for modal dialogs ([`restack_windows`](https://github.com/danakj/openbox/blob/master/openbox/stacking.c))

hlwm
1. has no application-group notion
2. does not track `_NET_WM_STATE_MODAL`
4. has `raise` as a command on one named client (also behind `raise_on_click`/`raise_on_focus`)

therefore, making hlwm move a second, unnamed window would be a new policy rather than a bug fix (so I left it out of this PR. Can be handle separately if people want this behavior)

### Handling of `lower`

`lower` on a dialog is the mirror image of `raise` on its window: the named window moves as asked, and the invariant then requires the window it is transient for to end up below it

Options considered:
1. lower the dialog alone (behavior before this PR): the dialog sits below its own window until that window is next raised. This is exactly the state EWMH says to avoid and the state the rest of this PR removes, so exempting `lower` would be inconsistent (and "the user named that window" is the same argument that doesn't hold for `raise` on the parent)
2. lower the dialog, then the window it is transient for (recursively): what openbox does ([`restack_windows`](https://github.com/danakj/openbox/blob/master/openbox/stacking.c), "lower our parents after us, so they go below us"). Needs only the existing `Stack::lowerSlice`
3. stop the dialog directly above its window: what mutter does (its stacking constraints keep a transient above its parent at any position, so a lowered dialog stays just above its parent, [`stack.c`](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/core/stack.c)). Needs positional insertion in `Stack`, and makes `lower` a no-op whenever the parent is already on top

I picked option 2 as
1. it felt the more coherent with what this PR is trying to address: most applications can't be used while a dialog is up, so lowering just the dialog is almost always just getting the user into a bad/confusing state
2. it fits hlwm's `Stack`: a slice is raised to the top or lowered to the bottom of its layers, and relations are kept by moving a group in order (as `HSTag::onGlobalFloatingChange` already does, and as the `raise` side of this PR does)

Note: lowering a window that has dialogs is unchanged: the dialogs are above it already, so nothing else needs to move

### Invariant enforcement location in the code

The relation is enforced at the places where the stack order changes rather than modelled inside `Stack`:
1. `Stack` orders `Slice`s and knows nothing about clients (a `Slice` is also a frame or an unmanaged window); `WM_TRANSIENT_FOR` is a client property, so `Stack` would need a callback into the client manager on every reorder
2. those places are few and known: `raiseSlice` is only called from `Client::raise`, and `sliceAddLayer` from `Monitor::applyLayout` (fullscreen, focus) and `HSTag` (the `floating` attribute, both directions). The remaining `sliceAddLayer` callers keep the invariant already: the tag-wide `floating` toggle inserts at the bottom in stack order, and a newly managed client has no transients yet
3. each of those places has the client at hand, so the fix is a call to `withTransients()`/`raiseIntoLayer()` there, instead of a new invariant inside `Stack` that every existing caller would have to be audited against anyway

## Repro on 0.9.6 / master

```
herbstclient floating on
# open a window P, a dialog D transient for P (e.g. any GTK app's message box), and a third window O
herbstclient stack        # Floating-Layer: O, D, P (top to bottom)
herbstclient raise $P
herbstclient stack        # Floating-Layer: P, O, D on master — D, P, O with the fix

# the layer moves (third commit):
herbstclient jumpto $O
herbstclient set_attr clients.$P.fullscreen true
herbstclient stack        # Fullscreen-Layer: P alone on master (D stays below in the Floating-Layer) — D, P with the fix

# lower (fifth commit), starting again from O, D, P:
herbstclient lower $D
herbstclient stack        # Floating-Layer: O, P, D on master (D under its own window) — O, D, P with the fix
```